### PR TITLE
Update the logic for maintaining the telemetry preference

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/ui/startup/WACPStartUp.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/ui/startup/WACPStartUp.java
@@ -154,12 +154,12 @@ public class WACPStartUp implements IStartup {
 			throws Exception {
 		final Document doc = ParserXMLUtility.parseXMLFile(dataFile);
 		if (isAzureToolKit) {
-			try{
+			try {
 				String recordedVersion = DataOperations.getProperty(dataFile, Messages.version);
 				if (Utils.whetherUpdateTelemetryPref(recordedVersion)) {
 					DataOperations.updatePropertyValue(doc, Messages.prefVal, "true");
 				}
-			}catch (Exception ex){
+			} catch (Exception ex){
 				Activator.getDefault().log(ex.getMessage(), ex);
 			}
 		}

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/azurecommons/util/Utils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/azurecommons/util/Utils.java
@@ -156,7 +156,7 @@ public class Utils {
 	}
 
 	/*
-	 * when there is version upgrade, if the existed version >= 3.x, then respesct the recorded telemetry preference;
+	 * when there is version upgrade, if the existed version >= 3.x, then respect the recorded telemetry preference;
 	 * Otherwise, overwrite it to "true";
 	 */
     public static boolean whetherUpdateTelemetryPref(String recordedVersion) {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/azurecommons/util/Utils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/azurecommons/util/Utils.java
@@ -154,4 +154,54 @@ public class Utils {
 		}
 		return files;
 	}
+
+	/*
+	 * when there is version upgrade, if the existed version >= 3.x, then respesct the recorded telemetry preference;
+	 * Otherwise, overwrite it to "true";
+	 */
+    public static boolean whetherUpdateTelemetryPref(String recordedVersion) {
+        if (recordedVersion == null || recordedVersion.isEmpty()) {
+            return true;
+        }
+
+        if (compareVersion(recordedVersion, "3.0") >= 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /*
+    return negative: v1 < v2
+    return 0; v1 = v2
+    return positive: v1 > v2
+     */
+    public static int compareVersion(String version1, String version2) {
+        if ((version1 == null || version1.isEmpty()) && (version2 == null || version2.isEmpty())) {
+            return 0;
+        }
+
+        if (version1 == null || version1.isEmpty()) {
+            return -1;
+        }
+
+        if (version2 == null || version2.isEmpty()) {
+            return 1;
+        }
+
+        // neither is null
+        String[] version1Seg = version1.split("\\.");
+        String[] version2Seg = version2.split("\\.");
+
+        int i = 0;
+        while (i < version1Seg.length && i < version2Seg.length && version1Seg[i].equalsIgnoreCase(version2Seg[i])) {
+            i++;
+        }
+
+        if (i < version1Seg.length && i < version2Seg.length) {
+            return Integer.valueOf(version1Seg[i]).compareTo(Integer.valueOf(version2Seg[i]));
+        }
+
+        return version1Seg.length - version2Seg.length;
+    }
 }


### PR DESCRIPTION
When there is version upgrade, if the existed version >= 3.x, then respect the recorded telemetry preference. Otherwise, overwrite it to "true";