### PR TITLE
Fix the issue of Spark debug configuration needs to reopen everytime

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobDebuggerRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobDebuggerRunner.java
@@ -68,10 +68,9 @@ public class SparkBatchJobDebuggerRunner extends GenericDebuggerRunner {
     protected void execute(@NotNull ExecutionEnvironment environment, @Nullable Callback callback, @NotNull RunProfileState state) throws ExecutionException {
         SparkBatchJobSubmissionState submissionState = (SparkBatchJobSubmissionState) state;
         SparkSubmitModel submitModel = submissionState.getSubmitModel();
-        SparkSubmissionParameter submissionParameter = submissionState.getSubmissionParameter();
-        IClusterDetail clusterDetail = ((SparkBatchJobSubmissionState) state).getClusterDetail();
-        SparkSubmitAdvancedConfigModel advModel =
-                ((SparkBatchJobSubmissionState) state).getSubmitAdvancedConfigModel();
+        SparkSubmissionParameter submissionParameter = submitModel.getSubmissionParameter();
+        IClusterDetail clusterDetail = submitModel.getSelectedClusterDetail();
+        SparkSubmitAdvancedConfigModel advModel = submitModel.getAdvancedConfigModel();
 
         submitModel
                 .remoteDebugCompileRxOp(submissionParameter)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobSubmissionState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobSubmissionState.java
@@ -48,20 +48,12 @@ import java.util.ArrayList;
  */
 public class SparkBatchJobSubmissionState implements RunProfileState, RemoteState {
     private final Project myProject;
-    private SparkSubmissionParameter submissionParameter;
     private SparkSubmitModel submitModel;
     private RemoteConnection remoteConnection;
 
-    private SparkSubmitAdvancedConfigModel submitAdvancedConfigModel;
-
-    private IClusterDetail clusterDetail;
-
-    public SparkBatchJobSubmissionState(Project project, SparkSubmissionParameter submissionParameter, SparkSubmitModel submitModel, IClusterDetail detail, SparkSubmitAdvancedConfigModel advModel) {
+    public SparkBatchJobSubmissionState(Project project, SparkSubmitModel submitModel) {
         this.myProject = project;
-        this.submissionParameter = submissionParameter;
         this.submitModel = submitModel;
-        this.clusterDetail = detail;
-        this.submitAdvancedConfigModel = advModel;
     }
 
     public void setRemoteConnection(RemoteConnection remoteConnection) {
@@ -70,20 +62,6 @@ public class SparkBatchJobSubmissionState implements RunProfileState, RemoteStat
 
     public SparkSubmitModel getSubmitModel() {
         return submitModel;
-    }
-
-    public IClusterDetail getClusterDetail() {
-        return clusterDetail;
-    }
-
-    public SparkSubmitAdvancedConfigModel getSubmitAdvancedConfigModel() {
-        return submitAdvancedConfigModel;
-    }
-
-
-
-    public SparkSubmissionParameter getSubmissionParameter() {
-        return submissionParameter;
     }
 
     @Nullable

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/RemoteDebugSettingsEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/RemoteDebugSettingsEditor.java
@@ -48,8 +48,11 @@ public class RemoteDebugSettingsEditor extends SettingsEditor<RemoteDebugRunConf
 
     @Override
     protected void applyEditorTo(@NotNull RemoteDebugRunConfiguration remoteDebugRunConfiguration) throws ConfigurationException {
-        remoteDebugRunConfiguration.getSubmitModel().setSubmissionParameters(submissionPanel.constructSubmissionParameter());
+        this.runConfiguration = remoteDebugRunConfiguration;
 
+        // Set the parameters from view to model
+        this.runConfiguration.getSubmitModel().setSubmissionParameters(
+                submissionPanel.constructSubmissionParameter());
     }
 
     @NotNull


### PR DESCRIPTION
Now, after start up configuration, the Spark configuration 'DEBUG'
exector can start without reconfiguration.

Signed-off-by: Zhang Wei <zhwe@microsoft.com>