### PR TITLE
Limit the Spark driver retry to 1 for debugging

### DIFF
--- a/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJobScenario.java
+++ b/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJobScenario.java
@@ -137,6 +137,18 @@ public class SparkBatchRemoteDebugJobScenario {
         assertEquals(expectedDriverJvmOption, submittedDriverJavaOption);
     }
 
+    @Then("^the Spark driver max retries should be '(.+)'$")
+    public void checkSparkDriverMaxRetries(String expectedMaxRetries) throws Throwable {
+        assertNull(caught);
+
+        String maxRetries =
+                ((SparkConfigures) submissionParameterArgumentCaptor.getValue().getJobConfig()
+                        .getOrDefault("conf", new SparkConfigures()))
+                        .get("spark.yarn.maxAppAttempts").toString();
+
+        assertEquals(expectedMaxRetries, maxRetries);
+    }
+
     @Given("^setup a mock livy service for (.+) request '(.+)' to return '(.+)' with status code (\\d+)$")
     public void mockLivyService(String action, String serviceUrl, String response, int statusCode) throws Throwable {
         URI mockUri = new URI(serviceUrl);

--- a/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJobScenario.feature
+++ b/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJobScenario.feature
@@ -8,6 +8,7 @@ Feature: Spark Batch Remote Debug Job Testing
     And create batch Spark Job with driver debugging for 'http://localhost:8998/batches' with following parameters
       | spark.driver.extraJavaOptions | -head |
     Then the Spark driver JVM option should be '-head -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0'
+    Then the Spark driver max retries should be '1'
 
     And create batch Spark Job with driver debugging for 'http://localhost:8998/batches' with following parameters
       | | |

--- a/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJobScenario.feature
+++ b/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJobScenario.feature
@@ -6,6 +6,10 @@ Feature: Spark Batch Remote Debug Job Testing
     Then throw exception 'com.microsoft.azure.hdinsight.spark.common.DebugParameterDefinedException' with message 'The driver Debug parameter is defined in Spark job configuration: -head -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1234 -tail'
 
     And create batch Spark Job with driver debugging for 'http://localhost:8998/batches' with following parameters
+      | spark.yarn.maxAppAttempts | 3 |
+    Then throw exception 'com.microsoft.azure.hdinsight.spark.common.DebugParameterDefinedException' with message 'The driver max app attempts parameter is defined in Spark job configuration: 3'
+
+    And create batch Spark Job with driver debugging for 'http://localhost:8998/batches' with following parameters
       | spark.driver.extraJavaOptions | -head |
     Then the Spark driver JVM option should be '-head -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0'
     Then the Spark driver max retries should be '1'

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJob.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJob.java
@@ -462,6 +462,7 @@ public class SparkBatchRemoteDebugJob implements ISparkBatchDebugJob, ILogger {
             SparkBatchSubmission submission) throws DebugParameterDefinedException, URISyntaxException {
         final String driverDebugOption = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0";
         final String sparkJobDriverJvmOptionConfKey = "spark.driver.extraJavaOptions";
+        final String sparkJobDriverRetriesConfKey = "spark.yarn.maxAppAttempts";
         final String jvmDebugOptionPattern = ".*\\bsuspend=(?<isSuspend>[yn]),address=(?<port>\\d+).*";
 
         Map<String, Object> jobConfig = submissionParameter.getJobConfig();
@@ -476,6 +477,12 @@ public class SparkBatchRemoteDebugJob implements ISparkBatchDebugJob, ILogger {
                         "The driver Debug parameter is defined in Spark job configuration: " +
                                 sparkConf.get(sparkJobDriverJvmOptionConfKey));
             }
+
+            if (sparkConf.get(sparkJobDriverRetriesConfKey) != null) {
+                throw new DebugParameterDefinedException(
+                        "The driver max app attempts parameter is defined in Spark job configuration: " +
+                                sparkConf.get(sparkJobDriverRetriesConfKey));
+            }
         } else {
             sparkConf = new SparkConfigures();
             jobConfig.put(SparkSubmissionParameter.Conf, sparkConf);
@@ -487,7 +494,7 @@ public class SparkBatchRemoteDebugJob implements ISparkBatchDebugJob, ILogger {
         SparkConfigures sparkConfigWithDebug = new SparkConfigures(sparkConf);
 
         sparkConfigWithDebug.put(sparkJobDriverJvmOptionConfKey, driverOption);
-        sparkConfigWithDebug.put("spark.yarn.maxAppAttempts", "1");
+        sparkConfigWithDebug.put(sparkJobDriverRetriesConfKey, "1");
         jobConfigWithDebug.put(SparkSubmissionParameter.Conf, sparkConfigWithDebug);
         SparkSubmissionParameter debugSubmissionParameter = new SparkSubmissionParameter(
                 submissionParameter.getClusterName(),

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJob.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJob.java
@@ -485,7 +485,9 @@ public class SparkBatchRemoteDebugJob implements ISparkBatchDebugJob, ILogger {
         driverOption = (carriedDriverOption.trim() + " " + driverDebugOption).trim();
         HashMap<String, Object> jobConfigWithDebug = new HashMap<>(submissionParameter.getJobConfig());
         SparkConfigures sparkConfigWithDebug = new SparkConfigures(sparkConf);
+
         sparkConfigWithDebug.put(sparkJobDriverJvmOptionConfKey, driverOption);
+        sparkConfigWithDebug.put("spark.yarn.maxAppAttempts", "1");
         jobConfigWithDebug.put(SparkSubmissionParameter.Conf, sparkConfigWithDebug);
         SparkSubmissionParameter debugSubmissionParameter = new SparkSubmissionParameter(
                 submissionParameter.getClusterName(),


### PR DESCRIPTION
For debugging senario, no need to retry the driver for failures.

Signed-off-by: Zhang Wei <zhwe@microsoft.com>