### PR TITLE
Fix 'RUN' executor is un-usable for Spark debug configuration

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -65,6 +65,7 @@
 
     <configurationType implementation="com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfigurationType"/>
     <programRunner implementation="com.microsoft.azure.hdinsight.spark.run.SparkBatchJobDebuggerRunner" />
+    <programRunner implementation="com.microsoft.azure.hdinsight.spark.run.SparkBatchJobRunner" />
 
   </extensions>
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.microsoft.azure.hdinsight.spark.run;
+
+import com.intellij.execution.configurations.RunProfile;
+import com.intellij.execution.executors.DefaultRunExecutor;
+import com.intellij.execution.runners.DefaultProgramRunner;
+import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel;
+import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+public class SparkBatchJobRunner extends DefaultProgramRunner {
+    @NotNull
+    @Override
+    public String getRunnerId() {
+        return "SparkBatchJobRun";
+    }
+
+    @Override
+    public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
+        return DefaultRunExecutor.EXECUTOR_ID.equals(executorId) && profile instanceof RemoteDebugRunConfiguration;
+    }
+
+    public void submitJob(SparkSubmitModel submitModel) {
+        submitModel.action(submitModel.getSubmissionParameter());
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobSubmissionState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobSubmissionState.java
@@ -67,10 +67,17 @@ public class SparkBatchJobSubmissionState implements RunProfileState, RemoteStat
     @Nullable
     @Override
     public ExecutionResult execute(Executor executor, @NotNull ProgramRunner programRunner) throws ExecutionException {
-        ConsoleViewImpl consoleView = new ConsoleViewImpl(myProject, false);
-        RemoteDebugProcessHandler process = new RemoteDebugProcessHandler(myProject);
-        consoleView.attachToProcess(process);
-        return new DefaultExecutionResult(consoleView, process);
+        if (programRunner instanceof SparkBatchJobDebuggerRunner) {
+            ConsoleViewImpl consoleView = new ConsoleViewImpl(myProject, false);
+            RemoteDebugProcessHandler process = new RemoteDebugProcessHandler(myProject);
+            consoleView.attachToProcess(process);
+            return new DefaultExecutionResult(consoleView, process);
+        } else if (programRunner instanceof SparkBatchJobRunner) {
+            SparkBatchJobRunner jobRunner = (SparkBatchJobRunner) programRunner;
+            jobRunner.submitJob(getSubmitModel());
+        }
+
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Zhang Wei <zhwe@microsoft.com>