### PR TITLE
Fix telemetry 1003507

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/components/AzureWizardPage.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/components/AzureWizardPage.java
@@ -1,0 +1,46 @@
+package com.microsoft.azuretools.core.components;
+
+import com.microsoft.azuretools.telemetry.AppInsightsClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.wizard.WizardPage;
+
+public abstract class AzureWizardPage extends WizardPage {
+    private static final String WIZARD_PAGE = "WizardPage";
+    private static final String TITLE = "Title";
+    private static final String WIZARD_DIALOG = "WizardDialog";
+    
+    protected AzureWizardPage(String pageName) {
+        super(pageName);
+    }
+    
+    protected AzureWizardPage(String pageName,
+            String title,
+            ImageDescriptor titleImage) {
+        super(pageName, title, titleImage);
+    }
+
+    public void sendButtonClickedTelemetry(String action) {
+        final Map<String, String> properties = new HashMap<>();
+        String simpleName = this.getClass().getSimpleName();
+        if (simpleName == null) {
+            simpleName = "";
+        }
+        properties.put(WIZARD_PAGE, simpleName);
+        String title = this.getTitle();
+        if (title == null) {
+            title = "";
+        }
+        properties.put(TITLE, title);
+        String wizardDialog = this.getShell().getText();
+        if (wizardDialog == null) {
+            wizardDialog = "";
+        }
+        properties.put(WIZARD_DIALOG, wizardDialog);
+        AppInsightsClient.createByType(AppInsightsClient.EventType.WizardStep,
+                simpleName, action, properties);
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.docker/src/com/microsoft/azuretools/docker/ui/wizards/publish/AzureConfigureDockerContainerStep.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.docker/src/com/microsoft/azuretools/docker/ui/wizards/publish/AzureConfigureDockerContainerStep.java
@@ -24,6 +24,7 @@ import com.microsoft.azure.docker.model.AzureDockerImageInstance;
 import com.microsoft.azure.docker.model.KnownDockerImages;
 import com.microsoft.azure.docker.ops.utils.AzureDockerValidationUtils;
 import com.microsoft.azuretools.core.Activator;
+import com.microsoft.azuretools.core.components.AzureWizardPage;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -53,7 +54,7 @@ import org.eclipse.ui.forms.ManagedForm;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 
-public class AzureConfigureDockerContainerStep extends WizardPage {
+public class AzureConfigureDockerContainerStep extends AzureWizardPage {
 	private static final Logger log =  Logger.getLogger(AzureConfigureDockerContainerStep.class.getName());
 
 	private Text dockerContainerNameTextField;

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.docker/src/com/microsoft/azuretools/docker/ui/wizards/publish/AzureSelectDockerHostPage.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.docker/src/com/microsoft/azuretools/docker/ui/wizards/publish/AzureSelectDockerHostPage.java
@@ -32,6 +32,7 @@ import com.microsoft.azure.docker.ops.utils.AzureDockerValidationUtils;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azuretools.core.Activator;
 import com.microsoft.azuretools.core.components.AzureWizardDialog;
+import com.microsoft.azuretools.core.components.AzureWizardPage;
 import com.microsoft.azuretools.core.utils.PluginUtil;
 import com.microsoft.azuretools.docker.ui.dialogs.AzureInputDockerLoginCredsDialog;
 import com.microsoft.azuretools.docker.ui.dialogs.AzureViewDockerDialog;
@@ -77,8 +78,14 @@ import org.eclipse.ui.forms.ManagedForm;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 
-public class AzureSelectDockerHostPage extends WizardPage {
+public class AzureSelectDockerHostPage extends AzureWizardPage {
 	private static final Logger log =  Logger.getLogger(AzureSelectDockerHostPage.class.getName());
+	
+	private static final String REFRESH = "Refresh";
+	private static final String VIEW = "View";
+	private static final String ADD = "Add";
+	private static final String DELETE = "Delete";
+	private static final String EDIT = "Edit";
 
 	private Composite mainContainer;
 	private Text dockerArtifactPathTextField;
@@ -182,15 +189,15 @@ public class AzureSelectDockerHostPage extends WizardPage {
 		GridData gd_dockerHostsRefreshButton = new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1);
 		gd_dockerHostsRefreshButton.verticalIndent = 1;
 		dockerHostsRefreshButton.setLayoutData(gd_dockerHostsRefreshButton);
-		dockerHostsRefreshButton.setText("Refresh");
+		dockerHostsRefreshButton.setText(REFRESH);
 		
 		dockerHostsViewButton = new Button(mainContainer, SWT.NONE);
 		dockerHostsViewButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
-		dockerHostsViewButton.setText("View");
+		dockerHostsViewButton.setText(VIEW);
 		
 		dockerHostsAddButton = new Button(mainContainer, SWT.NONE);
 		dockerHostsAddButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
-		dockerHostsAddButton.setText("Add");
+		dockerHostsAddButton.setText(ADD);
 		
 		dockerHostsDeleteButton = new Button(mainContainer, SWT.NONE);
 		dockerHostsDeleteButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
@@ -367,6 +374,7 @@ public class AzureSelectDockerHostPage extends WizardPage {
 			    AzureDockerUIResources.updateAzureResourcesWithProgressDialog(mainContainer.getShell(), project);
 			    refreshDockerHostsTable(mainContainer);
 				setPageComplete(doValidate());
+				sendButtonClickedTelemetry(REFRESH);
 			}
 		});
 		
@@ -390,6 +398,7 @@ public class AzureSelectDockerHostPage extends WizardPage {
 						setPageComplete(doValidate());
 					}
 				}
+				sendButtonClickedTelemetry(VIEW);
 			}
 		});
 		
@@ -425,6 +434,7 @@ public class AzureSelectDockerHostPage extends WizardPage {
 					dockerHostsTable.select(0);
 				}
 				setPageComplete(doValidate());
+				sendButtonClickedTelemetry(ADD);
 			}
 		});
 		
@@ -466,6 +476,7 @@ public class AzureSelectDockerHostPage extends WizardPage {
 					}
 					setPageComplete(doValidate());
 				}
+				sendButtonClickedTelemetry(DELETE);
 			}
 		});
 		
@@ -482,6 +493,7 @@ public class AzureSelectDockerHostPage extends WizardPage {
 					}
 				}
 				setPageComplete(doValidate());
+				sendButtonClickedTelemetry(EDIT);
 			}
 		});
 	}


### PR DESCRIPTION
Fix telemetry bug to send button clicked event in wizard page.
1. A new class AzureWizardPage is added (extended from WizardPage)
2. Extend the docker wiazard pages from the new class
3. Call the sendButtonClickedTelemetry method when necessary.
4. Data sent include the wizardpage title, wizarddialog title, wizardpage simple class name.