### PR TITLE
make property background transparent in eclipse

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/views/RedisPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/views/RedisPropertyView.java
@@ -32,8 +32,10 @@ import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
@@ -55,7 +57,7 @@ public class RedisPropertyView extends ViewPart implements RedisPropertyMvpView 
     private static final String LABEL_NAME = "Name";
     private static final String LABEL_TYPE = "Type";
     private static final String LABEL_RES_GRP = "Resource Group";
-    private static final String LABEL_SUBSCRIPTION = "Subscription";
+    private static final String LABEL_SUBSCRIPTION = "Subscription Id";
     private static final String LABEL_REGION = "Region";
     private static final String LABEL_HOST_NAME = "Host Name";
     private static final String LABEL_SSL = "SSL Port";
@@ -177,6 +179,7 @@ public class RedisPropertyView extends ViewPart implements RedisPropertyMvpView 
         lnkSecondaryKey.setEnabled(false);
         lnkSecondaryKey.setText(COPY_TO_CLIPBOARD);
         
+        setTextFieldTransparent();
         setScrolledCompositeContent();
         
         // View cLose event
@@ -228,6 +231,19 @@ public class RedisPropertyView extends ViewPart implements RedisPropertyMvpView 
         lnkSecondaryKey.setEnabled(true);
         container.layout();
         setScrolledCompositeContent();
+    }
+    
+    private void setTextFieldTransparent() {
+        Color transparentColor = new Color(Display.getCurrent(), 0, 0, 0, 0);
+        txtNameValue.setBackground(transparentColor);
+        txtTypeValue.setBackground(transparentColor);
+        txtResGrpValue.setBackground(transparentColor);
+        txtSubscriptionValue.setBackground(transparentColor);
+        txtRegionValue.setBackground(transparentColor);
+        txtHostNameValue.setBackground(transparentColor);
+        txtSslPortValue.setBackground(transparentColor);
+        txtNonSslPortValue.setBackground(transparentColor);
+        txtVersionValue.setBackground(transparentColor);
     }
 
     private void setScrolledCompositeContent() {

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/views/RedisPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/views/RedisPropertyView.java
@@ -35,6 +35,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
@@ -179,7 +180,7 @@ public class RedisPropertyView extends ViewPart implements RedisPropertyMvpView 
         lnkSecondaryKey.setEnabled(false);
         lnkSecondaryKey.setText(COPY_TO_CLIPBOARD);
         
-        setTextFieldTransparent();
+        setChildrenTransparent(container);
         setScrolledCompositeContent();
         
         // View cLose event
@@ -233,17 +234,16 @@ public class RedisPropertyView extends ViewPart implements RedisPropertyMvpView 
         setScrolledCompositeContent();
     }
     
-    private void setTextFieldTransparent() {
+    private void setChildrenTransparent(Composite container) {
+        if (container == null) {
+            return;
+        }
         Color transparentColor = new Color(Display.getCurrent(), 0, 0, 0, 0);
-        txtNameValue.setBackground(transparentColor);
-        txtTypeValue.setBackground(transparentColor);
-        txtResGrpValue.setBackground(transparentColor);
-        txtSubscriptionValue.setBackground(transparentColor);
-        txtRegionValue.setBackground(transparentColor);
-        txtHostNameValue.setBackground(transparentColor);
-        txtSslPortValue.setBackground(transparentColor);
-        txtNonSslPortValue.setBackground(transparentColor);
-        txtVersionValue.setBackground(transparentColor);
+        for (Control control: container.getChildren()) {
+            if (control instanceof Text) {
+                control.setBackground(transparentColor);
+            }
+        }
     }
 
     private void setScrolledCompositeContent() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/rediscache/RedisCachePropertyView.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/rediscache/RedisCachePropertyView.form
@@ -42,7 +42,7 @@
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Subscription"/>
+          <text value="Subscription Id"/>
         </properties>
       </component>
       <component id="acbf4" class="javax.swing.JLabel">


### PR DESCRIPTION
1. Make the textfield of the redis cache property view in eclipse transparent
2. Correct the label name from "Subscription" -> "Subscription Id"

Related Issue: #622 