### PR TITLE
fix dark theme color issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/DarkThemeManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/DarkThemeManager.java
@@ -40,7 +40,7 @@ public class DarkThemeManager {
     private static final String Gray = "#BBBBBB";
 
     private static final String Blue = "blue";
-    private static final String LightBlue = "deepskyblue";
+    private static final String LightBlue = "#5394EC";
 
     public static DarkThemeManager getInstance(){
         if(instance == null){
@@ -95,7 +95,7 @@ public class DarkThemeManager {
     }
 
     public String getHyperLinkColor(){
-        if(UIUtil.isUnderDarcula()){
+        if (UIUtil.isUnderDarcula()) {
             return LightBlue;
         }
 


### PR DESCRIPTION
Fix the link color issue in dark theme of intellij. Issue https://github.com/Microsoft/azure-tools-for-java/issues/576
![image](https://user-images.githubusercontent.com/1286176/27025910-ac1e64d2-4f8e-11e7-94f6-839db972fe04.png)
The color code is choosen from the `Darcula` theme itself:
![image](https://user-images.githubusercontent.com/1286176/27025796-506e118c-4f8e-11e7-8b68-8e6413918db2.png)
We'd better update all of our dark theme color to `Darcula` color code.
e.g. `#2B2B2B` for console background.
![image](https://user-images.githubusercontent.com/1286176/27025859-82078ec6-4f8e-11e7-9fad-cba084c0b273.png)
