### PR TITLE
remove duplicate spark clusters from rest api

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/ClusterManagerEx.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/ClusterManagerEx.java
@@ -26,7 +26,6 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.microsoft.azure.hdinsight.metadata.ClusterMetaDataService;
 import com.microsoft.azure.hdinsight.sdk.cluster.*;
-import com.microsoft.azuretools.authmanage.AdAuthManager;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.authmanage.models.SubscriptionDetail;
 import com.microsoft.azuretools.azurecommons.helpers.StringHelper;
@@ -35,7 +34,6 @@ import com.microsoft.azure.hdinsight.sdk.common.AggregatedException;
 import com.microsoft.azure.hdinsight.sdk.common.AuthenticationErrorHandler;
 import com.microsoft.azure.hdinsight.sdk.common.HDIException;
 import com.microsoft.azure.hdinsight.sdk.storage.HDStorageAccount;
-import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -136,7 +134,7 @@ public class ClusterManagerEx {
         List<SubscriptionDetail> subscriptionList = null;
         try {
             subscriptionList = manager.getSubscriptionManager().getSubscriptionDetails();
-            cachedClusterDetails = ClusterManager.getInstance().getHDInsightCausersWithSpecificType(subscriptionList, ClusterType.spark, OSTYPE, project);
+            cachedClusterDetails = ClusterManager.getInstance().getHDInsightClustersWithSpecificType(subscriptionList, ClusterType.spark, OSTYPE, project);
             // TODO: so far we have not a good way to judge whether it is token expired as we have changed the way to list hdinsight clusters
             if (cachedClusterDetails.size() == 0) {
                 //DefaultLoader.getUIHelper().showError("Falied to get HDInsight Cluster, Please make sure there's no login problem first","List HDInsight Cluster Error");

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/ClusterManager.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/ClusterManager.java
@@ -81,7 +81,7 @@ public class ClusterManager {
      * @return detailed cluster info list with specific cluster type
      * @throws AggregatedException
      */
-    public synchronized List<IClusterDetail> getHDInsightCausersWithSpecificType(
+    public synchronized List<IClusterDetail> getHDInsightClustersWithSpecificType(
             List<SubscriptionDetail> subscriptions,
             ClusterType type,
             String osType,

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/ClusterManager.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/ClusterManager.java
@@ -29,7 +29,9 @@ import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -84,19 +86,24 @@ public class ClusterManager {
             ClusterType type,
             String osType,
             Object projectObject) throws AggregatedException {
-
         List<IClusterDetail> clusterDetailList = getClusterDetails(subscriptions, projectObject);
-        List<IClusterDetail> filterClusterDetailList = new ArrayList<>();
+
+        Map<String, IClusterDetail> filterClusterDetailMap = new HashMap<>();
         for (IClusterDetail clusterDetail : clusterDetailList) {
             if (clusterDetail.getOSType() != null && osType != null) {
                 if (clusterDetail.getType().equals(type) && clusterDetail.getOSType().toLowerCase().equals(osType.toLowerCase())) {
-                    filterClusterDetailList.add(clusterDetail);
+                    filterClusterDetailMap.put(clusterDetail.getName(), clusterDetail);
                 }
             } else {
                 if (clusterDetail.getType().equals(type)) {
-                    filterClusterDetailList.add(clusterDetail);
+                    filterClusterDetailMap.put(clusterDetail.getName(), clusterDetail);
                 }
             }
+        }
+
+        List<IClusterDetail> filterClusterDetailList = new ArrayList<>();
+        for (IClusterDetail clusterDetail : filterClusterDetailMap.values()) {
+            filterClusterDetailList.add(clusterDetail);
         }
 
         return filterClusterDetailList;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/StorageAccountNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/StorageAccountNode.java
@@ -64,7 +64,7 @@ public class StorageAccountNode extends RefreshableNode implements TelemetryProp
                 addChildNode(new BlobContainerNode(this, blobStorageAccount, blobContainer, !StringHelper.isNullOrWhiteSpace(defaultContainer) && defaultContainer.equals(blobContainer.getName())));
             }
         } else if(storageAccount.getAccountType() == StorageAccountTypeEnum.ADLS) {
-            // TODO：　adls support
+            // TODO adls support
         }
     }
 


### PR DESCRIPTION
+ Fix https://github.com/Microsoft/azure-tools-for-java/issues/590
+ Fix https://github.com/Microsoft/azure-tools-for-java/issues/651
The root cause is the clusters list return from api `https://main.hdinsight.ext.azure.com/api/Clusters/GetAll` is doubled. We temporarily fix the issue by  removing the duplicated clusters in the list.
