### PR TITLE
Property refactor

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/editors/rediscache/RedisExplorerEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/editors/rediscache/RedisExplorerEditor.java
@@ -202,5 +202,6 @@ public class RedisExplorerEditor extends EditorPart implements RedisExplorerMvpV
         this.redisExplorerPresenter.onDetachView();
         RedisExplorerEditorInput redisInput = (RedisExplorerEditorInput) this.getEditorInput();
         this.redisExplorerPresenter.onRelease(redisInput.getId());
+        super.dispose();
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/UIHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/UIHelperImpl.java
@@ -284,12 +284,7 @@ public class UIHelperImpl implements UIHelper {
             }
             final RedisPropertyView view = (RedisPropertyView) page.showView(RedisPropertyView.ID, node.getResourceId(),
                     IWorkbenchPage.VIEW_ACTIVATE);
-            Display.getDefault().asyncExec(new Runnable() {
-                @Override
-                public void run() {
-                    view.readProperty(sid, resId);
-                }
-            });
+            view.readProperty(sid, resId);
         } catch (PartInitException e) {
             showException(UNABLE_TO_GET_REDIS_PROPERTY, e, UNABLE_TO_GET_REDIS_PROPERTY, false, false);
         }

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/UIHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/UIHelperImpl.java
@@ -40,20 +40,15 @@ import org.eclipse.ui.PlatformUI;
 
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.management.storage.StorageAccount;
-import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azureexplorer.Activator;
-import com.microsoft.azuretools.azureexplorer.editors.BlobExplorerFileEditor;
-import com.microsoft.azuretools.azureexplorer.editors.QueueFileEditor;
 import com.microsoft.azuretools.azureexplorer.editors.StorageEditorInput;
-import com.microsoft.azuretools.azureexplorer.editors.TableFileEditor;
 import com.microsoft.azuretools.azureexplorer.editors.rediscache.RedisExplorerEditor;
 import com.microsoft.azuretools.azureexplorer.editors.rediscache.RedisExplorerEditorInput;
 import com.microsoft.azuretools.azureexplorer.forms.OpenSSLFinderForm;
-import com.microsoft.azuretools.azureexplorer.messages.MessageHandler;
 import com.microsoft.azuretools.azureexplorer.views.RedisPropertyView;
 import com.microsoft.azuretools.core.utils.PluginUtil;
-import com.microsoft.azuretools.utils.AzureModelController;
+import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.helpers.UIHelper;
 import com.microsoft.tooling.msservices.helpers.azure.sdk.StorageClientSDKManager;
 import com.microsoft.tooling.msservices.model.storage.BlobContainer;
@@ -61,7 +56,6 @@ import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount;
 import com.microsoft.tooling.msservices.model.storage.Queue;
 import com.microsoft.tooling.msservices.model.storage.StorageServiceTreeItem;
 import com.microsoft.tooling.msservices.model.storage.Table;
-import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.rediscache.RedisCacheNode;
 
 public class UIHelperImpl implements UIHelper {

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/views/RedisPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/views/RedisPropertyView.java
@@ -39,8 +39,15 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.IViewSite;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchListener;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
 
+import com.microsoft.azuretools.azureexplorer.editors.rediscache.RedisExplorerEditor;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.rediscache.RedisCacheProperty;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.rediscache.RedisPropertyMvpView;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.rediscache.RedisPropertyViewPresenter;
@@ -182,14 +189,6 @@ public class RedisPropertyView extends ViewPart implements RedisPropertyMvpView 
         setChildrenTransparent(container);
         setScrolledCompositeContent();
         
-        // View cLose event
-        parent.addDisposeListener(new DisposeListener() {
-            @Override
-            public void widgetDisposed(DisposeEvent e) {
-                RedisPropertyView.this.redisPropertyViewPresenter.onDetachView();
-            }
-        });
-        
         lnkPrimaryKey.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
@@ -207,6 +206,27 @@ public class RedisPropertyView extends ViewPart implements RedisPropertyMvpView 
 
     @Override
     public void setFocus() { }
+    
+    @Override
+    public void init(IViewSite site) throws PartInitException {
+        super.init(site);
+        IWorkbench workbench = PlatformUI.getWorkbench();
+        final IWorkbenchPage activePage = workbench.getActiveWorkbenchWindow().getActivePage();
+        workbench.addWorkbenchListener( new IWorkbenchListener() {
+            public boolean preShutdown( IWorkbench workbench, boolean forced )     {
+                activePage.hideView(RedisPropertyView.this);
+                return true;
+            }
+         
+            public void postShutdown( IWorkbench workbench ) { }
+        });
+    }
+    
+    @Override
+    public void dispose() {
+        this.redisPropertyViewPresenter.onDetachView();
+        super.dispose();
+    }
     
     @Override
     public void readProperty(String sid, String id) {

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/views/RedisPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/views/RedisPropertyView.java
@@ -28,8 +28,6 @@ import java.awt.datatransfer.StringSelection;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
-import org.eclipse.swt.events.DisposeEvent;
-import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Color;
@@ -47,7 +45,6 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
 
-import com.microsoft.azuretools.azureexplorer.editors.rediscache.RedisExplorerEditor;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.rediscache.RedisCacheProperty;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.rediscache.RedisPropertyMvpView;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.rediscache.RedisPropertyViewPresenter;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/UIHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/UIHelperImpl.java
@@ -311,14 +311,12 @@ public class UIHelperImpl implements UIHelper {
             itemVirtualFile.putUserData(RESOURCE_ID, resId);
         }
         FileEditor[] editors = fileEditorManager.openFile( itemVirtualFile, true, true);
-        ApplicationManager.getApplication().invokeLater(() -> {
-            for (FileEditor editor: editors) {
-                if (editor.getName().equals(RedisCachePropertyView.ID) &&
-                        editor instanceof RedisCachePropertyView) {
-                    ((RedisCachePropertyView) editor).readProperty(sid, resId);
-                }
+        for (FileEditor editor: editors) {
+            if (editor.getName().equals(RedisCachePropertyView.ID) &&
+                    editor instanceof RedisCachePropertyView) {
+                ((RedisCachePropertyView) editor).readProperty(sid, resId);
             }
-        }, ModalityState.any());
+        }
     }
 
     @Override

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisPropertyViewPresenter.java
@@ -61,6 +61,9 @@ public class RedisPropertyViewPresenter<V extends RedisPropertyMvpView> extends 
         })
         .subscribeOn(Schedulers.io())
         .subscribe(redis -> {
+            if (redis == null) {
+                getMvpView().onError(CANNOT_GET_REDIS_PROPERTY);
+            }
             RedisCacheProperty property = new RedisCacheProperty(redis.name(), redis.type(), redis.resourceGroupName(),
                   redis.regionName(), sid, redis.redisVersion(), redis.sslPort(), redis.nonSslPort(),
                   redis.keys().primaryKey(), redis.keys().secondaryKey(), redis.hostName());

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisPropertyViewPresenter.java
@@ -63,6 +63,7 @@ public class RedisPropertyViewPresenter<V extends RedisPropertyMvpView> extends 
         .subscribe(redis -> {
             if (redis == null) {
                 getMvpView().onError(CANNOT_GET_REDIS_PROPERTY);
+                return;
             }
             RedisCacheProperty property = new RedisCacheProperty(redis.name(), redis.type(), redis.resourceGroupName(),
                   redis.regionName(), sid, redis.redisVersion(), redis.sslPort(), redis.nonSslPort(),


### PR DESCRIPTION
- Use rxJava in Redis Property Presenter
- Add a shut down listerner in Eclipse property view, to make sure the view will be closed when eclipse will be shut down
- Change the resource release logic into lifecycle method: dispose(), instead of add a close listener