### PR TITLE
Fix redis explorer telemetry name issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/editors/rediscache/RedisExplorerEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/editors/rediscache/RedisExplorerEditor.java
@@ -64,6 +64,7 @@ public class RedisExplorerEditor extends EditorPart implements RedisExplorerMvpV
 
     // Identifier of this class
     public static final String ID = "com.microsoft.azuretools.azureexplorer.editors.rediscache.RedisExplorerEditor";
+    public static final String INSIGHT_NAME = "AzurePlugin.Eclipse.Editor.RedisExplorerEditor";
 
     // Icon path for the search button
     private static final String SEARCH_ICON_PATH = "icons/search.png";
@@ -250,7 +251,7 @@ public class RedisExplorerEditor extends EditorPart implements RedisExplorerMvpV
         scrolledComposite.setMinSize(cmpoMain.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 
         
-        cbDatabase.addListener(SWT.Selection, new AzureListenerWrapper(ID, "cbDatabase", null) {
+        cbDatabase.addListener(SWT.Selection, new AzureListenerWrapper(INSIGHT_NAME, "cbDatabase", null) {
             @Override 
             protected void handleEventFunc(Event event) {
                 if (cbActionType.getText().equals(ACTION_GET)) {
@@ -262,7 +263,7 @@ public class RedisExplorerEditor extends EditorPart implements RedisExplorerMvpV
             }
         });
 
-        lstKey.addListener(SWT.Selection, new AzureListenerWrapper(ID, "lstKey", null) {
+        lstKey.addListener(SWT.Selection, new AzureListenerWrapper(INSIGHT_NAME, "lstKey", null) {
             @Override
             protected void handleEventFunc(Event event) {
                 String selectedKey = lstKey.getItem(lstKey.getSelectionIndex());
@@ -275,14 +276,14 @@ public class RedisExplorerEditor extends EditorPart implements RedisExplorerMvpV
             }
         });
 
-        btnSearch.addListener(SWT.Selection, new AzureListenerWrapper(ID, "btnSearch", null) {
+        btnSearch.addListener(SWT.Selection, new AzureListenerWrapper(INSIGHT_NAME, "btnSearch", null) {
             @Override
             protected void handleEventFunc(Event event) {
                 onBtnSearchClick();
             }
         });
 
-        btnScanMoreKey.addListener(SWT.Selection, new AzureListenerWrapper(ID, "btnScanMoreKey", null) {
+        btnScanMoreKey.addListener(SWT.Selection, new AzureListenerWrapper(INSIGHT_NAME, "btnScanMoreKey", null) {
             @Override
             protected void handleEventFunc(Event event) {
                 setWidgetEnableStatus(false);
@@ -298,7 +299,7 @@ public class RedisExplorerEditor extends EditorPart implements RedisExplorerMvpV
             }
         });
 
-        cbActionType.addListener(SWT.Selection, new AzureListenerWrapper(ID, "cbActionType", null) {
+        cbActionType.addListener(SWT.Selection, new AzureListenerWrapper(INSIGHT_NAME, "cbActionType", null) {
             @Override
             protected void handleEventFunc(Event event) {
                 String selected = cbActionType.getText();

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/components/AzureListenerWrapper.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/components/AzureListenerWrapper.java
@@ -78,7 +78,7 @@ public abstract class AzureListenerWrapper implements Listener {
         if (null != properties) {
             telemetryProperties.putAll(properties);
         }
-        String eventName = String.format("%s_%s_%d", compositeName, widgetName, event.type);
+        String eventName = String.format("%s.%s.%d", compositeName, widgetName, event.type);
         AppInsightsClient.create(eventName, null, telemetryProperties, false);
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/rediscache/RedisCacheExplorer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/rediscache/RedisCacheExplorer.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 public class RedisCacheExplorer extends BaseEditor implements RedisExplorerMvpView {
 
     public static final String ID = "com.microsoft.intellij.helpers.rediscache.RedisCacheExplorer";
+    public static final String INSIGHT_NAME = "AzurePlugin.IntelliJ.Editor.RedisCacheExplorer";
 
     private String currentCursor;
     private String lastChosenKey;
@@ -117,7 +118,7 @@ public class RedisCacheExplorer extends BaseEditor implements RedisExplorerMvpVi
 
         progressBar.setIndeterminate(true);
 
-        cbDatabase.addActionListener(new AzureActionListenerWrapper(ID, "cbDatabase", null) {
+        cbDatabase.addActionListener(new AzureActionListenerWrapper(INSIGHT_NAME, "cbDatabase", null) {
             @Override
             public void actionPerformedFunc(ActionEvent event) {
                 if (cbActionType.getSelectedItem().equals(ACTION_GET)) {
@@ -129,7 +130,7 @@ public class RedisCacheExplorer extends BaseEditor implements RedisExplorerMvpVi
             }
         });
 
-        lstKey.addListSelectionListener(new AzureListSelectionListenerWrapper(ID, "lstKey", null) {
+        lstKey.addListSelectionListener(new AzureListSelectionListenerWrapper(INSIGHT_NAME, "lstKey", null) {
             @Override
             public void valueChangedFunc(ListSelectionEvent event) {
                 String selectedKey = (String) lstKey.getSelectedValue();
@@ -142,14 +143,14 @@ public class RedisCacheExplorer extends BaseEditor implements RedisExplorerMvpVi
             }
         });
 
-        btnSearch.addActionListener(new AzureActionListenerWrapper(ID, "btnSearch", null) {
+        btnSearch.addActionListener(new AzureActionListenerWrapper(INSIGHT_NAME, "btnSearch", null) {
             @Override
             public void actionPerformedFunc(ActionEvent event) {
                 RedisCacheExplorer.this.onBtnSearchClick();
             }
         });
 
-        btnScanMore.addActionListener(new AzureActionListenerWrapper(ID, "btnScanMore", null) {
+        btnScanMore.addActionListener(new AzureActionListenerWrapper(INSIGHT_NAME, "btnScanMore", null) {
             @Override
             public void actionPerformedFunc(ActionEvent event) {
                 RedisCacheExplorer.this.setWidgetEnableStatus(false);
@@ -160,7 +161,7 @@ public class RedisCacheExplorer extends BaseEditor implements RedisExplorerMvpVi
 
         txtKeyPattern.addActionListener(event -> onBtnSearchClick());
 
-        cbActionType.addActionListener(new AzureActionListenerWrapper(ID, "cbActionType", null) {
+        cbActionType.addActionListener(new AzureActionListenerWrapper(INSIGHT_NAME, "cbActionType", null) {
             @Override
             public void actionPerformedFunc(ActionEvent event) {
                 String selected = (String) cbActionType.getSelectedItem();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/components/AzureActionListenerWrapper.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/components/AzureActionListenerWrapper.java
@@ -89,7 +89,7 @@ public abstract class AzureActionListenerWrapper implements ActionListener {
             telemetryProperties.putAll(properties);
         }
 
-        String eventName = String.format("%s_%s_%s", compositeName, widgetName, cmd);
+        String eventName = String.format("%s.%s.%s", compositeName, widgetName, cmd);
         AppInsightsClient.create(eventName, null, telemetryProperties, false);
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/components/AzureListSelectionListenerWrapper.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/components/AzureListSelectionListenerWrapper.java
@@ -76,7 +76,7 @@ public abstract  class AzureListSelectionListenerWrapper implements ListSelectio
             telemetryProperties.putAll(properties);
         }
 
-        String eventName = String.format("%s_%s_%s", compositeName, widgetName, SELECTEVENT);
+        String eventName = String.format("%s.%s.%s", compositeName, widgetName, SELECTEVENT);
         AppInsightsClient.create(eventName, null, telemetryProperties, false);
     }
 }


### PR DESCRIPTION
Fix the redis explorer telemetry issue.
1. Use customize name for telemetry
2. Use "." instead of "_" to construct the final name