### PR TITLE
Fix the extra Spark config input issue with persistence

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/RemoteDebugRunConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/RemoteDebugRunConfiguration.java
@@ -30,30 +30,18 @@ import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.WriteExternalException;
-import com.intellij.psi.search.GlobalSearchScope;
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmissionParameter;
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel;
 import com.microsoft.azure.hdinsight.spark.run.SparkBatchJobSubmissionState;
 import com.microsoft.azure.hdinsight.spark.ui.SparkSubmissionContentPanel;
-import com.microsoft.azuretools.utils.Pair;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class RemoteDebugRunConfiguration extends ModuleBasedConfiguration<RunConfigurationModule> {
-    private static final String SUBMISSION_CONTENT_NAME = "spark_submission";
-    private static final String SUBMISSION_ATTRIBUTE_CLUSTER_NAME = "cluster_name";
-    private static final String SUBMISSION_ATTRIBUTE_SELECTED_CLUSTER = "selected_cluster";
-    private static final String SUBMISSION_ATTRIBUTE_IS_LOCAL_ARTIFACT = "is_local_artifact";
-    private static final String SUBMISSION_ATTRIBUTE_ARTIFACT_NAME = "artifact_name";
-    private static final String SUBMISSION_ATTRIBUTE_FILE_PATH = "file_path";
-    private static final String SUBMISSION_ATTRIBUTE_CLASSNAME = "classname";
 
     private SparkSubmitModel submitModel;
 
@@ -67,71 +55,19 @@ public class RemoteDebugRunConfiguration extends ModuleBasedConfiguration<RunCon
     public void readExternal(Element rootElement) throws InvalidDataException {
         super.readExternal(rootElement);
 
-        SparkSubmitModel model = getSubmitModel();
-        SparkSubmissionParameter parameter = Optional.ofNullable(model.getSubmissionParameter())
-                .orElse(new SparkSubmissionParameter(
-                        "",
-                        false,
-                        "",
-                        "",
-                        "",
-                        "",
-                        new ArrayList<String>(),
-                        new ArrayList<String>(),
-                        new ArrayList<String>(),
-                        Arrays.stream(SparkSubmissionParameter.defaultParameters)
-                            .collect(Collectors.toMap(Pair::first, Pair::second))));
-
-        Optional.ofNullable(rootElement.getChild(SUBMISSION_CONTENT_NAME)).ifPresent((element -> {
-            Optional.ofNullable(element.getAttribute(SUBMISSION_ATTRIBUTE_CLUSTER_NAME))
-                    .ifPresent(attribute -> parameter.setClusterName(attribute.getValue()));
-            Optional.ofNullable(element.getAttribute(SUBMISSION_ATTRIBUTE_IS_LOCAL_ARTIFACT))
-                    .ifPresent(attribute -> parameter.setLocalArtifact(attribute.getValue().toLowerCase()                                                              .equals("true")));
-            Optional.ofNullable(element.getAttribute(SUBMISSION_ATTRIBUTE_ARTIFACT_NAME))
-                    .ifPresent(attribute -> parameter.setArtifactName(attribute.getValue()));
-            Optional.ofNullable(element.getAttribute(SUBMISSION_ATTRIBUTE_CLASSNAME))
-                    .ifPresent(attribute -> parameter.setClassName(attribute.getValue()));
-
-            model.setSubmissionParameters(parameter);
-        }));
+        this.submitModel = SparkSubmitModel.factoryFromElement(this.submitModel.getProject(), rootElement);
     }
 
     @Override
     public void writeExternal(Element rootElement) throws WriteExternalException {
         super.writeExternal(rootElement);
 
-        SparkSubmitModel model = getSubmitModel();
-
-        SparkSubmissionParameter submissionParameter = model.getSubmissionParameter();
-
-        if (submissionParameter == null) {
-            return;
-        }
-
-        // The element to save editor's setting
-        Element remoteDebugSettingsElement = new Element(SUBMISSION_CONTENT_NAME);
-        remoteDebugSettingsElement.setAttribute(
-                SUBMISSION_ATTRIBUTE_CLUSTER_NAME, submissionParameter.getClusterName());
-        remoteDebugSettingsElement.setAttribute(
-                SUBMISSION_ATTRIBUTE_IS_LOCAL_ARTIFACT, Boolean.toString(model.isLocalArtifact()));
-        remoteDebugSettingsElement.setAttribute(
-                SUBMISSION_ATTRIBUTE_ARTIFACT_NAME, submissionParameter.getArtifactName());
-        remoteDebugSettingsElement.setAttribute(
-                SUBMISSION_ATTRIBUTE_CLASSNAME, submissionParameter.getMainClassName());
-
+        Element remoteDebugSettingsElement = this.submitModel.exportToElement();
         rootElement.addContent(remoteDebugSettingsElement);
     }
 
     public SparkSubmitModel getSubmitModel() {
         return submitModel;
-    }
-
-    public Object getSelectedClusterItem() {
-        return this.getSubmitModel().getClusterComboBoxModel().getSelectedItem();
-    }
-
-    public void setSelectedClusterItem(Object selectedClusterItem) {
-        this.getSubmitModel().getClusterComboBoxModel().setSelectedItem(selectedClusterItem);
     }
 
     @NotNull
@@ -160,6 +96,7 @@ public class RemoteDebugRunConfiguration extends ModuleBasedConfiguration<RunCon
 
     public void apply(SparkSubmissionContentPanel submissionPanel) {
         this.submitModel.setSubmissionParameters(submissionPanel.constructSubmissionParameter());
+        this.submitModel.setAdvancedConfigModel(submissionPanel.getSubmitModel().getAdvancedConfigModel());
     }
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/RemoteDebugSettingsEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/RemoteDebugSettingsEditor.java
@@ -24,8 +24,9 @@ package com.microsoft.azure.hdinsight.spark.run.configuration;
 
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SettingsEditor;
+import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel;
 import com.microsoft.azure.hdinsight.spark.ui.SparkSubmissionContentPanel;
-import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkSubmissionContentPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkSubmissionContentPanel.java
@@ -149,11 +149,17 @@ public class SparkSubmissionContentPanel extends JPanel{
     private final JLabel[] errorMessageLabels = new JLabel[5];
     private SparkSubmissionAdvancedConfigDialog advancedConfigDialog;
 
-    public void apply(SparkSubmitModel submitModel) {
-        this.submitModel = submitModel;
-        initializeModel();
-        updateTableColumn();
-        loadParameter();
+    /**
+     * Apply the parameters in new SubmitModel
+     *
+     * @param newSubmitModel the new submit model to apply
+     */
+    public void apply(SparkSubmitModel newSubmitModel) {
+        SparkSubmissionParameter parameter = newSubmitModel.getSubmissionParameter();
+        SubmissionTableModel tableModel = (SubmissionTableModel) jobConfigurationTable.getModel();
+
+        loadParameter(parameter);
+        tableModel.loadJobConfigMap(parameter.getJobConfig());
     }
 
     private enum ErrorMessageLabelTag {
@@ -169,11 +175,10 @@ public class SparkSubmissionContentPanel extends JPanel{
         initializeComponents();
         initializeModel();
         updateTableColumn();
-        loadParameter();
+        loadParameter(submitModel.getSubmissionParameter());
     }
 
-    private void loadParameter() {
-        SparkSubmissionParameter parameter = submitModel.getSubmissionParameter();
+    private void loadParameter(SparkSubmissionParameter parameter) {
         if (parameter != null) {
             if (parameter.isLocalArtifact()) {
                 localArtifactRadioButton.setSelected(true);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/uihelper/InteractiveRenderer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/uihelper/InteractiveRenderer.java
@@ -35,16 +35,8 @@ public class InteractiveRenderer extends DefaultTableCellRenderer {
     @Override
     public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
         Component component =  super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-        if (column == interactiveColumn && hasFocus) {
-
-            InteractiveTableModel tableModel = (InteractiveTableModel)table.getModel();
-            if(tableModel != null)
-
-            if ((tableModel.getRowCount() - 1) == row && !tableModel.hasEmptyRow())
-            {
-               tableModel.addEmptyRow();
-            }
-
+        InteractiveTableModel tableModel = (InteractiveTableModel)table.getModel();
+        if (column == interactiveColumn && hasFocus && tableModel != null) {
             int lastRow = tableModel.getRowCount();
             if (row == lastRow - 1) {
                 table.setRowSelectionInterval(lastRow - 1, lastRow - 1);

--- a/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJobScenario.feature
+++ b/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJobScenario.feature
@@ -9,12 +9,14 @@ Feature: Spark Batch Remote Debug Job Testing
       | spark.yarn.maxAppAttempts | 3 |
     Then throw exception 'com.microsoft.azure.hdinsight.spark.common.DebugParameterDefinedException' with message 'The driver max app attempts parameter is defined in Spark job configuration: 3'
 
-    And create batch Spark Job with driver debugging for 'http://localhost:8998/batches' with following parameters
+    Given setup a mock livy service for POST request 'http://127.0.0.1:9876/batches' to return '{"id":9, "state":"starting","appId":"application_1492415936046_0015","appInfo":{"driverLogUrl":"https://spkdbg.azurehdinsight.net/yarnui/10.0.0.15/node/containerlogs/container_e02_1492415936046_0015_01_000001/livy","sparkUiUrl":"https://spkdbg.azurehdinsight.net/yarnui/hn/proxy/application_1492415936046_0015/"},"log":["\t ApplicationMaster RPC port: -1","\t queue: default","\t start time: 1492569369011","\t final status: UNDEFINED","\t tracking URL: https://spkdbg.azurehdinsight.net/yarnui/hn/proxy/application_1492415936046_0015/","\t user: livy","17/04/19 02:36:09 INFO ShutdownHookManager: Shutdown hook called","17/04/19 02:36:09 INFO ShutdownHookManager: Deleting directory /tmp/spark-1984dc9d-acd4-4648-9104-398431590f8e","YARN Diagnostics:","AM container is launched, waiting for AM container to Register with RM"]}' with status code 200
+    And create batch Spark Job with driver debugging for 'http://localhost:9876/batches' with following parameters
       | spark.driver.extraJavaOptions | -head |
     Then the Spark driver JVM option should be '-head -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0'
     Then the Spark driver max retries should be '1'
 
-    And create batch Spark Job with driver debugging for 'http://localhost:8998/batches' with following parameters
+    Given setup a mock livy service for POST request 'http://127.0.0.1:9876/batches' to return '{"id":9, "state":"starting","appId":"application_1492415936046_0015","appInfo":{"driverLogUrl":"https://spkdbg.azurehdinsight.net/yarnui/10.0.0.15/node/containerlogs/container_e02_1492415936046_0015_01_000001/livy","sparkUiUrl":"https://spkdbg.azurehdinsight.net/yarnui/hn/proxy/application_1492415936046_0015/"},"log":["\t ApplicationMaster RPC port: -1","\t queue: default","\t start time: 1492569369011","\t final status: UNDEFINED","\t tracking URL: https://spkdbg.azurehdinsight.net/yarnui/hn/proxy/application_1492415936046_0015/","\t user: livy","17/04/19 02:36:09 INFO ShutdownHookManager: Shutdown hook called","17/04/19 02:36:09 INFO ShutdownHookManager: Deleting directory /tmp/spark-1984dc9d-acd4-4648-9104-398431590f8e","YARN Diagnostics:","AM container is launched, waiting for AM container to Register with RM"]}' with status code 200
+    And create batch Spark Job with driver debugging for 'http://localhost:9876/batches' with following parameters
       | | |
     Then the Spark driver JVM option should be '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0'
 

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJob.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchRemoteDebugJob.java
@@ -186,9 +186,13 @@ public class SparkBatchRemoteDebugJob implements ISparkBatchDebugJob, ILogger {
                             "Bad spark job response: " + httpResponse.getMessage()));
 
             this.setBatchId(jobResp.getId());
+
+            return this;
         }
 
-        return this;
+        throw new UnknownServiceException(String.format(
+                "Failed to submit Spark remove debug job. error code: %d, type: %s, reason: %s.",
+                httpResponse.getCode(), httpResponse.getContent(), httpResponse.getMessage()));
     }
 
     /**
@@ -493,7 +497,7 @@ public class SparkBatchRemoteDebugJob implements ISparkBatchDebugJob, ILogger {
                 submissionParameter.getFile(),
                 submissionParameter.getMainClassName(),
                 submissionParameter.getReferencedFiles(),
-                submissionParameter.getReferencedFiles(),
+                submissionParameter.getReferencedJars(),
                 submissionParameter.getArgs(),
                 jobConfigWithDebug
         );


### PR DESCRIPTION
The Spark Remote Debug run configuration supports all paramters
persistence now.

Signed-off-by: Zhang Wei <zhwe@microsoft.com>