### PR TITLE
Fix mooncake service principle login issue

### DIFF
--- a/BuildDevint
+++ b/BuildDevint
@@ -30,7 +30,7 @@ set -x
 
 # Build Utils
 mvn install -f $SCRIPTPATH/Utils/pom.xml -Dmaven.repo.local=$SCRIPTPATH/.repository $MAVEN_QUIET
-mvn install -f $SCRIPTPATH/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml -Dmaven.repo.local=$SCRIPTPATH/.repository $MAVEN_QUIET
+mvn install -f $SCRIPTPATH/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml -Dmaven.repo.local=$SCRIPTPATH/.repository
 
 # # Build eclipse plugin
 mvn clean install -f $SCRIPTPATH/PluginsAndFeatures/azure-toolkit-for-eclipse/pom.xml $MAVEN_QUIET

--- a/BuildDevint
+++ b/BuildDevint
@@ -30,7 +30,7 @@ set -x
 
 # Build Utils
 mvn install -f $SCRIPTPATH/Utils/pom.xml -Dmaven.repo.local=$SCRIPTPATH/.repository $MAVEN_QUIET
-mvn install -f $SCRIPTPATH/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml -Dmaven.repo.local=$SCRIPTPATH/.repository
+mvn install -f $SCRIPTPATH/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml -Dmaven.repo.local=$SCRIPTPATH/.repository $MAVEN_QUIET
 
 # # Build eclipse plugin
 mvn clean install -f $SCRIPTPATH/PluginsAndFeatures/azure-toolkit-for-eclipse/pom.xml $MAVEN_QUIET

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/ServicePrincipalAzureManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/ServicePrincipalAzureManager.java
@@ -78,29 +78,12 @@ public class ServicePrincipalAzureManager extends AzureManagerBase {
     }
 
     private Azure.Authenticated auth() throws IOException {
-        ApplicationTokenCredentials credentials = (atc == null) ? ApplicationTokenCredentials.fromFile(credFile) : atc;
-        if (!credentials.environment().managementEndpoint().contains(AzureEnvironment.AZURE.managementEndpoint()) &&
-            AuthMethodManager.getClientBuilder() != null) {
-            // Register attached resources certificates needed to work with China and Germany clouds
-                RestClient restClient = new RestClient.Builder(
-                    AuthMethodManager.getClientBuilder(),
-                    new Retrofit.Builder())
-                    .withBaseUrl(credentials.environment().resourceManagerEndpoint())
-                    .withCredentials(credentials)
-                    .withSerializerAdapter(new AzureJacksonAdapter())
-                    .withResponseBuilderFactory(new AzureResponseBuilder.Factory())
-                    .withUserAgent(CommonSettings.USER_AGENT)
-                    .build();
-
-                return Azure.authenticate(restClient, credentials.domain());
-        } else {
-            Azure.Configurable azureConfigurable = Azure.configure()
+        Azure.Configurable azureConfigurable = Azure.configure()
                     .withInterceptor(new TelemetryInterceptor())
                     .withUserAgent(CommonSettings.USER_AGENT);
-            return (atc == null)
+        return (atc == null)
                 ? azureConfigurable.authenticate(credFile)
                 : azureConfigurable.authenticate(atc);
-        }
     }
 
     @Override


### PR DESCRIPTION
Currently user failed login mooncake. The reason is the azure china endpoint has updated the certificate. So the certificate packaged in the plugin does not work anymore. But
1. Now certs of azure china endpoint could be verified by the default keystore of intelliJ/jdk.
2. So remove the code to use custom store.
3. After tester verify the change. Will clean the unused code.