### PR TITLE
Fix the log missing issue of Spark Job containers

### DIFF
--- a/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/spark/jobs/JobUtilsScenario.java
+++ b/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/spark/jobs/JobUtilsScenario.java
@@ -38,7 +38,7 @@ public class JobUtilsScenario {
         Object lock = new Object();
         Iterator logIterExpect = logs.iterator();
 
-        Subscription sub = JobUtils.createYarnLogObservable(null, logUrl, "stderr", 10)
+        Subscription sub = JobUtils.createYarnLogObservable(null, null, logUrl, "stderr", 10)
                 .subscribe((line) -> {
                     String logExpect = logIterExpect.next().toString();
                     assertEquals(logExpect, line);


### PR DESCRIPTION
Replace the container log fetching stop from unsubscribe()
to a dedicated Observable since those logs need to handle
before being unsubscribed.

Signed-off-by: Zhang Wei <zhwe@microsoft.com>