### PR TITLE
fix login issue: displayedId mismatch

### DIFF
--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AdAuthManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AdAuthManager.java
@@ -76,8 +76,14 @@ public class AdAuthManager {
         AuthContext ac = new AuthContext(String.format("%s/%s", Constants.authority, commonTid), cache);
 
         AuthenticationResult result = ac.acquireToken(AzureEnvironment.AZURE.resourceManagerEndpoint(), Constants.clientId, Constants.redirectUri, PromptBehavior.Always, null);
+        String uniqueId = result.getUserInfo().getUniqueId();
         String displayableId = result.getUserInfo().getDisplayableId();
-        UserIdentifier uid = new UserIdentifier(displayableId, UserIdentifierType.RequiredDisplayableId);
+        UserIdentifier uid;
+        if (uniqueId != null) {
+            uid = new UserIdentifier(uniqueId, UserIdentifierType.UniqueId);
+        } else {
+            uid = new UserIdentifier(displayableId, UserIdentifierType.RequiredDisplayableId);
+        }
 
         Map<String, List<String>> tidToSidsMap = new HashMap<>();
 //        List<Tenant> tenants = AccessTokenAzureManager.authTid(commonTid).tenants().list();
@@ -97,12 +103,11 @@ public class AdAuthManager {
         }
 
         // save account email
-        String accountEmail = displayableId;
-        if (accountEmail == null) {
+        if (displayableId == null) {
             throw new IllegalArgumentException("accountEmail is null");
         }
 
-        adAuthDetails.setAccountEmail(accountEmail);
+        adAuthDetails.setAccountEmail(displayableId);
         adAuthDetails.setTidToSidsMap(tidToSidsMap);
 //        saveSettings();
 


### PR DESCRIPTION
I find previously we only use `displayedId` to login instead of `uniqueId`. This commit might fix it.

related issue #740 
