### PR TITLE
Maven plugin refactor

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/com/microsoft/azuretools/container/handlers/DockerRunHandler.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/com/microsoft/azuretools/container/handlers/DockerRunHandler.java
@@ -63,7 +63,7 @@ import rx.Observable;
 
 public class DockerRunHandler extends AzureAbstractHandler {
 
-    private static final String MAVEN_GOALS = "clean package";
+    private static final String MAVEN_GOALS = "package";
     private IWorkbenchWindow window;
     private IProject project;
     private String basePath;

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/com/microsoft/azuretools/container/handlers/DockerRunHandler.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/com/microsoft/azuretools/container/handlers/DockerRunHandler.java
@@ -64,7 +64,6 @@ import rx.Observable;
 public class DockerRunHandler extends AzureAbstractHandler {
 
     private static final String MAVEN_GOALS = "clean package";
-    private static final String MODE = "run";
     private IWorkbenchWindow window;
     private IProject project;
     private String basePath;
@@ -109,7 +108,7 @@ public class DockerRunHandler extends AzureAbstractHandler {
                 MavenExecuteAction action = new MavenExecuteAction(MAVEN_GOALS);
                 IContainer container;
                 container = MavenUtils.getPomFile(project).getParent();
-                action.launch(container, MODE, () -> {
+                action.launch(container, () -> {
                     // TODO: callback after mvn package done. IMPORTANT
                     buildAndRun(event);
                     return null;

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/com/microsoft/azuretools/container/handlers/PublishHandler.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/com/microsoft/azuretools/container/handlers/PublishHandler.java
@@ -63,7 +63,7 @@ import rx.Observable;
 
 public class PublishHandler extends AzureAbstractHandler {
 
-    private static final String MAVEN_GOALS = "clean package";
+    private static final String MAVEN_GOALS = "package";
     private IWorkbenchWindow window;
     private IProject project;
     private String destinationPath;

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/com/microsoft/azuretools/container/handlers/PublishHandler.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/com/microsoft/azuretools/container/handlers/PublishHandler.java
@@ -64,7 +64,6 @@ import rx.Observable;
 public class PublishHandler extends AzureAbstractHandler {
 
     private static final String MAVEN_GOALS = "clean package";
-    private static final String MODE = "run";
     private IWorkbenchWindow window;
     private IProject project;
     private String destinationPath;
@@ -89,7 +88,7 @@ public class PublishHandler extends AzureAbstractHandler {
                 MavenExecuteAction action = new MavenExecuteAction(MAVEN_GOALS);
                 IContainer container;
                 container = MavenUtils.getPomFile(project).getParent();
-                action.launch(container, MODE, () -> {
+                action.launch(container, () -> {
                     buildAndRun(event);
                     return null;
                 });
@@ -142,7 +141,7 @@ public class PublishHandler extends AzureAbstractHandler {
                     ConfigFileUtil.saveConfig(project, DockerRuntime.getInstance().saveToProps(props));
                 }
             });
-            
+
             Map<String, String> extraInfo = new HashMap<>();
             try {
                 boolean isJar = MavenUtils.isMavenProject(this.project) && MavenUtils.getPackaging(this.project).equals(WebAppUtils.TYPE_JAR);

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/actions/MavenExecuteAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/actions/MavenExecuteAction.java
@@ -33,13 +33,12 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.DebugEvent;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.IDebugEventSetListener;
+import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.IProcess;
-import org.eclipse.debug.ui.DebugUITools;
-import org.eclipse.debug.ui.IDebugModelPresentation;
 import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.debug.ui.RefreshTab;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -47,43 +46,36 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.JavaRuntime;
-import org.eclipse.jface.viewers.ILabelProvider;
-import org.eclipse.jface.viewers.ILabelProviderListener;
-import org.eclipse.jface.window.Window;
 import org.eclipse.m2e.actions.MavenLaunchConstants;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
-import org.eclipse.m2e.internal.launch.LaunchingUtils;
-import org.eclipse.m2e.internal.launch.Messages;
-import org.eclipse.osgi.util.NLS;
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.dialogs.ElementListSelectionDialog;
 
-import java.util.ArrayList;
 import java.util.concurrent.Callable;
 
 public class MavenExecuteAction {
 
-    private String goalName = null;
+    private final String goalName;
+
+    private static final String MVN_LAUNCH_MODE = "run";
 
     public MavenExecuteAction(String goal) {
         this.goalName = goal;
     }
 
-    public void launch(IContainer basecon, String mode, Callable<?> callback) throws CoreException {
+    public void launch(IContainer basecon, Callable<?> callback) throws CoreException {
         if (basecon == null) {
             return;
         }
 
-        ILaunchConfiguration launchConfiguration = getLaunchConfiguration(basecon, mode);
+        ILaunchConfiguration launchConfiguration = createLaunchConfiguration(basecon);
         if (launchConfiguration == null) {
             return;
         }
+
+        ILaunch launch = launchConfiguration.launch(MVN_LAUNCH_MODE, new NullProgressMonitor(), true, true);
 
         DebugPlugin.getDefault().addDebugEventListener(new IDebugEventSetListener() {
             @Override
@@ -92,7 +84,7 @@ public class MavenExecuteAction {
                     DebugEvent event = events[i];
                     if (event.getSource() instanceof IProcess && event.getKind() == DebugEvent.TERMINATE) {
                         IProcess process = (IProcess) event.getSource();
-                        if (launchConfiguration == process.getLaunch().getLaunchConfiguration()) {
+                        if (launch == process.getLaunch()) {
                             DebugPlugin.getDefault().removeDebugEventListener(this);
                             try {
                                 if (process.getExitValue() == 0) {
@@ -107,23 +99,20 @@ public class MavenExecuteAction {
                 }
             }
         });
-
-        DebugUITools.launch(launchConfiguration, mode);
     }
 
-    private ILaunchConfiguration createLaunchConfiguration(IContainer basedir, String goal) {
+    private ILaunchConfiguration createLaunchConfiguration(IContainer basedir) {
         try {
             ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
             ILaunchConfigurationType launchConfigurationType = launchManager
                     .getLaunchConfigurationType(MavenLaunchConstants.LAUNCH_CONFIGURATION_TYPE_ID);
 
-            String launchSafeGoalName = goal.replace(':', '-');
+            String launchSafeGoalName = goalName.replace(':', '-');
 
-            ILaunchConfigurationWorkingCopy workingCopy = launchConfigurationType.newInstance(null,
-                    NLS.bind(Messages.ExecutePomAction_executing, launchSafeGoalName,
-                            basedir.getLocation().toString().replace('/', '-')));
+            ILaunchConfigurationWorkingCopy workingCopy = launchConfigurationType.newInstance(null, launchSafeGoalName);
+
             workingCopy.setAttribute(MavenLaunchConstants.ATTR_POM_DIR, basedir.getLocation().toOSString());
-            workingCopy.setAttribute(MavenLaunchConstants.ATTR_GOALS, goal);
+            workingCopy.setAttribute(MavenLaunchConstants.ATTR_GOALS, goalName);
             workingCopy.setAttribute(IDebugUIConstants.ATTR_PRIVATE, true);
             workingCopy.setAttribute(RefreshTab.ATTR_REFRESH_SCOPE, "${project}");
             workingCopy.setAttribute(RefreshTab.ATTR_REFRESH_RECURSIVE, true);
@@ -156,7 +145,6 @@ public class MavenExecuteAction {
         }
     }
 
-    // IJavaProjects
     private IPath getJREContainerPath(IContainer basedir) throws CoreException {
         IProject project = basedir.getProject();
         if (project != null && project.hasNature(JavaCore.NATURE_ID)) {
@@ -171,115 +159,4 @@ public class MavenExecuteAction {
         }
         return null;
     }
-
-    private ILaunchConfiguration getLaunchConfiguration(IContainer basedir, String mode) {
-        if (goalName != null) {
-            return createLaunchConfiguration(basedir, goalName);
-        }
-
-        ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
-        ILaunchConfigurationType launchConfigurationType = launchManager
-                .getLaunchConfigurationType(MavenLaunchConstants.LAUNCH_CONFIGURATION_TYPE_ID);
-
-        // scan existing launch configurations
-        IPath basedirLocation = basedir.getLocation();
-        try {
-            ILaunchConfiguration[] launchConfigurations = launchManager
-                    .getLaunchConfigurations(launchConfigurationType);
-            ArrayList<ILaunchConfiguration> matchingConfigs = new ArrayList<ILaunchConfiguration>();
-            for (ILaunchConfiguration configuration : launchConfigurations) {
-                try {
-                    // substitute variables (may throw exceptions)
-                    String workDir = LaunchingUtils.substituteVar(
-                            configuration.getAttribute(MavenLaunchConstants.ATTR_POM_DIR, (String) null));
-                    if (workDir == null) {
-                        continue;
-                    }
-                    IPath workPath = new Path(workDir);
-                    if (basedirLocation.equals(workPath)) {
-                        matchingConfigs.add(configuration);
-                    }
-                } catch (CoreException e) {
-                }
-
-            }
-
-            if (matchingConfigs.size() == 1) {
-                return matchingConfigs.get(0);
-            } else if (matchingConfigs.size() > 1) {
-                final IDebugModelPresentation labelProvider = DebugUITools.newDebugModelPresentation();
-                ElementListSelectionDialog dialog = new ElementListSelectionDialog(getShell(), //
-                        new ILabelProvider() {
-                            @Override
-                            public Image getImage(Object element) {
-                                return labelProvider.getImage(element);
-                            }
-
-                            @Override
-                            public String getText(Object element) {
-                                if (element instanceof ILaunchConfiguration) {
-                                    ILaunchConfiguration configuration = (ILaunchConfiguration) element;
-                                    try {
-                                        return labelProvider.getText(element) + " : "
-                                                + configuration.getAttribute(MavenLaunchConstants.ATTR_GOALS, "");
-                                    } catch (CoreException ex) {
-                                        // ignore
-                                    }
-                                }
-                                return labelProvider.getText(element);
-                            }
-
-                            @Override
-                            public boolean isLabelProperty(Object element, String property) {
-                                return labelProvider.isLabelProperty(element, property);
-                            }
-
-                            @Override
-                            public void addListener(ILabelProviderListener listener) {
-                                labelProvider.addListener(listener);
-                            }
-
-                            @Override
-                            public void removeListener(ILabelProviderListener listener) {
-                                labelProvider.removeListener(listener);
-                            }
-
-                            @Override
-                            public void dispose() {
-                                labelProvider.dispose();
-                            }
-                        });
-                dialog.setElements(matchingConfigs.toArray(new ILaunchConfiguration[matchingConfigs.size()]));
-                dialog.setTitle(Messages.ExecutePomAction_dialog_title);
-                if (mode.equals(ILaunchManager.DEBUG_MODE)) {
-                    dialog.setMessage(Messages.ExecutePomAction_dialog_debug_message);
-                } else {
-                    dialog.setMessage(Messages.ExecutePomAction_dialog_run_message);
-                }
-                dialog.setMultipleSelection(false);
-                int result = dialog.open();
-                labelProvider.dispose();
-                return result == Window.OK ? (ILaunchConfiguration) dialog.getFirstResult() : null;
-            }
-
-        } catch (CoreException ex) {
-        }
-
-        String newName = launchManager.generateLaunchConfigurationName(basedirLocation.lastSegment());
-        try {
-            ILaunchConfigurationWorkingCopy workingCopy = launchConfigurationType.newInstance(null, newName);
-            workingCopy.setAttribute(MavenLaunchConstants.ATTR_POM_DIR, basedirLocation.toString());
-
-            setProjectConfiguration(workingCopy, basedir);
-
-            return workingCopy.doSave();
-        } catch (Exception ex) {
-        }
-        return null;
-    }
-
-    private Shell getShell() {
-        return PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-    }
-
 }

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/handlers/DeployToAzureHandler.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/handlers/DeployToAzureHandler.java
@@ -40,7 +40,6 @@ import org.eclipse.ui.handlers.HandlerUtil;
 public class DeployToAzureHandler extends AzureAbstractHandler {
 
     private static final String MAVEN_GOALS = "clean package";
-    private static final String MODE = "run";
     private static final String TITLE = "Deploy to Azure App Service";
     private static final String NO_PROJECT_ERR = "Can't detect an active project";
 
@@ -60,7 +59,7 @@ public class DeployToAzureHandler extends AzureAbstractHandler {
                 MavenExecuteAction action = new MavenExecuteAction(MAVEN_GOALS);
                 IContainer container;
                 container = MavenUtils.getPomFile(project).getParent();
-                action.launch(container, MODE, () -> {
+                action.launch(container, () -> {
                     DefaultLoader.getIdeHelper().invokeLater(() -> WebAppDeployDialog.go(shell, project));
                     return null;
                 });

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/handlers/DeployToAzureHandler.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/handlers/DeployToAzureHandler.java
@@ -39,7 +39,7 @@ import org.eclipse.ui.handlers.HandlerUtil;
 
 public class DeployToAzureHandler extends AzureAbstractHandler {
 
-    private static final String MAVEN_GOALS = "clean package";
+    private static final String MAVEN_GOALS = "package";
     private static final String TITLE = "Deploy to Azure App Service";
     private static final String NO_PROJECT_ERR = "Can't detect an active project";
 


### PR DESCRIPTION
This PR has two major changes:

1. Remove some useless codes and m2e's internal dependencies. 
2. Change the Maven goal from "clean package" to "package". The reason to remove the clean goal is that, the file we need is *.(jar|war), which is always updated as long as the maven goal is successful. And by removing the clean goal, we can avoid removing user's file unexpectly. 