### PR TITLE
Rename container module name

### DIFF
--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/container/ContainerRegistryModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/container/ContainerRegistryModule.java
@@ -31,7 +31,7 @@ public class ContainerRegistryModule extends AzureRefreshableNode {
 
     private static final String ACR_MODULE_ID = ContainerRegistryModule.class.getName();
     private static final String ICON_PATH = "acr.png";
-    private static final String BASE_MODULE_NAME = "Container Registry";
+    private static final String BASE_MODULE_NAME = "Container Registries";
     private final ContainerRegistryModulePresenter<ContainerRegistryModule> containerRegistryPresenter;
 
     /**


### PR DESCRIPTION
Issue: #1003 

Rename "Container Registry" to "Container Registries" in Azure Explorer

**UI change:**

Eclipse:
![_20170908142828](https://user-images.githubusercontent.com/6193897/30198981-25d8447e-94a3-11e7-9322-13e0d33b2014.png)

IntelliJ:
![_20170908143351](https://user-images.githubusercontent.com/6193897/30198982-25db8a6c-94a3-11e7-8901-476f2f8753f6.png)
