### PR TITLE
Add select docker file filed in docker run

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunConfiguration.java
@@ -43,6 +43,8 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.Paths;
+
 public class DockerHostRunConfiguration extends RunConfigurationBase {
     // TODO: move to util
     private static final String MISSING_ARTIFACT = "A web archive (.war) artifact has not been configured.";
@@ -103,7 +105,8 @@ public class DockerHostRunConfiguration extends RunConfigurationBase {
         if (Utils.isEmptyString(dockerHostRunModel.getDockerHost())) {
             throw new ConfigurationException(INVALID_DOCKER_HOST);
         }
-        if (Utils.isEmptyString(dockerHostRunModel.getDockerFilePath())) {
+        if (Utils.isEmptyString(dockerHostRunModel.getDockerFilePath())
+                || !Paths.get(dockerHostRunModel.getDockerFilePath()).toFile().exists()) {
             throw new ConfigurationException(INVALID_DOCKER_FILE);
         }
         if (dockerHostRunModel.isTlsEnabled() && Utils.isEmptyString(dockerHostRunModel.getDockerCertPath())) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunConfiguration.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.intellij.runner.container.dockerhost;
 
 import com.intellij.execution.ExecutionException;
@@ -30,6 +52,7 @@ public class DockerHostRunConfiguration extends RunConfigurationBase {
     private static final String MISSING_MODEL = "Configuration data model not initialized.";
     private static final String ARTIFACT_NAME_REGEX = "^[.A-Za-z0-9_-]+\\.(war|jar)$";
     private static final String INVALID_DOCKER_HOST = "Please specify a valid docker host.";
+    private static final String INVALID_DOCKER_FILE = "Please specify a valid docker file.";
     private static final String INVALID_CERT_PATH = "Please specify a valid certificate path.";
     private static final String MISSING_IMAGE_NAME = "Please specify a valid image name.";
     private final DockerHostRunModel dockerHostRunModel;
@@ -80,6 +103,9 @@ public class DockerHostRunConfiguration extends RunConfigurationBase {
         if (Utils.isEmptyString(dockerHostRunModel.getDockerHost())) {
             throw new ConfigurationException(INVALID_DOCKER_HOST);
         }
+        if (Utils.isEmptyString(dockerHostRunModel.getDockerFilePath())) {
+            throw new ConfigurationException(INVALID_DOCKER_FILE);
+        }
         if (dockerHostRunModel.isTlsEnabled() && Utils.isEmptyString(dockerHostRunModel.getDockerCertPath())) {
             throw new ConfigurationException(INVALID_CERT_PATH);
         }
@@ -125,6 +151,14 @@ public class DockerHostRunConfiguration extends RunConfigurationBase {
 
     public void setDockerCertPath(String dockerCertPath) {
         dockerHostRunModel.setDockerCertPath(dockerCertPath);
+    }
+
+    public String getDockerFilePath() {
+        return dockerHostRunModel.getDockerFilePath();
+    }
+
+    public void setDockerFilePath(String dockerFilePath) {
+        dockerHostRunModel.setDockerFilePath(dockerFilePath);
     }
 
     public boolean isTlsEnabled() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunConfigurationFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunConfigurationFactory.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.intellij.runner.container.dockerhost;
 
 import com.intellij.execution.configurations.ConfigurationFactory;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunModel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunModel.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.intellij.runner.container.dockerhost;
 
 import com.spotify.docker.client.DefaultDockerClient;
@@ -16,6 +38,7 @@ public class DockerHostRunModel {
     private String tagName;
     private String targetPath;
     private String targetName;
+    private String dockerFilePath;
 
     public DockerHostRunModel() {
         try {
@@ -29,6 +52,7 @@ public class DockerHostRunModel {
         String date = df.format(new Date());
         imageName = String.format("%s-%s", "localimage", date);
         tagName = "latest";
+        dockerFilePath = "";
     }
 
     public String getDockerHost() {
@@ -85,5 +109,13 @@ public class DockerHostRunModel {
 
     public void setTargetName(String targetName) {
         this.targetName = targetName;
+    }
+
+    public String getDockerFilePath() {
+        return dockerFilePath;
+    }
+
+    public void setDockerFilePath(String dockerFilePath) {
+        this.dockerFilePath = dockerFilePath;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunRunner.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.intellij.runner.container.dockerhost;
 
 import com.intellij.execution.configurations.RunProfile;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunSettingsEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunSettingsEditor.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.intellij.runner.container.dockerhost;
 
 import com.intellij.openapi.options.ConfigurationException;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/DockerHostRunState.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.intellij.runner.container.dockerhost;
 
 import com.google.common.collect.ImmutableList;
@@ -98,7 +120,7 @@ public class DockerHostRunState implements RunProfileState {
                     processHandler.setText(String.format("Locating artifact ... [%s]", targetFilePath));
 
                     // validate dockerfile
-                    Path targetDockerfile = Paths.get(basePath, Constant.DOCKERFILE_FOLDER, Constant.DOCKERFILE_NAME);
+                    Path targetDockerfile = Paths.get(dataModel.getDockerFilePath());
                     processHandler.setText(String.format("Validating dockerfile ... [%s]", targetDockerfile));
                     if (!targetDockerfile.toFile().exists()) {
                         throw new FileNotFoundException("Dockerfile not found.");
@@ -119,9 +141,10 @@ public class DockerHostRunState implements RunProfileState {
                             dataModel.getDockerCertPath()
                     );
 
-                    String latestImageName = DockerUtil.buildImage(docker,
+                    DockerUtil.buildImage(docker,
                             imageNameWithTag,
-                            Paths.get(basePath, Constant.DOCKERFILE_FOLDER),
+                            targetDockerfile.getParent(),
+                            targetDockerfile.getFileName().toString(),
                             new DockerProgressHandler(processHandler)
                     );
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.form
@@ -3,12 +3,12 @@
   <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="505" height="400"/>
+      <xy x="20" y="20" width="554" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="d7b04" layout-manager="GridLayoutManager" row-count="3" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="d7b04" layout-manager="GridLayoutManager" row-count="4" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -34,7 +34,7 @@
           </component>
           <component id="92978" class="javax.swing.JLabel">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Image Name"/>
@@ -42,7 +42,7 @@
           </component>
           <component id="ccb6e" class="javax.swing.JTextField" binding="textImageName">
             <constraints>
-              <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -50,7 +50,7 @@
           </component>
           <component id="59411" class="javax.swing.JLabel">
             <constraints>
-              <grid row="2" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="4" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Tag Name"/>
@@ -58,7 +58,7 @@
           </component>
           <component id="74141" class="javax.swing.JTextField" binding="textTagName">
             <constraints>
-              <grid row="2" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -66,7 +66,7 @@
           </component>
           <component id="7d16b" class="javax.swing.JCheckBox" binding="comboTlsEnabled">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value=""/>
@@ -74,7 +74,7 @@
           </component>
           <component id="cb7de" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Enable TLS"/>
@@ -83,7 +83,7 @@
           <grid id="545fd" binding="pnlDockerCertPath" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="1" column="2" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="2" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>
@@ -104,6 +104,22 @@
               </component>
             </children>
           </grid>
+          <component id="130ed" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Docker File Path"/>
+            </properties>
+          </component>
+          <component id="c0075" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">
+            <constraints>
+              <grid row="1" column="2" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
         </children>
       </grid>
       <grid id="b7c46" binding="pnlArtifact" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.java
@@ -36,6 +36,7 @@ import com.intellij.ui.ListCellRendererWrapper;
 import com.microsoft.azuretools.azurecommons.util.Utils;
 import com.microsoft.azuretools.telemetry.AppInsightsClient;
 import com.microsoft.intellij.runner.container.dockerhost.DockerHostRunConfiguration;
+import com.microsoft.intellij.runner.container.utils.DockerUtil;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
 
 import org.jetbrains.idea.maven.model.MavenConstants;
@@ -70,6 +71,7 @@ public class SettingPanel {
     private JComboBox<Artifact> cbArtifact;
     private JPanel rootPanel;
     private JPanel pnlDockerCertPath;
+    private TextFieldWithBrowseButton dockerFilePathTextField;
 
     private Artifact lastSelectedArtifact;
     private boolean isCbArtifactInited;
@@ -85,6 +87,25 @@ public class SettingPanel {
         dockerCertPathTextField.addActionListener(this::onDockerCertPathBrowseButtonClick);
         comboTlsEnabled.addActionListener(event -> updateComponentEnabledState());
 
+        dockerFilePathTextField.setText(DockerUtil.getDefaultDockerFilePathIfExist(project));
+        dockerFilePathTextField.addActionListener(e -> {
+            String path = dockerFilePathTextField.getText();
+            final VirtualFile file = FileChooser.chooseFile(
+                    new FileChooserDescriptor(
+                            true /*chooseFiles*/,
+                            false /*chooseFolders*/,
+                            false /*chooseJars*/,
+                            false /*chooseJarsAsFiles*/,
+                            false /*chooseJarContents*/,
+                            false /*chooseMultiple*/
+                    ),
+                    project,
+                    Utils.isEmptyString(path) ? null : LocalFileSystem.getInstance().findFileByPath(path)
+            );
+            if (file != null) {
+                dockerFilePathTextField.setText(file.getPath());
+            }
+        });
 
         // Artifact to build
         isCbArtifactInited = false;
@@ -102,7 +123,6 @@ public class SettingPanel {
                     }
                 }
                 lastSelectedArtifact = selectedArtifact;
-
             }
         });
 
@@ -154,6 +174,7 @@ public class SettingPanel {
         textDockerHost.setText(conf.getDockerHost());
         comboTlsEnabled.setSelected(conf.isTlsEnabled());
         dockerCertPathTextField.setText(conf.getDockerCertPath());
+        dockerFilePathTextField.setText(conf.getDockerFilePath());
         textImageName.setText(conf.getImageName());
         textTagName.setText(conf.getTagName());
         updateComponentEnabledState();
@@ -175,6 +196,7 @@ public class SettingPanel {
         conf.setDockerHost(textDockerHost.getText());
         conf.setTlsEnabled(comboTlsEnabled.isSelected());
         conf.setDockerCertPath(dockerCertPathTextField.getText());
+        conf.setDockerFilePath(dockerFilePathTextField.getText());
         conf.setImageName(textImageName.getText());
         if (Utils.isEmptyString(textTagName.getText())) {
             conf.setTagName("latest");

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.java
@@ -87,7 +87,6 @@ public class SettingPanel {
         dockerCertPathTextField.addActionListener(this::onDockerCertPathBrowseButtonClick);
         comboTlsEnabled.addActionListener(event -> updateComponentEnabledState());
 
-        dockerFilePathTextField.setText(DockerUtil.getDefaultDockerFilePathIfExist(project));
         dockerFilePathTextField.addActionListener(e -> {
             String path = dockerFilePathTextField.getText();
             final VirtualFile file = FileChooser.chooseFile(
@@ -174,7 +173,11 @@ public class SettingPanel {
         textDockerHost.setText(conf.getDockerHost());
         comboTlsEnabled.setSelected(conf.isTlsEnabled());
         dockerCertPathTextField.setText(conf.getDockerCertPath());
-        dockerFilePathTextField.setText(conf.getDockerFilePath());
+        if (Utils.isEmptyString(conf.getDockerFilePath())) {
+            dockerFilePathTextField.setText(DockerUtil.getDefaultDockerFilePathIfExist(project));
+        } else {
+            dockerFilePathTextField.setText(conf.getDockerFilePath());
+        }
         textImageName.setText(conf.getImageName());
         textTagName.setText(conf.getTagName());
         updateComponentEnabledState();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/utils/DockerUtil.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/utils/DockerUtil.java
@@ -22,6 +22,7 @@
 
 package com.microsoft.intellij.runner.container.utils;
 
+import com.intellij.openapi.project.Project;
 import com.microsoft.azuretools.azurecommons.util.Utils;
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerCertificates;
@@ -116,6 +117,16 @@ public class DockerUtil {
     }
 
     /**
+     * build image.
+     */
+    public static String buildImage(DockerClient docker, String imageNameWithTag, Path dockerDirectory,
+                                    String dockerFile, ProgressHandler progressHandler)
+            throws DockerException, InterruptedException, IOException {
+        String imageId = docker.build(dockerDirectory, imageNameWithTag, dockerFile, progressHandler);
+        return imageId == null ? null : imageNameWithTag;
+    }
+
+    /**
      * Push image to a private registry.
      */
     public static void pushImage(DockerClient dockerClient, String registryUrl, String registryUsername,
@@ -143,7 +154,7 @@ public class DockerUtil {
     }
 
     /**
-     * get DockerClient instance.
+     * Get DockerClient instance.
      */
     public static DockerClient getDockerClient(String dockerHost, boolean tlsEnabled, String certPath) throws
             DockerCertificateException {
@@ -154,5 +165,21 @@ public class DockerUtil {
         } else {
             return DefaultDockerClient.builder().uri(URI.create(dockerHost)).build();
         }
+    }
+
+    /**
+     * check if the default docker file exists (in project base path).
+     * If yes, return the path as a String.
+     * Else return an empty String.
+     */
+    public static String getDefaultDockerFilePathIfExist(Project project) {
+        String basePath = project.getBasePath();
+        if (!Utils.isEmptyString(basePath)) {
+            Path targetDockerfile = Paths.get(basePath, Constant.DOCKERFILE_NAME);
+            if (targetDockerfile != null && targetDockerfile.toFile().exists()) {
+                return targetDockerfile.toString();
+            }
+        }
+        return "";
     }
 }


### PR DESCRIPTION
This PR allows user to select a docker file when he wants to use the **Docker Run** feature. So no need to run **Add Docker Support** first.

UI:
It will load the default docker file under the project base path. (If the user has already clicked the **Add Docker Support** before).
![image](https://user-images.githubusercontent.com/6193897/30260154-3bb9fcb8-96f8-11e7-9d2c-d2c8e357acb1.png)

If the docker file is not specified or the file is not existed, a error message will show at the bottom of the RunDialog.

![image](https://user-images.githubusercontent.com/6193897/30260491-34dcae3e-96fa-11e7-855a-c766f6c6a7ad.png)

![image](https://user-images.githubusercontent.com/6193897/30260500-44f43184-96fa-11e7-9ed8-ffbd1a6d63ea.png)