### PR TITLE
Add docker file selector in push image

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.form
@@ -109,7 +109,7 @@
               <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Docker File Path"/>
+              <text value="Docker File"/>
             </properties>
           </component>
           <component id="c0075" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.form
@@ -18,7 +18,7 @@
         <children>
           <component id="7558b" class="javax.swing.JLabel">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Docker Host"/>
@@ -26,7 +26,7 @@
           </component>
           <component id="51819" class="javax.swing.JTextField" binding="textDockerHost">
             <constraints>
-              <grid row="0" column="2" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="1" column="2" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -106,7 +106,7 @@
           </grid>
           <component id="130ed" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Docker File Path"/>
@@ -114,7 +114,7 @@
           </component>
           <component id="c0075" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">
             <constraints>
-              <grid row="1" column="2" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="0" column="2" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/PushImageRunConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/PushImageRunConfiguration.java
@@ -44,6 +44,8 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.Paths;
+
 public class PushImageRunConfiguration extends RunConfigurationBase {
     // TODO: move to util
     private static final String MISSING_ARTIFACT = "A web archive (.war) artifact has not been configured.";
@@ -51,6 +53,7 @@ public class PushImageRunConfiguration extends RunConfigurationBase {
     private static final String MISSING_USERNAME = "Please specify Username.";
     private static final String MISSING_PASSWORD = "Please specify Password.";
     private static final String MISSING_IMAGE_WITH_TAG = "Please specify Image and Tag.";
+    private static final String INVALID_DOCKER_FILE = "Please specify a valid docker file.";
     private static final String INVALID_IMAGE_WITH_TAG = "Image and Tag should start with '%s/'";
     private static final String INVALID_ARTIFACT_FILE = "The artifact name %s is invalid. "
             + "An artifact name may contain only the ASCII letters 'a' through 'z' (case-insensitive), "
@@ -101,6 +104,10 @@ public class PushImageRunConfiguration extends RunConfigurationBase {
     public void validate() throws ConfigurationException {
         if (dataModel == null) {
             throw new ConfigurationException(MISSING_MODEL);
+        }
+        if (Utils.isEmptyString(dataModel.getDockerFilePath())
+                || !Paths.get(dataModel.getDockerFilePath()).toFile().exists()) {
+            throw new ConfigurationException(INVALID_DOCKER_FILE);
         }
         // acr
         PrivateRegistryImageSetting setting = dataModel.getPrivateRegistryImageSetting();
@@ -158,6 +165,14 @@ public class PushImageRunConfiguration extends RunConfigurationBase {
 
     public void setTargetName(String targetName) {
         dataModel.setTargetName(targetName);
+    }
+
+    public String getDockerFilePath() {
+        return dataModel.getDockerFilePath();
+    }
+
+    public void setDockerFilePath(String dockerFilePath) {
+        dataModel.setDockerFilePath(dockerFilePath);
     }
 
     public PrivateRegistryImageSetting getPrivateRegistryImageSetting() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/PushImageRunModel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/PushImageRunModel.java
@@ -28,6 +28,7 @@ public class PushImageRunModel {
     private PrivateRegistryImageSetting privateRegistryImageSetting = new PrivateRegistryImageSetting();
     private String targetPath;
     private String targetName;
+    private String dockerFilePath;
 
     public PrivateRegistryImageSetting getPrivateRegistryImageSetting() {
         return privateRegistryImageSetting;
@@ -51,5 +52,13 @@ public class PushImageRunModel {
 
     public void setTargetName(String targetName) {
         this.targetName = targetName;
+    }
+
+    public String getDockerFilePath() {
+        return dockerFilePath;
+    }
+
+    public void setDockerFilePath(String dockerFilePath) {
+        this.dockerFilePath = dockerFilePath;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/PushImageRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/PushImageRunState.java
@@ -87,7 +87,7 @@ public class PushImageRunState implements RunProfileState {
                     String targetFileName = dataModel.getTargetName();
 
                     // validate dockerfile
-                    Path targetDockerfile = Paths.get(basePath, Constant.DOCKERFILE_FOLDER, Constant.DOCKERFILE_NAME);
+                    Path targetDockerfile = Paths.get(dataModel.getDockerFilePath());
                     processHandler.setText(String.format("Validating dockerfile ... [%s]", targetDockerfile));
                     if (!targetDockerfile.toFile().exists()) {
                         throw new FileNotFoundException("Dockerfile not found.");
@@ -103,9 +103,10 @@ public class PushImageRunState implements RunProfileState {
                     String imageNameWithTag = dataModel.getPrivateRegistryImageSetting().getImageNameWithTag();
                     processHandler.setText(String.format("Building image ...  [%s]", imageNameWithTag));
                     DockerClient docker = DefaultDockerClient.fromEnv().build();
-                    String latestImageName = DockerUtil.buildImage(docker,
+                    DockerUtil.buildImage(docker,
                             imageNameWithTag,
-                            Paths.get(basePath, Constant.DOCKERFILE_FOLDER),
+                            targetDockerfile.getParent(),
+                            targetDockerfile.getFileName().toString(),
                             new DockerProgressHandler(processHandler)
                     );
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/ui/SettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/ui/SettingPanel.form
@@ -8,14 +8,14 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="224" binding="pnlAcrHolder" layout-manager="BorderLayout" hgap="0" vgap="0">
+      <grid id="224" layout-manager="BorderLayout" hgap="0" vgap="0">
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="3c9fc" binding="pnlAcr" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="3c9fc" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints border-constraint="Center"/>
             <properties>
@@ -25,7 +25,7 @@
             <children>
               <component id="f038c" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Server URL"/>
@@ -33,7 +33,7 @@
               </component>
               <component id="1e6ca" class="javax.swing.JTextField" binding="textServerUrl">
                 <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -41,7 +41,7 @@
               </component>
               <component id="833c7" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Username"/>
@@ -49,7 +49,7 @@
               </component>
               <component id="aaa08" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Password"/>
@@ -57,7 +57,7 @@
               </component>
               <component id="95e6b" class="javax.swing.JTextField" binding="textUsername">
                 <constraints>
-                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -65,7 +65,7 @@
               </component>
               <component id="1885" class="javax.swing.JPasswordField" binding="passwordField" default-binding="true">
                 <constraints>
-                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -73,7 +73,7 @@
               </component>
               <component id="bcf62" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Image and tag"/>
@@ -81,7 +81,7 @@
               </component>
               <component id="3129f" class="javax.swing.JTextField" binding="textImageTag">
                 <constraints>
-                  <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -89,17 +89,17 @@
                   <text value=""/>
                 </properties>
               </component>
-              <component id="ac7ea" class="javax.swing.JLabel">
+              <component id="7d545" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Startup File"/>
+                  <text value="Docker File"/>
                 </properties>
               </component>
-              <component id="d2c62" class="javax.swing.JTextField" binding="textStartupFile">
+              <component id="b3aa7" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">
                 <constraints>
-                  <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>


### PR DESCRIPTION
This PR allows user to select a docker file when he wants to push a docker image onto ACR. So no need to run Add Docker Support first.

UI:
It will load the default docker file under the project base path. (If the user has already clicked the Add Docker Support before).
![1](https://user-images.githubusercontent.com/6193897/30262591-1a10103c-9704-11e7-847e-3d77c39de603.png)

If the docker file is not specified or the file is not existed, a error message will show at the bottom of the RunDialog.
![3](https://user-images.githubusercontent.com/6193897/30262605-259cd21e-9704-11e7-9d41-d660669d591f.png)
![2](https://user-images.githubusercontent.com/6193897/30262608-2840cd86-9704-11e7-9cc2-05d844207c12.png)

