### PR TITLE
add docker file selector in run on web app (linux)

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/PushImageRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/PushImageRunState.java
@@ -84,7 +84,6 @@ public class PushImageRunState implements RunProfileState {
                     // locate artifact to specified location
                     String targetFilePath = dataModel.getTargetPath();
                     processHandler.setText(String.format("Locating artifact ... [%s]", targetFilePath));
-                    String targetFileName = dataModel.getTargetName();
 
                     // validate dockerfile
                     Path targetDockerfile = Paths.get(dataModel.getDockerFilePath());

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/WebAppOnLinuxDeployConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/WebAppOnLinuxDeployConfiguration.java
@@ -47,6 +47,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 
 public class WebAppOnLinuxDeployConfiguration extends RunConfigurationBase {
 
@@ -60,6 +61,7 @@ public class WebAppOnLinuxDeployConfiguration extends RunConfigurationBase {
     private static final String MISSING_RESOURCE_GROUP = "Please specify Resource Group.";
     private static final String MISSING_APP_SERVICE_PLAN = "Please specify App Service Plan.";
     private static final String INVALID_IMAGE_WITH_TAG = "Image and Tag should start with '%s/'";
+    private static final String INVALID_DOCKER_FILE = "Please specify a valid docker file.";
 
     // TODO: move to util
     private static final String MISSING_ARTIFACT = "A web archive (.war|.jar) artifact has not been configured.";
@@ -130,6 +132,10 @@ public class WebAppOnLinuxDeployConfiguration extends RunConfigurationBase {
             }
         } catch (IOException e) {
             throw new ConfigurationException(NEED_SIGN_IN);
+        }
+        if (Utils.isEmptyString(deployModel.getDockerFilePath())
+                || !Paths.get(deployModel.getDockerFilePath()).toFile().exists()) {
+            throw new ConfigurationException(INVALID_DOCKER_FILE);
         }
         // acr
         PrivateRegistryImageSetting setting = deployModel.getPrivateRegistryImageSetting();
@@ -303,5 +309,13 @@ public class WebAppOnLinuxDeployConfiguration extends RunConfigurationBase {
 
     public void setTargetName(String targetName) {
         deployModel.setTargetName(targetName);
+    }
+
+    public String getDockerFilePath() {
+        return deployModel.getDockerFilePath();
+    }
+
+    public void setDockerFilePath(String dockerFilePath) {
+        deployModel.setDockerFilePath(dockerFilePath);
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/WebAppOnLinuxDeployState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/WebAppOnLinuxDeployState.java
@@ -90,10 +90,9 @@ public class WebAppOnLinuxDeployState implements RunProfileState {
                     // locate artifact to specified location
                     String targetFilePath = deployModel.getTargetPath();
                     processHandler.setText(String.format("Locating artifact ... [%s]", targetFilePath));
-                    String targetFileName = deployModel.getTargetName();
 
                     // validate dockerfile
-                    Path targetDockerfile = Paths.get(basePath, Constant.DOCKERFILE_FOLDER, Constant.DOCKERFILE_NAME);
+                    Path targetDockerfile = Paths.get(deployModel.getDockerFilePath());
                     processHandler.setText(String.format("Validating dockerfile ... [%s]", targetDockerfile));
                     if (!targetDockerfile.toFile().exists()) {
                         throw new FileNotFoundException("Dockerfile not found.");
@@ -109,9 +108,10 @@ public class WebAppOnLinuxDeployState implements RunProfileState {
                     String imageNameWithTag = deployModel.getPrivateRegistryImageSetting().getImageNameWithTag();
                     processHandler.setText(String.format("Building image ...  [%s]", imageNameWithTag));
                     DockerClient docker = DefaultDockerClient.fromEnv().build();
-                    String latestImageName = DockerUtil.buildImage(docker,
+                    DockerUtil.buildImage(docker,
                             imageNameWithTag,
-                            Paths.get(basePath, Constant.DOCKERFILE_FOLDER),
+                            targetDockerfile.getParent(),
+                            targetDockerfile.getFileName().toString(),
                             new DockerProgressHandler(processHandler)
                     );
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/ui/SettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/ui/SettingPanel.form
@@ -47,7 +47,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="3c9fc" binding="pnlAcr" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="3c9fc" binding="pnlAcr" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints border-constraint="Center"/>
             <properties>
@@ -57,7 +57,7 @@
             <children>
               <component id="f038c" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Server URL"/>
@@ -65,7 +65,7 @@
               </component>
               <component id="1e6ca" class="javax.swing.JTextField" binding="textServerUrl">
                 <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -73,7 +73,7 @@
               </component>
               <component id="833c7" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Username"/>
@@ -81,7 +81,7 @@
               </component>
               <component id="aaa08" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Password"/>
@@ -89,7 +89,7 @@
               </component>
               <component id="95e6b" class="javax.swing.JTextField" binding="textUsername">
                 <constraints>
-                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -97,7 +97,7 @@
               </component>
               <component id="1885" class="javax.swing.JPasswordField" binding="passwordField" default-binding="true">
                 <constraints>
-                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -105,7 +105,7 @@
               </component>
               <component id="bcf62" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Image and tag"/>
@@ -113,7 +113,7 @@
               </component>
               <component id="3129f" class="javax.swing.JTextField" binding="textImageTag">
                 <constraints>
-                  <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -123,7 +123,7 @@
               </component>
               <component id="ac7ea" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Startup File"/>
@@ -131,7 +131,23 @@
               </component>
               <component id="d2c62" class="javax.swing.JTextField" binding="textStartupFile">
                 <constraints>
-                  <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
+              <component id="6fb3a" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Docker File"/>
+                </properties>
+              </component>
+              <component id="a54b7" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/WebAppOnLinuxDeployModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/WebAppOnLinuxDeployModel.java
@@ -39,6 +39,7 @@ public class WebAppOnLinuxDeployModel {
     private String appServicePlanName;
     private String targetPath;
     private String targetName;
+    private String dockerFilePath;
 
 
     public WebAppOnLinuxDeployModel() {
@@ -163,5 +164,13 @@ public class WebAppOnLinuxDeployModel {
     
     public String getTargetName() {
         return this.targetName;
+    }
+
+    public String getDockerFilePath() {
+        return dockerFilePath;
+    }
+
+    public void setDockerFilePath(String dockerFilePath) {
+        this.dockerFilePath = dockerFilePath;
     }
 }


### PR DESCRIPTION
This PR allows user to select a docker file when he wants to run on web app (linux). So no need to run Add Docker Support first.

UI:
It will load the default docker file under the project base path. (If the user has already clicked the Add Docker Support before).
![image](https://user-images.githubusercontent.com/6193897/30267620-b95d20e2-9715-11e7-93d0-cbd86b86939c.png)

If the docker file is not specified or the file is not existed, a error message will show at the bottom of the RunDialog.
![image](https://user-images.githubusercontent.com/6193897/30267646-cbd57896-9715-11e7-9edd-7eacdbf8154e.png)
![image](https://user-images.githubusercontent.com/6193897/30267760-28094a2a-9716-11e7-8415-12937a764be4.png)
