### PR TITLE
show menu items even if there is no dockerfile in the project base path

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/PushImageAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/PushImageAction.java
@@ -60,18 +60,6 @@ public class PushImageAction extends AzureAnAction {
         ApplicationManager.getApplication().invokeLater(() -> runConfiguration(project));
     }
 
-    @Override
-    public void update(AnActionEvent event) {
-        Project project = DataKeys.PROJECT.getData(event.getDataContext());
-        boolean dockerFileExists = false;
-        if (project != null) {
-            String basePath = project.getBasePath();
-            dockerFileExists = basePath != null && Paths.get(basePath, Constant.DOCKERFILE_FOLDER,
-                    Constant.DOCKERFILE_NAME).toFile().exists();
-        }
-        event.getPresentation().setEnabledAndVisible(dockerFileExists);
-    }
-
     @SuppressWarnings({"deprecation", "Duplicates"})
     private void runConfiguration(Project project) {
         final RunManagerEx manager = RunManagerEx.getInstanceEx(project);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/RunOnDockerHostAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/RunOnDockerHostAction.java
@@ -62,18 +62,6 @@ public class RunOnDockerHostAction extends AzureAnAction {
         ApplicationManager.getApplication().invokeLater(() -> runConfiguration(project));
     }
 
-    @Override
-    public void update(AnActionEvent event) {
-        Project project = DataKeys.PROJECT.getData(event.getDataContext());
-        boolean dockerFileExists = false;
-        if (project != null) {
-            String basePath = project.getBasePath();
-            dockerFileExists = basePath != null && Paths.get(basePath, Constant.DOCKERFILE_FOLDER,
-                    Constant.DOCKERFILE_NAME).toFile().exists();
-        }
-        event.getPresentation().setEnabledAndVisible(dockerFileExists);
-    }
-
     @SuppressWarnings({"deprecation", "Duplicates"})
     private void runConfiguration(Project project) {
         final RunManagerEx manager = RunManagerEx.getInstanceEx(project);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/WebAppOnLinuxAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/WebAppOnLinuxAction.java
@@ -69,18 +69,6 @@ public class WebAppOnLinuxAction extends AzureAnAction {
         }
     }
 
-    @Override
-    public void update(AnActionEvent event) {
-        Project project = DataKeys.PROJECT.getData(event.getDataContext());
-        boolean dockerFileExists = false;
-        if (project != null) {
-            String basePath = project.getBasePath();
-            dockerFileExists = basePath != null && Paths.get(basePath, Constant.DOCKERFILE_FOLDER,
-                    Constant.DOCKERFILE_NAME).toFile().exists();
-        }
-        event.getPresentation().setEnabledAndVisible(dockerFileExists);
-    }
-
     @SuppressWarnings({"deprecation", "Duplicates"})
     private void runConfiguration(Project project) {
         final RunManagerEx manager = RunManagerEx.getInstanceEx(project);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/dockerhost/ui/SettingPanel.form
@@ -16,6 +16,22 @@
         <properties/>
         <border type="none"/>
         <children>
+          <component id="130ed" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Docker File"/>
+            </properties>
+          </component>
+          <component id="c0075" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
           <component id="7558b" class="javax.swing.JLabel">
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -104,22 +120,6 @@
               </component>
             </children>
           </grid>
-          <component id="130ed" class="javax.swing.JLabel">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Docker File"/>
-            </properties>
-          </component>
-          <component id="c0075" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">
-            <constraints>
-              <grid row="0" column="2" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="150" height="-1"/>
-              </grid>
-            </constraints>
-            <properties/>
-          </component>
         </children>
       </grid>
       <grid id="b7c46" binding="pnlArtifact" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/ui/SettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/ui/SettingPanel.form
@@ -23,6 +23,22 @@
             </properties>
             <border type="none" title-justification="1"/>
             <children>
+              <component id="7d545" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Docker File"/>
+                </properties>
+              </component>
+              <component id="b3aa7" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
               <component id="f038c" class="javax.swing.JLabel">
                 <constraints>
                   <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -88,22 +104,6 @@
                 <properties>
                   <text value=""/>
                 </properties>
-              </component>
-              <component id="7d545" class="javax.swing.JLabel">
-                <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <text value="Docker File"/>
-                </properties>
-              </component>
-              <component id="b3aa7" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">
-                <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                    <preferred-size width="150" height="-1"/>
-                  </grid>
-                </constraints>
-                <properties/>
               </component>
             </children>
           </grid>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/utils/DockerUtil.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/utils/DockerUtil.java
@@ -107,16 +107,6 @@ public class DockerUtil {
     }
 
     /**
-     * buildImage.
-     */
-    public static String buildImage(DockerClient docker, String imageNameWithTag, Path dockerDirectory, ProgressHandler
-            progressHandler)
-            throws DockerException, InterruptedException, IOException {
-        String imageId = docker.build(dockerDirectory, imageNameWithTag, progressHandler);
-        return imageId == null ? null : imageNameWithTag;
-    }
-
-    /**
      * build image.
      */
     public static String buildImage(DockerClient docker, String imageNameWithTag, Path dockerDirectory,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/ui/SettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/ui/SettingPanel.form
@@ -55,6 +55,22 @@
             </properties>
             <border type="none" title-justification="1"/>
             <children>
+              <component id="6fb3a" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Docker File"/>
+                </properties>
+              </component>
+              <component id="a54b7" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
               <component id="f038c" class="javax.swing.JLabel">
                 <constraints>
                   <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -132,22 +148,6 @@
               <component id="d2c62" class="javax.swing.JTextField" binding="textStartupFile">
                 <constraints>
                   <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                    <preferred-size width="150" height="-1"/>
-                  </grid>
-                </constraints>
-                <properties/>
-              </component>
-              <component id="6fb3a" class="javax.swing.JLabel">
-                <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <text value="Docker File"/>
-                </properties>
-              </component>
-              <component id="a54b7" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathTextField">
-                <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>


### PR DESCRIPTION
This PR has two major changes:
1. Adjust the Dockerfile selector component position in *.form file to make it be focused by default.
2. Remove checking the existance of Dockerfile and enbale the menu items.

**UI changes:**
- Menu items shows even if there is no Dockerfile under the project base path.
![1](https://user-images.githubusercontent.com/6193897/30305540-031a5bec-97a6-11e7-98cb-a7c7f2937197.png)

- Screenshots of clicking each of the menu item.
1. Docker Run:
![2](https://user-images.githubusercontent.com/6193897/30305542-031b275c-97a6-11e7-867d-0875b9c72c1b.png)

2. Push Image:
![3](https://user-images.githubusercontent.com/6193897/30305539-0319d76c-97a6-11e7-819c-a1d2dc258f5f.png)

3. Run on Web App (Linux)
![4](https://user-images.githubusercontent.com/6193897/30305541-031aefa8-97a6-11e7-8c12-6d1ff01aab82.png)
