### PR TITLE
Add cache to container model

### DIFF
--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/container/ContainerRegistryModulePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/container/ContainerRegistryModulePresenter.java
@@ -22,7 +22,6 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.container;
 
-import com.microsoft.azure.management.containerregistry.Registries;
 import com.microsoft.azure.management.containerregistry.Registry;
 import com.microsoft.azuretools.core.mvp.model.container.ContainerRegistryMvpModel;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
@@ -30,6 +29,7 @@ import com.microsoft.azuretools.core.mvp.ui.base.NodeContent;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ContainerRegistryModulePresenter<V extends ContainerRegistryModule> extends MvpPresenter<V> {
@@ -42,10 +42,10 @@ public class ContainerRegistryModulePresenter<V extends ContainerRegistryModule>
     public void onModuleRefresh() {
         HashMap<String, ArrayList<NodeContent>> nodeMap = new HashMap<>();
         try {
-            Map<String, Registries> registriesMap = containerRegistryMvpModel.getContainerRegistries();
+            Map<String, List<Registry>> registriesMap = containerRegistryMvpModel.getContainerRegistryMap(true /*force*/);
             for (String sid : registriesMap.keySet()) {
                 ArrayList<NodeContent> nodeContentList = new ArrayList<>();
-                for (Registry registry : registriesMap.get(sid).list()) {
+                for (Registry registry : registriesMap.get(sid)) {
                     nodeContentList
                             .add(new NodeContent(registry.id(), registry.name(), "" /*provisionState*/));
                 }

--- a/Utils/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/container/ContainerRegistryMvpModelTest.java
+++ b/Utils/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/container/ContainerRegistryMvpModelTest.java
@@ -122,32 +122,7 @@ public class ContainerRegistryMvpModelTest {
     }
 
     @Test
-    public void getContainerRegistries() throws Exception {
-        List<Subscription> subscriptions = new ArrayList<Subscription>();
-        Registries registries1 = mock(Registries.class);
-        Registries registries2 = mock(Registries.class);
-        Azure azure1 = mock(Azure.class); when(azure1.containerRegistries()).thenReturn(registries1);
-        Azure azure2 = mock(Azure.class); when(azure2.containerRegistries()).thenReturn(registries2);
-        Subscription sub1 = mock(Subscription.class); when(sub1.subscriptionId()).thenReturn("1");
-        Subscription sub2 = mock(Subscription.class); when(sub2.subscriptionId()).thenReturn("2");
-        when(authMethodManagerMock.getAzureClient("1")).thenReturn(azure1);
-        when(authMethodManagerMock.getAzureClient("2")).thenReturn(azure2);
-        when(mvpModel.getSelectedSubscriptions()).thenReturn(subscriptions);
-
-        Map<String, Registries> emptyRegistriesMap = containerRegistryMvpModel.getContainerRegistries();
-        assertEquals(0, emptyRegistriesMap.size());
-
-        subscriptions.add(sub1);
-        subscriptions.add(sub2);
-        subscriptions.add(subscriptionWithoutRegistries);
-        Map<String, Registries> registriesMap = containerRegistryMvpModel.getContainerRegistries();
-        assertEquals(2, registriesMap.size());
-        assertEquals(registries1, registriesMap.get(sub1.subscriptionId()));
-        assertEquals(registries2, registriesMap.get(sub2.subscriptionId()));
-    }
-
-    @Test
-    public void getContainerRegistry() throws Exception {
+    public void testGetContainerRegistry() throws Exception {
         Registry registry = containerRegistryMvpModel.getContainerRegistry(MOCK_SUBSCRIPTION_ID, MOCK_REGISTRY_ID);
         assertEquals(registryMock, registry);
 
@@ -157,7 +132,7 @@ public class ContainerRegistryMvpModelTest {
     }
 
     @Test
-    public void setAdminUserEnabled() throws Exception {
+    public void testSetAdminUserEnabled() throws Exception {
         Registry.Update update = mock(Registry.Update.class);
         Registry.Update with = mock(Registry.Update.class);
         Registry.Update without = mock(Registry.Update.class);


### PR DESCRIPTION
Add a ConcurrentHashMap as a cache in ContainerRegistryMvpModel. No UI change is introduced.

Remaining work is to add Unit test for the new added method

```Java
public Map<String, List<Registry>> getContainerRegistryMap(boolean force) throws IOException
```