### PR TITLE
Init container explorer model

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/container/PushToContainerRegistryAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/container/PushToContainerRegistryAction.java
@@ -108,7 +108,7 @@ public class PushToContainerRegistryAction extends NodeActionListener {
     }
 
     // TODO: Should move to presenter. Load info dynamically after opening the dialog first.
-    private PrivateRegistryImageSetting querySettings(String subscriptionId, String resourceId) throws IOException {
+    private PrivateRegistryImageSetting querySettings(String subscriptionId, String resourceId) throws Exception {
         Registry registry = ContainerRegistryMvpModel.getInstance().getContainerRegistry(subscriptionId, resourceId);
         String serverUrl = null;
         String username = null;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerExplorerMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerExplorerMvpModel.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.azuretools.core.mvp.model.container;
 
 import com.google.gson.Gson;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerExplorerMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerExplorerMvpModel.java
@@ -22,11 +22,8 @@
 
 package com.microsoft.azuretools.core.mvp.model.container;
 
-import com.google.gson.Gson;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
-import com.microsoft.azuretools.azurecommons.util.Utils;
-import com.microsoft.azuretools.core.mvp.model.container.pojo.Repository;
-import com.microsoft.azuretools.core.mvp.model.container.pojo.Tag;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
@@ -34,17 +31,14 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class ContainerExplorerMvpModel {
 
     private static final OkHttpClient sharedClient = new OkHttpClient();
     private static final String URL_PREFIX = "https://";
     private static final String REPOSITORY_PATH = "/v2/_catalog";
     private static final String TAG_PATH = "/v2/%s/tags/list";
-    private static final String HEADER_LINK = "link";
     private static final String HEADER_AUTH = "Authorization";
+    private static final String INVALID_URL = "Invalid URL: ";
 
     private ContainerExplorerMvpModel() {
     }
@@ -60,71 +54,42 @@ public class ContainerExplorerMvpModel {
     /**
      * list repositories under the given private registry.
      */
-    public List<String> listRepositories(@NotNull String serverUrl, @NotNull String username,
-                                         @NotNull String password) throws Exception {
-        List<String> ret = new ArrayList<>();
+    public String listRepositories(@NotNull String serverUrl, @NotNull String username, @NotNull String password,
+                                   @Nullable String queryString) throws Exception {
         OkHttpClient client = createRestClient(username, password);
         final String host = URL_PREFIX + serverUrl;
-        String path = REPOSITORY_PATH;
-        boolean executeNextHttpCall = true;
-        while (executeNextHttpCall) {
-            HttpUrl route = HttpUrl.parse(host + path);
-            Request request = new Request.Builder().url(route).get().build();
-            try (Response response = client.newCall(request).execute()) {
-                if (response.isSuccessful()) {
-                    Gson gson = new Gson();
-                    Repository repo = gson.fromJson(response.body().string(), Repository.class);
-                    ret.addAll(repo.getRepositories());
-                    // TODO: add page division
-                    String linkHeader = response.header(HEADER_LINK);
-                    if (!Utils.isEmptyString(linkHeader)) {
-                        path = linkHeader.substring(linkHeader.indexOf("<") + 1, linkHeader.lastIndexOf(">"));
-                        executeNextHttpCall = true;
-                    } else {
-                        executeNextHttpCall = false;
-                    }
-                } else {
-                    throw new Exception(response.message());
-                }
-            }
-        }
-        return ret;
+        String path = REPOSITORY_PATH + (queryString == null ? "" : queryString);
+        return getResponse(client, host + path);
     }
 
     /**
      * list repositories under the given repository.
      */
-    public List<String> listTags(@NotNull String serverUrl, @NotNull String username, @NotNull String password,
-                                 @NotNull String repo) throws Exception {
-        List<String> ret = new ArrayList<>();
+    public String listTags(@NotNull String serverUrl, @NotNull String username, @NotNull String password,
+                                 @NotNull String repo, @Nullable String queryString) throws Exception {
         OkHttpClient client = createRestClient(username, password);
         final String host = URL_PREFIX + serverUrl;
-        String path = String.format(TAG_PATH, repo);
-        boolean executeNextHttpCall = true;
-        while (executeNextHttpCall) {
-            HttpUrl route = HttpUrl.parse(host + path);
-            Request request = new Request.Builder().url(route).get().build();
-            try (Response response = client.newCall(request).execute()) {
-                if (response.isSuccessful()) {
-                    Gson gson = new Gson();
-                    Tag tag = gson.fromJson(response.body().string(), Tag.class);
-                    ret.addAll(tag.getTags());
-                    // TODO: add page division
-                    String linkHeader = response.header(HEADER_LINK);
-                    if (!Utils.isEmptyString(linkHeader)) {
-                        path = linkHeader.substring(linkHeader.indexOf("<") + 1, linkHeader.lastIndexOf(">"));
-                        executeNextHttpCall = true;
-                    } else {
-                        executeNextHttpCall = false;
-                    }
-                } else {
-                    throw new Exception(response.message());
-                }
-            }
-        }
-        return ret;
+        String path = String.format(TAG_PATH, repo) + (queryString == null ? "" : queryString);
+        return getResponse(client, host + path);
     }
 
+    @NotNull
+    private String getResponse(@NotNull OkHttpClient client, @NotNull String url) throws Exception {
+        HttpUrl route = HttpUrl.parse(url);
+        if (route == null) {
+            throw new Exception(INVALID_URL + url);
+        }
+        Request request = new Request.Builder().url(route).get().build();
+        try (Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful()) {
+                return response.body().string();
+            } else {
+                throw new Exception(response.message());
+            }
+        }
+    }
+
+    @NotNull
     private OkHttpClient createRestClient(@NotNull String username, @NotNull String password) {
         return sharedClient.newBuilder()
                 .authenticator((route, response) -> {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerExplorerMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerExplorerMvpModel.java
@@ -31,14 +31,17 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
+import java.util.Map;
+
 public class ContainerExplorerMvpModel {
 
-    private static final OkHttpClient sharedClient = new OkHttpClient();
-    private static final String URL_PREFIX = "https://";
-    private static final String REPOSITORY_PATH = "/v2/_catalog";
-    private static final String TAG_PATH = "/v2/%s/tags/list";
+    private static final String URL_PREFIX = "https";
+    private static final String REPOSITORY_PATH = "v2/_catalog";
+    private static final String TAG_PATH = "v2/%s/tags/list";
     private static final String HEADER_AUTH = "Authorization";
-    private static final String INVALID_URL = "Invalid URL: ";
+    private static final String INVALID_URL = "The request URL is NULL.";
+
+    private final OkHttpClient sharedClient = new OkHttpClient();
 
     private ContainerExplorerMvpModel() {
     }
@@ -55,31 +58,44 @@ public class ContainerExplorerMvpModel {
      * list repositories under the given private registry.
      */
     public String listRepositories(@NotNull String serverUrl, @NotNull String username, @NotNull String password,
-                                   @Nullable String queryString) throws Exception {
+                                   @Nullable Map<String, String> query) throws Exception {
         OkHttpClient client = createRestClient(username, password);
-        final String host = URL_PREFIX + serverUrl;
-        String path = REPOSITORY_PATH + (queryString == null ? "" : queryString);
-        return getResponse(client, host + path);
+        HttpUrl.Builder urlBuilder = new HttpUrl.Builder()
+                .scheme(URL_PREFIX)
+                .host(serverUrl)
+                .addPathSegment(REPOSITORY_PATH);
+        if (query != null) {
+            for (String key : query.keySet()) {
+                urlBuilder.addQueryParameter(key, query.get(key));
+            }
+        }
+        return getResponse(client, urlBuilder.build());
     }
 
     /**
      * list repositories under the given repository.
      */
     public String listTags(@NotNull String serverUrl, @NotNull String username, @NotNull String password,
-                                 @NotNull String repo, @Nullable String queryString) throws Exception {
+                                 @NotNull String repo, @Nullable Map<String, String> query) throws Exception {
         OkHttpClient client = createRestClient(username, password);
-        final String host = URL_PREFIX + serverUrl;
-        String path = String.format(TAG_PATH, repo) + (queryString == null ? "" : queryString);
-        return getResponse(client, host + path);
+        HttpUrl.Builder urlBuilder = new HttpUrl.Builder()
+                .scheme(URL_PREFIX)
+                .host(serverUrl)
+                .addPathSegment(String.format(TAG_PATH, repo));
+        if (query != null) {
+            for (String key : query.keySet()) {
+                urlBuilder.addQueryParameter(key, query.get(key));
+            }
+        }
+        return getResponse(client, urlBuilder.build());
     }
 
     @NotNull
-    private String getResponse(@NotNull OkHttpClient client, @NotNull String url) throws Exception {
-        HttpUrl route = HttpUrl.parse(url);
-        if (route == null) {
-            throw new Exception(INVALID_URL + url);
+    private String getResponse(@NotNull OkHttpClient client, HttpUrl url) throws Exception {
+        if (url == null) {
+            throw new NullPointerException(INVALID_URL);
         }
-        Request request = new Request.Builder().url(route).get().build();
+        Request request = new Request.Builder().url(url).get().build();
         try (Response response = client.newCall(request).execute()) {
             if (response.isSuccessful()) {
                 return response.body().string();

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerExplorerMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerExplorerMvpModel.java
@@ -31,6 +31,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class ContainerExplorerMvpModel {
@@ -40,6 +41,8 @@ public class ContainerExplorerMvpModel {
     private static final String TAG_PATH = "v2/%s/tags/list";
     private static final String HEADER_AUTH = "Authorization";
     private static final String INVALID_URL = "The request URL is NULL.";
+    private static final String BODY = "body";
+    private static final String LINK_HEADER = "link";
 
     private final OkHttpClient sharedClient = new OkHttpClient();
 
@@ -57,7 +60,7 @@ public class ContainerExplorerMvpModel {
     /**
      * list repositories under the given private registry.
      */
-    public String listRepositories(@NotNull String serverUrl, @NotNull String username, @NotNull String password,
+    public Map<String, String> listRepositories(@NotNull String serverUrl, @NotNull String username, @NotNull String password,
                                    @Nullable Map<String, String> query) throws Exception {
         OkHttpClient client = createRestClient(username, password);
         HttpUrl.Builder urlBuilder = new HttpUrl.Builder()
@@ -73,9 +76,9 @@ public class ContainerExplorerMvpModel {
     }
 
     /**
-     * list repositories under the given repository.
+     * list tags under the given repository.
      */
-    public String listTags(@NotNull String serverUrl, @NotNull String username, @NotNull String password,
+    public Map<String, String> listTags(@NotNull String serverUrl, @NotNull String username, @NotNull String password,
                                  @NotNull String repo, @Nullable Map<String, String> query) throws Exception {
         OkHttpClient client = createRestClient(username, password);
         HttpUrl.Builder urlBuilder = new HttpUrl.Builder()
@@ -91,14 +94,17 @@ public class ContainerExplorerMvpModel {
     }
 
     @NotNull
-    private String getResponse(@NotNull OkHttpClient client, HttpUrl url) throws Exception {
+    private Map<String, String> getResponse(@NotNull OkHttpClient client, HttpUrl url) throws Exception {
         if (url == null) {
             throw new NullPointerException(INVALID_URL);
         }
         Request request = new Request.Builder().url(url).get().build();
         try (Response response = client.newCall(request).execute()) {
             if (response.isSuccessful()) {
-                return response.body().string();
+                Map<String, String> responseMap = new HashMap<>();
+                responseMap.put(BODY, response.body().string());
+                responseMap.put(LINK_HEADER, response.header(LINK_HEADER));
+                return responseMap;
             } else {
                 throw new Exception(response.message());
             }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerExplorerMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerExplorerMvpModel.java
@@ -1,0 +1,114 @@
+package com.microsoft.azuretools.core.mvp.model.container;
+
+import com.google.gson.Gson;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.util.Utils;
+import com.microsoft.azuretools.core.mvp.model.container.pojo.Repository;
+import com.microsoft.azuretools.core.mvp.model.container.pojo.Tag;
+
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ContainerExplorerMvpModel {
+
+    private static final OkHttpClient sharedClient = new OkHttpClient();
+    private static final String URL_PREFIX = "https://";
+    private static final String REPOSITORY_PATH = "/v2/_catalog";
+    private static final String TAG_PATH = "/v2/%s/tags/list";
+    private static final String HEADER_LINK = "link";
+    private static final String HEADER_AUTH = "Authorization";
+
+    private ContainerExplorerMvpModel() {
+    }
+
+    private static final class ContainerExplorerMvpModelHolder {
+        private static final ContainerExplorerMvpModel INSTANCE = new ContainerExplorerMvpModel();
+    }
+
+    public static ContainerExplorerMvpModel getInstance() {
+        return ContainerExplorerMvpModelHolder.INSTANCE;
+    }
+
+    /**
+     * list repositories under the given private registry.
+     */
+    public List<String> listRepositories(@NotNull String serverUrl, @NotNull String username,
+                                         @NotNull String password) throws Exception {
+        List<String> ret = new ArrayList<>();
+        OkHttpClient client = createRestClient(username, password);
+        final String host = URL_PREFIX + serverUrl;
+        String path = REPOSITORY_PATH;
+        boolean executeNextHttpCall = true;
+        while (executeNextHttpCall) {
+            HttpUrl route = HttpUrl.parse(host + path);
+            Request request = new Request.Builder().url(route).get().build();
+            try (Response response = client.newCall(request).execute()) {
+                if (response.isSuccessful()) {
+                    Gson gson = new Gson();
+                    Repository repo = gson.fromJson(response.body().string(), Repository.class);
+                    ret.addAll(repo.getRepositories());
+                    // TODO: add page division
+                    String linkHeader = response.header(HEADER_LINK);
+                    if (!Utils.isEmptyString(linkHeader)) {
+                        path = linkHeader.substring(linkHeader.indexOf("<") + 1, linkHeader.lastIndexOf(">"));
+                        executeNextHttpCall = true;
+                    } else {
+                        executeNextHttpCall = false;
+                    }
+                } else {
+                    throw new Exception(response.message());
+                }
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * list repositories under the given repository.
+     */
+    public List<String> listTags(@NotNull String serverUrl, @NotNull String username, @NotNull String password,
+                                 @NotNull String repo) throws Exception {
+        List<String> ret = new ArrayList<>();
+        OkHttpClient client = createRestClient(username, password);
+        final String host = URL_PREFIX + serverUrl;
+        String path = String.format(TAG_PATH, repo);
+        boolean executeNextHttpCall = true;
+        while (executeNextHttpCall) {
+            HttpUrl route = HttpUrl.parse(host + path);
+            Request request = new Request.Builder().url(route).get().build();
+            try (Response response = client.newCall(request).execute()) {
+                if (response.isSuccessful()) {
+                    Gson gson = new Gson();
+                    Tag tag = gson.fromJson(response.body().string(), Tag.class);
+                    ret.addAll(tag.getTags());
+                    // TODO: add page division
+                    String linkHeader = response.header(HEADER_LINK);
+                    if (!Utils.isEmptyString(linkHeader)) {
+                        path = linkHeader.substring(linkHeader.indexOf("<") + 1, linkHeader.lastIndexOf(">"));
+                        executeNextHttpCall = true;
+                    } else {
+                        executeNextHttpCall = false;
+                    }
+                } else {
+                    throw new Exception(response.message());
+                }
+            }
+        }
+        return ret;
+    }
+
+    private OkHttpClient createRestClient(@NotNull String username, @NotNull String password) {
+        return sharedClient.newBuilder()
+                .authenticator((route, response) -> {
+                    String credential = Credentials.basic(username, password);
+                    return response.request().newBuilder().header(HEADER_AUTH, credential).build();
+                })
+                .build();
+    }
+}

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerRegistryMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerRegistryMvpModel.java
@@ -27,6 +27,7 @@ import com.microsoft.azure.management.containerregistry.Registries;
 import com.microsoft.azure.management.containerregistry.Registry;
 import com.microsoft.azure.management.resources.Subscription;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.core.mvp.model.AzureMvpModel;
 
 import java.io.IOException;
@@ -35,6 +36,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ContainerRegistryMvpModel {
+
+    public static final String CANNOT_GET_REGISTRY = "Cannot get Registry with resource Id: ";
 
     private ContainerRegistryMvpModel() {}
 
@@ -70,13 +73,18 @@ public class ContainerRegistryMvpModel {
     /**
      * Get ACR by Id.
      */
-    public Registry getContainerRegistry(String sid, String id) throws IOException {
+    @NotNull
+    public Registry getContainerRegistry(String sid, String id) throws Exception {
         Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
         Registries registries = azure.containerRegistries();
         if (registries == null) {
-            return null;
+            throw new Exception(CANNOT_GET_REGISTRY + id);
         }
-        return registries.getById(id);
+        Registry registry = registries.getById(id);
+        if (registry == null) {
+            throw new Exception(CANNOT_GET_REGISTRY + id);
+        }
+        return registry;
     }
 
     /**

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/pojo/Catalog.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/pojo/Catalog.java
@@ -26,7 +26,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
 
-public class Repository {
+public class Catalog {
 
     @SerializedName("repositories")
     private ArrayList<String> repositories;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/pojo/Repository.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/pojo/Repository.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.azuretools.core.mvp.model.container.pojo;
 
 import com.google.gson.annotations.SerializedName;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/pojo/Repository.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/pojo/Repository.java
@@ -1,0 +1,19 @@
+package com.microsoft.azuretools.core.mvp.model.container.pojo;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+
+public class Repository {
+
+    @SerializedName("repositories")
+    private ArrayList<String> repositories;
+
+    public ArrayList<String> getRepositories() {
+        return repositories;
+    }
+
+    public void setRepositories(ArrayList<String> repositories) {
+        this.repositories = repositories;
+    }
+}

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/pojo/Tag.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/pojo/Tag.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.azuretools.core.mvp.model.container.pojo;
 
 import com.google.gson.annotations.SerializedName;
@@ -6,19 +28,8 @@ import java.util.ArrayList;
 
 public class Tag {
 
-    @SerializedName("name")
-    private String name;
-
     @SerializedName("tags")
     private ArrayList<String> tags;
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
 
     public ArrayList<String> getTags() {
         return tags;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/pojo/Tag.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/pojo/Tag.java
@@ -1,0 +1,30 @@
+package com.microsoft.azuretools.core.mvp.model.container.pojo;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+
+public class Tag {
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("tags")
+    private ArrayList<String> tags;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ArrayList<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(ArrayList<String> tags) {
+        this.tags = tags;
+    }
+}

--- a/Utils/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/container/ContainerRegistryMvpModelTest.java
+++ b/Utils/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/container/ContainerRegistryMvpModelTest.java
@@ -125,10 +125,11 @@ public class ContainerRegistryMvpModelTest {
     public void testGetContainerRegistry() throws Exception {
         Registry registry = containerRegistryMvpModel.getContainerRegistry(MOCK_SUBSCRIPTION_ID, MOCK_REGISTRY_ID);
         assertEquals(registryMock, registry);
+    }
 
-
-        Registry registryNull = containerRegistryMvpModel.getContainerRegistry(MOCK_SUBSCRIPTION_ID_WITHOUT_REGISTRIES, MOCK_REGISTRY_ID);
-        assertEquals(null, registryNull);
+    @Test(expected = Exception.class)
+    public void testGetNonExistContainerRegistry() throws Exception {
+        containerRegistryMvpModel.getContainerRegistry(MOCK_SUBSCRIPTION_ID_WITHOUT_REGISTRIES, MOCK_REGISTRY_ID);
     }
 
     @Test


### PR DESCRIPTION
This PR add the model for Container Explorer.

The OkHttpClient is used to send the HTTP requests. And the usage of RESTful API is referenced to [Azure CLI's implementation](https://github.com/Azure/azure-cli/blob/096dbb966c4bb7bf8a0674fc44387b6543ee35be/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/repository.py#L191)