### PR TITLE
Add Pull Image Action in Container explorer

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/containerregistry/ContainerRegistryPropertyView.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/containerregistry/ContainerRegistryPropertyView.form
@@ -288,10 +288,10 @@
                   </grid>
                 </children>
               </grid>
-              <grid id="96a62" binding="pnlExplorer" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="96a62" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/containerregistry/ContainerRegistryPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/containerregistry/ContainerRegistryPropertyView.java
@@ -84,7 +84,7 @@ public class ContainerRegistryPropertyView extends BaseEditor implements Contain
     private static final String PULL_IMAGE = "Pull Image";
     private static final String CANNOT_GET_REGISTRY_CREDENTIALS = "Cannot get Registry Credentials";
     private static final String DISPLAY_ID = "Azure Plugin";
-    private static final String IMAGE_PULL_SUCCESS = "Image: %s is successfully pulled.";
+    private static final String IMAGE_PULL_SUCCESS = "%s is successfully pulled.";
 
     private boolean isAdminEnabled;
     private String registryId = "";
@@ -321,7 +321,7 @@ public class ContainerRegistryPropertyView extends BaseEditor implements Contain
 
     @Override
     public void dispose() {
-        containerPropertyPresenter.onAttachView(this);
+        containerPropertyPresenter.onDetachView();
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/utils/DockerUtil.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/utils/DockerUtil.java
@@ -133,6 +133,22 @@ public class DockerUtil {
     }
 
     /**
+     * Pull image from a private registry.
+     */
+    public static void pullImage(DockerClient dockerClient, String registryUrl, String registryUsername,
+                                 String registryPassword, String targetImageName)
+            throws DockerException, InterruptedException {
+        final RegistryAuth registryAuth = RegistryAuth.builder().username(registryUsername).password(registryPassword)
+                .build();
+        if (targetImageName.startsWith(registryUrl)) {
+            dockerClient.pull(targetImageName, registryAuth);
+        } else {
+            throw new DockerException("serverUrl and imageName mismatch.");
+        }
+
+    }
+
+    /**
      * Stop a container by id.
      */
     public static void stopContainer(DockerClient dockerClient, String runningContainerId) throws DockerException,

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/container/ContainerRegistryNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/container/ContainerRegistryNode.java
@@ -43,7 +43,7 @@ public class ContainerRegistryNode extends Node implements TelemetryProperties {
     private final String resourceId;
 
     // action name
-    private static final String SHOW_PROPERTY_ACTION = "Show properties";
+    private static final String OPEN_EXPLORER_ACTION = "Open ACR Explorer";
     private static final String OPEN_IN_BROWSER_ACTION = "Open in browser";
 
     // string formatter
@@ -62,7 +62,7 @@ public class ContainerRegistryNode extends Node implements TelemetryProperties {
 
     @Override
     protected void loadActions() {
-        addAction(SHOW_PROPERTY_ACTION, null, new ShowContainerRegistryPropertyAction());
+        addAction(OPEN_EXPLORER_ACTION, null, new ShowContainerRegistryPropertyAction());
         addAction(OPEN_IN_BROWSER_ACTION, null, new OpenInBrowserAction());
         super.loadActions();
     }


### PR DESCRIPTION
This PR Add pull image support in the ACR Explorer

Currently the pull image action is based on IntelliJ's native background task.

UI:

1. Change the menu item ‘Show property’ changed to ‘Open ACR Explorer’
![image](https://user-images.githubusercontent.com/6193897/30572718-fd363e04-9d21-11e7-8d72-63f5e7c15782.png)
2. Popup menu
![image](https://user-images.githubusercontent.com/6193897/30572768-498696b4-9d22-11e7-94a9-946bf1d8358c.png)
3. Action success
![image](https://user-images.githubusercontent.com/6193897/30572775-5c3919d0-9d22-11e7-9c76-34a8c22204c4.png)
![image](https://user-images.githubusercontent.com/6193897/30572787-632a0592-9d22-11e7-822e-8ceff26209b2.png)
4. When Admin is disabled
![image](https://user-images.githubusercontent.com/6193897/30572808-7dc120c0-9d22-11e7-9fe7-0d3900400b36.png)
