### PR TITLE
Change the ACR property from view to editor

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/plugin.xml
@@ -33,12 +33,6 @@
              icon="icons/RedisCache.png"
              name="Redis Cache Property">
        </view>
-       <view
-             class="com.microsoft.azuretools.azureexplorer.views.ContainerRegistryPropertyView"
-             id="com.microsoft.azuretools.azureexplorer.views.ContainerRegistryPropertyView"
-             icon="icons/acr.png"
-             name="Container Registry Property">
-       </view>
    </extension>
    <extension
             point="org.eclipse.ui.editors">
@@ -70,7 +64,13 @@
              icon="icons/RedisCache.png"
              id="com.microsoft.azuretools.azureexplorer.editors.rediscache.RedisExplorerEditor"
              name="Redis Cache Explorer">
-       </editor>        
+       </editor>
+       <editor
+             class="com.microsoft.azuretools.azureexplorer.editors.container.ContainerRegistryExplorerEditor"
+             icon="icons/acr.png"
+             id="com.microsoft.azuretools.azureexplorer.editors.container.ContainerRegistryExplorerEditor"
+             name="ACR Explorer">
+       </editor>
     </extension>
 
 	<extension point="org.eclipse.ui.handlers">

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/editors/container/ContainerRegistryExplorerEditorInput.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/editors/container/ContainerRegistryExplorerEditorInput.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azuretools.azureexplorer.editors.container;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IPersistableElement;
+
+public class ContainerRegistryExplorerEditorInput implements IEditorInput{
+
+    private String id;
+    private String subscriptionId;
+    private String registryName;
+
+    public ContainerRegistryExplorerEditorInput(String sid, String id, String name) {
+        this.id = id;
+        this.subscriptionId = sid;
+        this.registryName = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof ContainerRegistryExplorerEditorInput) {
+            ContainerRegistryExplorerEditorInput input = (ContainerRegistryExplorerEditorInput) o;
+            return this.getId().equals(input.getId());
+        }
+        return false;
+
+    }
+
+    @Override
+    public <T> T getAdapter(Class<T> arg0) {
+        return null;
+    }
+
+    @Override
+    public boolean exists() {
+        return false;
+    }
+
+    @Override
+    public ImageDescriptor getImageDescriptor() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return this.registryName;
+    }
+
+    @Override
+    public IPersistableElement getPersistable() {
+        return null;
+    }
+
+    @Override
+    public String getToolTipText() {
+        return null;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/EditorType.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/EditorType.java
@@ -1,20 +1,20 @@
 /**
  * Copyright (c) Microsoft Corporation
- * 
- * All rights reserved. 
- * 
+ *
+ * All rights reserved.
+ *
  * MIT License
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files 
- * (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, 
- * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
- * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH 
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
  * THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
@@ -22,4 +22,5 @@ package com.microsoft.azuretools.azureexplorer.helpers;
 
 public enum EditorType {
     REDIS_EXPLORER,
+    CONTAINER_EXPLORER
 }

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/UIHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/UIHelperImpl.java
@@ -22,12 +22,14 @@ package com.microsoft.azuretools.azureexplorer.helpers;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.util.Utils;
 import com.microsoft.azuretools.azureexplorer.Activator;
 import com.microsoft.azuretools.azureexplorer.editors.StorageEditorInput;
+import com.microsoft.azuretools.azureexplorer.editors.container.ContainerRegistryExplorerEditor;
+import com.microsoft.azuretools.azureexplorer.editors.container.ContainerRegistryExplorerEditorInput;
 import com.microsoft.azuretools.azureexplorer.editors.rediscache.RedisExplorerEditor;
 import com.microsoft.azuretools.azureexplorer.editors.rediscache.RedisExplorerEditorInput;
 import com.microsoft.azuretools.azureexplorer.forms.OpenSSLFinderForm;
-import com.microsoft.azuretools.azureexplorer.views.ContainerRegistryPropertyView;
 import com.microsoft.azuretools.azureexplorer.views.RedisPropertyView;
 import com.microsoft.azuretools.core.utils.PluginUtil;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
@@ -67,7 +69,7 @@ public class UIHelperImpl implements UIHelper {
 
     private static final String UNABLE_TO_OPEN_BROWSER = "Unable to open external web browser";
     private static final String UNABLE_TO_GET_PROPERTY = "Error opening view page";
-    private static final String UNABLE_TO_OPEN_EXPLORER = "Unable to open the Redis Cache Explorer";
+    private static final String UNABLE_TO_OPEN_EXPLORER = "Unable to open explorer";
 
     @Override
     public void showException(final String message,
@@ -284,10 +286,13 @@ public class UIHelperImpl implements UIHelper {
     public void openContainerRegistryPropertyView(@NotNull ContainerRegistryNode node) {
         String sid = node.getSubscriptionId();
         String resId = node.getResourceId();
-        if (sid == null || resId == null) {
+        if (Utils.isEmptyString(sid) || Utils.isEmptyString(resId)) {
             return;
         }
-        openView(ContainerRegistryPropertyView.ID, sid, resId);
+        IWorkbench workbench = PlatformUI.getWorkbench();
+        ContainerRegistryExplorerEditorInput input = new ContainerRegistryExplorerEditorInput(sid, resId, node.getName());
+        IEditorDescriptor descriptor = workbench.getEditorRegistry().findEditor(ContainerRegistryExplorerEditor.ID);
+        openEditor(EditorType.CONTAINER_EXPLORER, input, descriptor);
     }
 
     @Override
@@ -319,6 +324,7 @@ public class UIHelperImpl implements UIHelper {
             }
             switch (type) {
                 case REDIS_EXPLORER:
+                case CONTAINER_EXPLORER:
                     page.openEditor(input, descriptor.getId());
                     break;
                 default:
@@ -344,11 +350,6 @@ public class UIHelperImpl implements UIHelper {
                     final RedisPropertyView redisPropertyView = (RedisPropertyView) page.showView(RedisPropertyView.ID,
                             resId, IWorkbenchPage.VIEW_ACTIVATE);
                     redisPropertyView.onReadProperty(sid, resId);
-                    break;
-                case ContainerRegistryPropertyView.ID:
-                    final ContainerRegistryPropertyView registryPropertyView = (ContainerRegistryPropertyView)
-                            page.showView(ContainerRegistryPropertyView.ID, resId, IWorkbenchPage.VIEW_ACTIVATE);
-                    registryPropertyView.onReadProperty(sid, resId);
                     break;
                 default:
                     break;


### PR DESCRIPTION
This PR change the ACR property from view to editor.

Now when the user click 'open ACR Explorer' in Eclipse, an editor window will be opened
![image](https://user-images.githubusercontent.com/6193897/30575503-c1404e32-9d33-11e7-83b1-60da38f86cdf.png)

