### PR TITLE
let the file chooser locate to project base path

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/common/ContainerSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/common/ContainerSettingPanel.java
@@ -24,6 +24,7 @@ package com.microsoft.intellij.runner.container.common;
 
 import com.intellij.openapi.fileChooser.FileChooser;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -61,10 +62,13 @@ public class ContainerSettingPanel implements ContainerSettingView {
     private static final String SELECT_REGISTRY = "<Select Container Registry>";
     private static final String LOADING = "<Loading...>";
 
+    private final Project project;
+
     /**
      * Constructor.
      */
-    public ContainerSettingPanel() {
+    public ContainerSettingPanel(Project project) {
+        this.project = project;
         presenter = new ContainerSettingPresenter<>();
         presenter.onAttachView(this);
 
@@ -79,7 +83,7 @@ public class ContainerSettingPanel implements ContainerSettingView {
                             false /*chooseJarContents*/,
                             false /*chooseMultiple*/
                     ),
-                    null,
+                    this.project,
                     Utils.isEmptyString(path) ? null : LocalFileSystem.getInstance().findFileByPath(path)
             );
             if (file != null) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/ui/SettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/ui/SettingPanel.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="543" height="317"/>
+      <xy x="20" y="20" width="543" height="389"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -45,11 +45,11 @@
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-	  <nested-form id="1e21a" form-file="com/microsoft/intellij/runner/container/common/ContainerSettingPanel.form" binding="containerSettingPanel">
-		<constraints>
+      <nested-form id="1e21a" form-file="com/microsoft/intellij/runner/container/common/ContainerSettingPanel.form" binding="containerSettingPanel" custom-create="true">
+        <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
-	  </nested-form>
+      </nested-form>
     </children>
   </grid>
 </form>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/ui/SettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/pushimage/ui/SettingPanel.java
@@ -69,7 +69,7 @@ public class SettingPanel {
 
     public SettingPanel(Project project) {
         this.project = project;
-
+        $$$setupUI$$$(); // tell IntelliJ to call createUIComponents() here.
         // Artifact to build
         isCbArtifactInited = false;
         cbArtifact.addActionListener(e -> {
@@ -208,4 +208,10 @@ public class SettingPanel {
     public void disposeEditor() {
         containerSettingPanel.disposeEditor();
     }
+
+    private void createUIComponents() {
+        containerSettingPanel = new ContainerSettingPanel(this.project);
+    }
+
+    private void $$$setupUI$$$(){}
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/ui/SettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/ui/SettingPanel.form
@@ -55,7 +55,7 @@
             </properties>
             <border type="none" title-justification="1"/>
             <children>
-              <nested-form id="b627d" form-file="com/microsoft/intellij/runner/container/common/ContainerSettingPanel.form" binding="containerSettingPanel">
+              <nested-form id="b627d" form-file="com/microsoft/intellij/runner/container/common/ContainerSettingPanel.form" binding="containerSettingPanel" custom-create="true">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/ui/SettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/ui/SettingPanel.java
@@ -144,9 +144,10 @@ public class SettingPanel implements WebAppOnLinuxDeployView {
      */
 
     public SettingPanel(Project project) {
+        this.project = project;
         webAppOnLinuxDeployPresenter = new WebAppOnLinuxDeployPresenter<>();
         webAppOnLinuxDeployPresenter.onAttachView(this);
-        this.project = project;
+        $$$setupUI$$$(); // tell IntelliJ to call createUIComponents() here.
 
         // set create/update panel visible
         updatePanelVisibility();
@@ -559,7 +560,7 @@ public class SettingPanel implements WebAppOnLinuxDeployView {
     }
 
     private void createUIComponents() {
-        System.out.println(" createUIComponents");
+        containerSettingPanel = new ContainerSettingPanel(project);
         // create table of Web App on Linux
         DefaultTableModel tableModel = new DefaultTableModel() {
             @Override
@@ -739,4 +740,6 @@ public class SettingPanel implements WebAppOnLinuxDeployView {
         // TODO: blocked by SDK, API cannot list Linux ASP now.
         webAppOnLinuxDeployPresenter.onLoadAppServicePlan(sid);
     }
+
+    private void $$$setupUI$$$(){}
 }


### PR DESCRIPTION
This PR let the file chooser locate to project base path.

a parameter is added to the constructor of ```ContainerSettingPanel```.

and in Push Image and Run on Web App (Linux), the ContainerSettingPanel will be initialized in ```createUIComponents()```, the ```$$$setupUI$$$()``` is a place holder method to tell the Intellij to call ```createUIComponents()``` at the right place.