### PR TITLE
Fix ui bug for ACR explorer on Mac

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/editors/container/ContainerRegistryExplorerEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/editors/container/ContainerRegistryExplorerEditor.java
@@ -185,9 +185,6 @@ public class ContainerRegistryExplorerEditor extends EditorPart implements Conta
         glPanelHolder.horizontalSpacing = 0;
         panelHolder.setLayout(glPanelHolder);
 
-        setScrolledCompositeContent();
-        setChildrenTransparent(panelHolder);
-
         progressBar = new ProgressBar(panelHolder, SWT.HORIZONTAL | SWT.INDETERMINATE);
         GridData gdProgressBar = new GridData(SWT.FILL, SWT.TOP, false, false, 1, 1);
         gdProgressBar.heightHint = PROGRESS_BAR_HEIGHT;
@@ -493,6 +490,10 @@ public class ContainerRegistryExplorerEditor extends EditorPart implements Conta
             }
         });
         disableWidgets(true, true);
+
+        setScrolledCompositeContent();
+        setChildrenTransparent(panelHolder);
+        setChildrenTransparent(container);
     }
 
     @Override


### PR DESCRIPTION
Set the components background transparent.

Before:
<img width="749" alt="screen shot 2017-10-09 at 10 37 25 am" src="https://user-images.githubusercontent.com/6193897/31323747-b95929d0-ac71-11e7-936f-2a7910362ca6.png">

After:
<img width="818" alt="screen shot 2017-10-09 at 10 36 07 am" src="https://user-images.githubusercontent.com/6193897/31323755-c00af24a-ac71-11e7-9eba-4ead1bc2079c.png">
