### PR TITLE
Fix app setting cannot remove bug

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
@@ -166,7 +166,7 @@ public class WebAppPropertyView extends BaseEditor implements WebAppPropertyMvpV
 
         btnSave.addActionListener(e -> {
             setBtnEnableStatus(false);
-            presenter.onUpdateWebAppProperty(sid, resId, editedAppSettings);
+            presenter.onUpdateWebAppProperty(sid, resId, cachedAppSettings, editedAppSettings);
         });
 
         lnkUrl.setHyperlinkText("<Loading...>");

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyViewPresenter.java
@@ -1,7 +1,9 @@
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.appservice.AppServicePlan;
@@ -51,9 +53,15 @@ public class WebAppPropertyViewPresenter<V extends WebAppPropertyMvpView> extend
     }
 
     public void onUpdateWebAppProperty(@NotNull String sid, @NotNull String resId,
-            @NotNull Map<String, String> appSettings) {
+            @NotNull Map<String, String> cacheSettings, @NotNull Map<String, String> editedSettings) {
         Observable.fromCallable(() -> {
-            AzureWebAppMvpModel.getInstance().updateWebAppSettings(sid, resId, appSettings);
+            Set<String> toRemove = new HashSet<>();
+            for (String key : cacheSettings.keySet()) {
+                if (!editedSettings.containsKey(key)) {
+                    toRemove.add(key);
+                }
+            }
+            AzureWebAppMvpModel.getInstance().updateWebAppSettings(sid, resId, editedSettings, toRemove);
             return true;
         }).subscribeOn(getSchedulerProvider().io())
                 .subscribe(property -> DefaultLoader.getIdeHelper().invokeLater(() -> {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -260,10 +261,16 @@ public class AzureWebAppMvpModel {
         return app;
     }
 
-    public void updateWebAppSettings(String sid, String webAppId, Map<String, String> appSettings) throws Exception {
+    public void updateWebAppSettings(String sid, String webAppId, Map<String, String> toUpdate, Set<String> toRemove)
+            throws Exception {
         WebApp app = getWebAppById(sid, webAppId);
         clearTags(app);
-        app.update().withAppSettings(appSettings).apply();
+        com.microsoft.azure.management.appservice.WebAppBase.Update<WebApp> update = app.update()
+                .withAppSettings(toUpdate);
+        for (String key : toRemove) {
+            update = update.withoutAppSetting(key);
+        }
+        update.apply();
     }
 
     public void deleteWebAppOnLinux(String sid, String appid) throws IOException {


### PR DESCRIPTION
Related Issue: #1192 

To Update App Settings, the Azure SDK has two API to use.

```.withAppSettings(Map<String, String>)```: update and insert settings
```.withoutAppSetting(String)```: remove settings

So I use ```editedAppSettings``` as the Map that need to update, and camparing with ```cachedAppSettings``` to figure out which keys are missing.