### PR TITLE
Fix Local Run Context not recognized in code issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobLocalRunConfigurationProducer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobLocalRunConfigurationProducer.java
@@ -84,7 +84,6 @@ public class SparkBatchJobLocalRunConfigurationProducer extends JavaRunConfigura
                             .orElse(false);
                 })
                 .map(mcPair -> {
-                    sourceElement.set(mcPair.getKey());
                     setupConfiguration(configuration, mcPair.getValue(), context);
 
                     return true;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobLocalRunConfigurationProducer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobLocalRunConfigurationProducer.java
@@ -75,12 +75,12 @@ public class SparkBatchJobLocalRunConfigurationProducer extends JavaRunConfigura
                     return Optional.ofNullable(db.getDependencies().get(mcPair.getKey().getContainingFile()))
                             .map((Set<PsiFile> t) -> t.stream()
                                     .map(PsiFile::getVirtualFile)
-                                    .map(VirtualFile::getName)
-                                    .anyMatch(className -> className.equals("SparkContext.class") ||
-                                            className.equals("JavaSparkContext.class") ||
-                                            className.equals("SparkConf.class") ||
-                                            className.equals("StreamingContext.class") ||
-                                            className.equals("SparkSession.class")))
+                                    .map(VirtualFile::getNameWithoutExtension)
+                                    .anyMatch(className -> className.equals("SparkContext") ||
+                                            className.equals("JavaSparkContext") ||
+                                            className.equals("SparkConf") ||
+                                            className.equals("StreamingContext") ||
+                                            className.equals("SparkSession")))
                             .orElse(false);
                 })
                 .map(mcPair -> {


### PR DESCRIPTION
Don't update the source PsiElement to avoid common application
run configuration getting higher priority.

Signed-off-by: Wei Zhang <wezhang@outlook.com>