### PR TITLE
Fix the Spark Job Run disconnect button issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobSubmissionEvent.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobSubmissionEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.hdinsight.spark.run;
+
+import com.microsoft.azure.hdinsight.spark.common.SparkBatchJob;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class SparkBatchJobSubmissionEvent {
+    enum Type {
+        SUBMITTED
+    }
+
+    @Nullable
+    private SparkBatchJob job;
+
+    @NotNull
+    private
+    SparkBatchJobSubmissionEvent.Type eventType;
+
+    public SparkBatchJobSubmissionEvent(@NotNull Type eventType, @Nullable SparkBatchJob job) {
+        this.eventType = eventType;
+        this.job = job;
+    }
+
+    @NotNull
+    public SparkBatchJobSubmissionEvent.Type getEventType() {
+        return eventType;
+    }
+
+    public Optional<SparkBatchJob> getJob() {
+        return Optional.ofNullable(job);
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobSubmissionState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobSubmissionState.java
@@ -131,6 +131,15 @@ public class SparkBatchJobSubmissionState implements RunProfileState, RemoteStat
                 SparkBatchJobDisconnectAction disconnectAction = new SparkBatchJobDisconnectAction(remoteProcess);
                 ExecutionResult result = new DefaultExecutionResult(jobOutputView, processHandler, Separator.getInstance(), disconnectAction);
 
+                remoteProcess.getEventSubject()
+                        .subscribe(event -> {
+                            switch (event.getEventType()) {
+                                case SUBMITTED:
+                                    disconnectAction.setEnabled(true);
+                                    break;
+                            }
+                        });
+
                 ctrlSubject.subscribe(
                         messageWithType -> {
                             switch (messageWithType.getKey()) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkBatchJobDisconnectAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkBatchJobDisconnectAction.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 public class SparkBatchJobDisconnectAction extends AnAction {
     @Nullable
     private SparkBatchJobRemoteProcess remoteProcess;
-    private boolean isEnabled = true;
+    private boolean isEnabled = false;
 
     public SparkBatchJobDisconnectAction() {
         super();

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/ClusterOperationImpl.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/ClusterOperationImpl.java
@@ -93,7 +93,7 @@ public class ClusterOperationImpl implements IClusterOperation {
                          String managementURI = AuthMethodManager.getInstance().getAzureManager().getManagementURI();
                          return AzureAADHelper.executeRequest(managementURI,
                                  String.format("%s/configurations?api-version=%s", clusterId.replaceAll("/+$", ""), VERSION),
-                                 null,
+                                 RestServiceManager.ContentType.Json,
                                  "GET",
                                  null,
                                  accessToken,


### PR DESCRIPTION
The button should be enabled after job is submitted.

Signed-off-by: Wei Zhang <wezhang@outlook.com>