### PR TITLE
Fix the HDInsightLoader uninitialized issue on Eclipse Mac/Linux

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/Activator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/Activator.java
@@ -62,7 +62,8 @@ public class Activator extends AbstractUIPlugin {
 		super.start(context);
 		plugin = this;
         DefaultLoader.setUiHelper(new UIHelperImpl());
-		HDInsightLoader.setHHDInsightHelper(new com.microsoft.azuretools.azureexplorer.helpers.HDInsightHelperImpl());
+        com.microsoft.azuretools.azureexplorer.helpers.HDInsightHelperImpl.initHDInsightLoader();
+
         Node.setNode2Actions(NodeActionsMap.node2Actions);
 //        ServiceExplorerView serviceExplorerView = (ServiceExplorerView) PlatformUI
 //                .getWorkbench().getActiveWorkbenchWindow()

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/HDInsightHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/HDInsightHelperImpl.java
@@ -32,6 +32,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
 import com.microsoft.azure.hdinsight.common.HDInsightHelper;
+import com.microsoft.azure.hdinsight.common.HDInsightLoader;
 import com.microsoft.azure.hdinsight.common.JobViewManager;
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
@@ -107,5 +108,11 @@ public class HDInsightHelperImpl implements HDInsightHelper {
     @Override
     public boolean isOptIn() {
         return isOptIn;
+    }
+
+    public static synchronized void initHDInsightLoader() {
+        if (HDInsightLoader.getHDInsightHelper() == null) {
+            HDInsightLoader.setHHDInsightHelper(new com.microsoft.azuretools.azureexplorer.helpers.HDInsightHelperImpl());
+        }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.hdinsight/src/com/microsoft/azuretools/hdinsight/Activator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.hdinsight/src/com/microsoft/azuretools/hdinsight/Activator.java
@@ -26,6 +26,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
 import com.microsoft.tooling.msservices.components.DefaultLoader;
+import com.microsoft.azure.hdinsight.common.HDInsightLoader;
 import com.microsoft.azuretools.azurecommons.helpers.StringHelper;
 import com.microsoft.azuretools.telemetry.AppInsightsClient;
 import com.microsoft.azuretools.hdinsight.util.HDInsightJobViewUtils;
@@ -55,6 +56,9 @@ public class Activator extends AbstractUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		plugin = this;
+
+        com.microsoft.azuretools.azureexplorer.helpers.HDInsightHelperImpl.initHDInsightLoader();
+
 		String enabledProperty = DefaultLoader.getIdeHelper().getProperty(Messages.HDInsightFeatureEnabled);
 		if(StringHelper.isNullOrWhiteSpace(enabledProperty)) {
 			AppInsightsClient.create(Messages.HDInsightFeatureEnabled, context.getBundle().getVersion().toString());


### PR DESCRIPTION
Sometime, the Azure Explorer is lazy initialized, which caused
HDInsightLoader not set.

Signed-off-by: Wei Zhang <wezhang@outlook.com>