### PR TITLE
mitigation for issue #1332

### DIFF
--- a/Utils/azuretools-core/src/com/microsoft/azuretools/adauth/HttpHelper.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/adauth/HttpHelper.java
@@ -84,10 +84,13 @@ class HttpHelper {
             log.log(Level.SEVERE, message);
 
             TokenResponse r = JsonHelper.deserialize(TokenResponse.class, err.toString());
-            if (r.error.equals("invalid_grant"))
+            if (r.error.equals(AuthError.InvalidGrant)) {
                 throw new AuthException(AuthError.InvalidGrant, message);
-            else
+            } else if (r.error.equals(AuthError.InteractionRequired)) {
+                throw new AuthException(AuthError.InteractionRequired, message);
+            } else {
                 throw new IOException(message);
+            }
         }
 
         verifyCorrelationIdInReponseHeader(connection, callState);
@@ -146,8 +149,8 @@ class HttpHelper {
             try {
                 UUID correlationId = UUID.fromString(correlationIdHeader);
                 if (!correlationId.equals(callState.correlationId)) {
-                    log.log(Level.WARNING, "Returned correlation id '" + correlationId + "' does not match the sent correlation id '"
-                            + callState.correlationId + "'");
+                    log.log(Level.WARNING, "Returned correlation id '" + correlationId
+                            + "' does not match the sent correlation id '" + callState.correlationId + "'");
                 }
             } catch (IllegalArgumentException ex) {
                 log.log(Level.WARNING, "Returned correlation id '" + correlationIdHeader + "' is not in GUID format.");

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AdAuthManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AdAuthManager.java
@@ -120,7 +120,7 @@ public class AdAuthManager {
             // put tokens into the cache
             try {
                 ac1.acquireToken(env.managementEndpoint(), false, userId, isDisplayable);
-            } catch (AuthError e) {
+            } catch (AuthException e) {
                 //TODO: should narrow to AuthError.InteractionRequired
                 ac1.acquireToken(env.managementEndpoint(), true, userId, isDisplayable);
             }

--- a/core.sh
+++ b/core.sh
@@ -1,1 +1,0 @@
-mvn clean install -f Utils/ -Dmaven.repo.local=.repository -DskipTests

--- a/core.sh
+++ b/core.sh
@@ -1,0 +1,1 @@
+mvn clean install -f Utils/ -Dmaven.repo.local=.repository -DskipTests


### PR DESCRIPTION
Unblock the users who cannot use `refresh_token` of `common` tenant to acquire other tenants' tokens.

Mitigation:
Pop up a dialog, allowing users to repeat the whole sign-in process on specific tenant.