### PR TITLE
Support IntelliJ 2018.1

### DIFF
--- a/BuildDevint
+++ b/BuildDevint
@@ -42,7 +42,7 @@ chmod +x ./tools/IntellijVersionHelper
 if [ $INTELLIJ_VERSION == "true" ] ; then
     ./tools/IntellijVersionHelper 2017.3
 fi
-./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Pintellij_version=IC-2017.3 -Pdep_plugins=org.intellij.scala:2017.3.9
+./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Pintellij_version=IC-2017.3 -Pdep_plugins=org.intellij.scala:2017.3.15
 cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2017.3.zip
 
 # Build intellij 2018.1 plugin

--- a/BuildDevint
+++ b/BuildDevint
@@ -38,20 +38,20 @@ cp ./PluginsAndFeatures/azure-toolkit-for-eclipse/WindowsAzurePlugin4EJ/target/W
 chmod +x ./gradlew
 chmod +x ./tools/IntellijVersionHelper
 
-# Build intellij 2017.2 plugin
-if [ $INTELLIJ_VERSION == "true" ] ; then
-    ./tools/IntellijVersionHelper 2017.2
-fi
-
-./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Pintellij_version=IC-2017.2 -Pdep_plugins=org.intellij.scala:2017.2.13
-
-cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2017.2.zip
-
 # Build intellij 2017.3 plugin
 if [ $INTELLIJ_VERSION == "true" ] ; then
     ./tools/IntellijVersionHelper 2017.3
 fi
-./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s
+./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Pintellij_version=IC-2017.3 -Pdep_plugins=org.intellij.scala:2017.3.9
 cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2017.3.zip
+
+# Build intellij 2018.1 plugin
+if [ $INTELLIJ_VERSION == "true" ] ; then
+    ./tools/IntellijVersionHelper 2018.1
+fi
+
+./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s 
+
+cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.1.zip
 
 echo "ALL BUILD SUCCESSFUL"

--- a/BuildProduct.sh
+++ b/BuildProduct.sh
@@ -71,27 +71,27 @@ cp ./PluginsAndFeatures/azure-toolkit-for-eclipse/WindowsAzurePlugin4EJ/target/W
 chmod +x ./gradlew
 chmod +x ./tools/IntellijVersionHelper
 
-# Build intellij 2017.2 plugin
-if [ $INTELLIJ_VERSION == "true" ] ; then
-    ./tools/IntellijVersionHelper 2017.2
-fi
-
-./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Papplicationinsights.key=${INTELLIJ_KEY} -Pintellij_version=IC-2017.2 -Pdep_plugins=org.intellij.scala:2017.2.13
-
-cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2017.2.zip
-
 # Build intellij 2017.3 plugin
 if [ $INTELLIJ_VERSION == "true" ] ; then
     ./tools/IntellijVersionHelper 2017.3
 fi
-./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Papplicationinsights.key=${INTELLIJ_KEY}
+
+./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Papplicationinsights.key=${INTELLIJ_KEY} -Pintellij_version=IC-2017.3 -Pdep_plugins=org.intellij.scala:2017.3.9
+
 cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2017.3.zip
+
+# Build intellij 2018.1 plugin
+if [ $INTELLIJ_VERSION == "true" ] ; then
+    ./tools/IntellijVersionHelper 2018.1
+fi
+./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Papplicationinsights.key=${INTELLIJ_KEY}
+cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.1.zip
 
 # Extract jars to sign
 # intelliJ
 rm -rf ${INTELLIJ_TOSIGN}/*
-unzip -p ./artifacts/azure-toolkit-for-intellij-2017.2.zip azure-toolkit-for-intellij/lib/azure-toolkit-for-intellij.jar > ${INTELLIJ_TOSIGN}/azure-toolkit-for-intellij_2017.2.jar
-unzip -p ./artifacts/azure-toolkit-for-intellij-2017.3.zip azure-toolkit-for-intellij/lib/azure-toolkit-for-intellij.jar > ${INTELLIJ_TOSIGN}/azure-toolkit-for-intellij_2017.3.jar
+unzip -p ./artifacts/azure-toolkit-for-intellij-2017.2.zip azure-toolkit-for-intellij/lib/azure-toolkit-for-intellij.jar > ${INTELLIJ_TOSIGN}/azure-toolkit-for-intellij_2017.3.jar
+unzip -p ./artifacts/azure-toolkit-for-intellij-2017.3.zip azure-toolkit-for-intellij/lib/azure-toolkit-for-intellij.jar > ${INTELLIJ_TOSIGN}/azure-toolkit-for-intellij_2018.1.jar
 
 # Eclipse
 rm -rf ${ECLIPSE_TOSIGN}/*

--- a/BuildProduct.sh
+++ b/BuildProduct.sh
@@ -76,7 +76,7 @@ if [ $INTELLIJ_VERSION == "true" ] ; then
     ./tools/IntellijVersionHelper 2017.3
 fi
 
-./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Papplicationinsights.key=${INTELLIJ_KEY} -Pintellij_version=IC-2017.3 -Pdep_plugins=org.intellij.scala:2017.3.9
+./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Papplicationinsights.key=${INTELLIJ_KEY} -Pintellij_version=IC-2017.3 -Pdep_plugins=org.intellij.scala:2017.3.15
 
 cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2017.3.zip
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -1,6 +1,6 @@
 javaVersion=1.8
 org.gradle.jvmargs='-Duser.language=en'
 sources=false
-intellij_version=IC-2017.3
-dep_plugins=org.intellij.scala:2017.3.9
+intellij_version=IC-2018.1
+dep_plugins=org.intellij.scala:2018.1.8
 applicationinsights.key=57cc111a-36a8-44b3-b044-25d293b8b77c

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -96,7 +96,7 @@
   </change-notes>
 
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="172.3317" until-build="173.*"/>
+  <idea-version since-build="173.*" until-build="181.*"/>
   <resource-bundle>com.microsoft.intellij.ui.messages.messages</resource-bundle>
   <resource-bundle>com.microsoft.intellij.hdinsight.messages.messages</resource-bundle>
   <depends optional="true">org.intellij.scala</depends>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ApplicationSettings.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ApplicationSettings.java
@@ -10,8 +10,7 @@ import java.util.Map;
 @State(
         name = "HDInsightSettings",
         storages = {
-                @Storage(id = "com.microsoft.azure.application.settings",
-                        file = "$APP_CONFIG$/azure.application.settings.xml",
+                @Storage(file = "$APP_CONFIG$/azure.application.settings.xml",
                         scheme = StorageScheme.DIRECTORY_BASED)
         })
 public class ApplicationSettings implements PersistentStateComponent<ApplicationSettings.State> {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureSettings.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureSettings.java
@@ -37,7 +37,7 @@ import static com.microsoft.intellij.ui.messages.AzureBundle.message;
 @State(
         name = "AzureSettings",
         storages = {
-                @Storage(id = "AzureSettings", file = "$PROJECT_FILE$"),
+                @Storage(file = "$PROJECT_FILE$"),
                 @Storage(file = "$PROJECT_CONFIG_DIR$/azureSettings.xml", scheme = StorageScheme.DIRECTORY_BASED)
         }
 )


### PR DESCRIPTION
Since IntelliJ released 2018.1, we need to update the build scripts.

Meanwhile, some of the codes also need to change due to the API change of the storage annotation:
- https://www.jetbrains.org/intellij/sdk/docs/basics/persisting_state_of_components.html#defining-the-storage-location
- https://github.com/JetBrains/intellij-community/blob/master/platform/projectModel-api/src/com/intellij/openapi/components/Storage.java

attribute `id` is removed