### PR TITLE
Upgrade azure-client-runtime to v1.3.0

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -95,8 +95,8 @@ dependencies {
     compile fileTree(dir: '../AddLibrary/AzureLibraries/com.microsoft.azuretools.sdk/dependencies', include: ['applicationinsights-management-1.0.3.jar'])
     compile 'com.microsoft.sqlserver:mssql-jdbc:6.1.0.jre8'
     compile 'commons-io:commons-io:2.5'
-    compile 'com.microsoft.azure:azure-client-runtime:1.1.1', { force = true }
-    compile 'com.microsoft.azure:azure-client-authentication:1.1.1', { force = true }
+    compile 'com.microsoft.azure:azure-client-runtime:1.3.0', { force = true }
+    compile 'com.microsoft.azure:azure-client-authentication:1.3.0', { force = true }
     compile 'com.microsoft.azuretools:azuretools-core:3.7.0', {
         exclude group: "com.microsoft.azure", module: "azure-client-authentication"
         exclude group: "com.microsoft.azure", module: "azure-client-runtime"

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -328,12 +328,12 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-client-runtime</artifactId>
-                <version>1.1.1</version>
+                <version>1.3.0</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-client-authentication</artifactId>
-                <version>1.1.1</version>
+                <version>1.3.0</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>


### PR DESCRIPTION
New autorest generaged API codes depends on v1.3.0

Signed-off-by: Wei Zhang <wezhang@outlook.com>