### PR TITLE
use a private intellij-gradle-plugin build for SDK182

### DIFF
--- a/BuildDevint
+++ b/BuildDevint
@@ -38,19 +38,12 @@ cp ./PluginsAndFeatures/azure-toolkit-for-eclipse/WindowsAzurePlugin4EJ/target/W
 chmod +x ./gradlew
 chmod +x ./tools/IntellijVersionHelper
 
-# Build intellij 2017.3 plugin
-if [ $INTELLIJ_VERSION == "true" ] ; then
-    ./tools/IntellijVersionHelper 2017.3
-fi
-./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Pintellij_version=IC-2017.3 -Pdep_plugins=org.intellij.scala:2017.3.15
-cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2017.3.zip
-
 # Build intellij 2018.1 plugin
 if [ $INTELLIJ_VERSION == "true" ] ; then
     ./tools/IntellijVersionHelper 2018.1
 fi
 
-./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s 
+./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -Pintellij_version=IC-2018.1 -Pdep_plugins=org.intellij.scala:2018.1.8
 
 cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.1.zip
 
@@ -59,7 +52,7 @@ if [ $INTELLIJ_VERSION == "true" ] ; then
     ./tools/IntellijVersionHelper 2018.2
 fi
 
-./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s -PupdateVersionRange=false
+./gradlew clean buildPlugin --project-dir ./PluginsAndFeatures/azure-toolkit-for-intellij -s
 
 cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.2.zip
 echo "ALL BUILD SUCCESSFUL"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -4,7 +4,8 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
+            // url "https://oss.sonatype.org/content/repositories/snapshots/"
+            url 'http://yanzhjenkins.southeastasia.cloudapp.azure.com:8081/repository/maven-snapshots/'
         }
         maven {
             url 'http://dl.bintray.com/jetbrains/intellij-plugin-service'
@@ -14,13 +15,15 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.0-SNAPSHOT"
     }
 }
 
-plugins {
-    id "org.jetbrains.intellij" version "0.2.18"
-}
+// plugins {
+//     id "org.jetbrains.intellij" version "0.2.18"
+// }
 apply plugin: "kotlin"
+apply plugin: 'org.jetbrains.intellij'
 
 import org.apache.tools.ant.filters.*
 processResources {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -1,7 +1,7 @@
 javaVersion=1.8
 org.gradle.jvmargs='-Duser.language=en'
 sources=false
-intellij_version=IC-2018.1
-dep_plugins=org.intellij.scala:2018.1.8
+intellij_version=IC-182.2949.4
+dep_plugins=org.intellij.scala:2018.2.1
 applicationinsights.key=57cc111a-36a8-44b3-b044-25d293b8b77c
 updateVersionRange=true


### PR DESCRIPTION
Before JetBrains/gradle-intellij-plugin fixes SDK 182 issue, use a private one to build.