### PR TITLE
Catch and log exceptions when needed

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/sparkserverless/SparkServerlessClusterOpsCtrl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/sparkserverless/SparkServerlessClusterOpsCtrl.java
@@ -23,6 +23,7 @@
 package com.microsoft.azure.sparkserverless;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.common.mvc.IdeSchedulers;
 import com.microsoft.azure.sparkserverless.serverexplore.sparkserverlessnode.SparkServerlessClusterOps;
 import com.microsoft.azure.sparkserverless.serverexplore.ui.SparkServerlessClusterDestoryDialog;
@@ -32,10 +33,9 @@ import com.microsoft.azure.sparkserverless.serverexplore.ui.SparkServerlessProvi
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.intellij.rxjava.IdeaSchedulers;
 
-public class SparkServerlessClusterOpsCtrl {
+public class SparkServerlessClusterOpsCtrl implements ILogger {
     @NotNull
     private final SparkServerlessClusterOps sparkServerlessClusterOps;
-    private static Logger LOG = Logger.getInstance(SparkServerlessClusterOpsCtrl.class.getName());
     private IdeSchedulers ideSchedulers = new IdeaSchedulers(null);
 
     public SparkServerlessClusterOpsCtrl(@NotNull SparkServerlessClusterOps sparkServerlessClusterOps) {
@@ -44,42 +44,42 @@ public class SparkServerlessClusterOpsCtrl {
         this.sparkServerlessClusterOps.getDestroyAction()
                 .observeOn(ideSchedulers.dispatchUIThread())
                 .subscribe(triplet -> {
-                    LOG.info(String.format("Destroy message received. AdlAccount: %s, cluster: %s, currentNode: %s",
+                    log().info(String.format("Destroy message received. AdlAccount: %s, cluster: %s, currentNode: %s",
                             triplet.getLeft().getName(), triplet.getMiddle(), triplet.getRight().getName()));
                     SparkServerlessClusterDestoryDialog destroyDialog = new SparkServerlessClusterDestoryDialog(
                             triplet.getRight(), triplet.getMiddle());
                     destroyDialog.show();
-                }, ex -> LOG.error(ex.getMessage(), ex));
+                }, ex -> log().warn(ex.getMessage(), ex));
 
         this.sparkServerlessClusterOps.getProvisionAction()
                 .observeOn(ideSchedulers.dispatchUIThread())
                 .subscribe(pair -> {
-                    LOG.info(String.format("Provision message received. AdlAccount: %s, node: %s",
+                    log().info(String.format("Provision message received. AdlAccount: %s, node: %s",
                             pair.getLeft().getName(), pair.getRight().getName()));
                     SparkServerlessProvisionDialog provisionDialog = new SparkServerlessProvisionDialog(
                             pair.getRight(), pair.getLeft());
                     provisionDialog.show();
-                }, ex -> LOG.error(ex.getMessage(), ex));
+                }, ex -> log().warn(ex.getMessage(), ex));
 
         this.sparkServerlessClusterOps.getMonitorAction()
                 .observeOn(ideSchedulers.dispatchUIThread())
                 .subscribe(pair -> {
-                    LOG.info(String.format("Monitor message received. cluster: %s, node: %s",
+                    log().info(String.format("Monitor message received. cluster: %s, node: %s",
                             pair.getLeft(), pair.getRight()));
                     SparkServerlessClusterMonitorDialog monitorDialog = new SparkServerlessClusterMonitorDialog(
                             pair.getRight(), pair.getLeft());
                     monitorDialog.show();
-                }, ex -> LOG.error(ex.getMessage(), ex));
+                }, ex -> log().warn(ex.getMessage(), ex));
 
         this.sparkServerlessClusterOps.getUpdateAction()
                 .observeOn(ideSchedulers.dispatchUIThread())
                 .subscribe(pair -> {
-                    LOG.info(String.format("Update message received. cluster: %s, node: %s",
+                    log().info(String.format("Update message received. cluster: %s, node: %s",
                             pair.getLeft(), pair.getRight()));
                     SparkServerlessClusterUpdateDialog updateDialog = new SparkServerlessClusterUpdateDialog(
                             pair.getRight(), pair.getLeft());
                     updateDialog.show();
-                }, ex -> LOG.error(ex.getMessage(), ex));
+                }, ex -> log().warn(ex.getMessage(), ex));
     }
 
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/sparkserverless/SparkServerlessClusterOpsCtrl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/sparkserverless/SparkServerlessClusterOpsCtrl.java
@@ -25,6 +25,7 @@ package com.microsoft.azure.sparkserverless;
 import com.intellij.openapi.diagnostic.Logger;
 import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.common.mvc.IdeSchedulers;
+import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessCluster;
 import com.microsoft.azure.sparkserverless.serverexplore.sparkserverlessnode.SparkServerlessClusterOps;
 import com.microsoft.azure.sparkserverless.serverexplore.ui.SparkServerlessClusterDestoryDialog;
 import com.microsoft.azure.sparkserverless.serverexplore.ui.SparkServerlessClusterMonitorDialog;
@@ -45,7 +46,10 @@ public class SparkServerlessClusterOpsCtrl implements ILogger {
                 .observeOn(ideSchedulers.dispatchUIThread())
                 .subscribe(triplet -> {
                     log().info(String.format("Destroy message received. AdlAccount: %s, cluster: %s, currentNode: %s",
-                            triplet.getLeft().getName(), triplet.getMiddle(), triplet.getRight().getName()));
+                            triplet.getLeft().getName(),
+                            // Type cast is necessary for DestroyableCluster
+                            ((AzureSparkServerlessCluster) triplet.getMiddle()).getName(),
+                            triplet.getRight().getName()));
                     SparkServerlessClusterDestoryDialog destroyDialog = new SparkServerlessClusterDestoryDialog(
                             triplet.getRight(), triplet.getMiddle());
                     destroyDialog.show();
@@ -65,7 +69,7 @@ public class SparkServerlessClusterOpsCtrl implements ILogger {
                 .observeOn(ideSchedulers.dispatchUIThread())
                 .subscribe(pair -> {
                     log().info(String.format("Monitor message received. cluster: %s, node: %s",
-                            pair.getLeft(), pair.getRight()));
+                            pair.getLeft().getName(), pair.getRight().getName()));
                     SparkServerlessClusterMonitorDialog monitorDialog = new SparkServerlessClusterMonitorDialog(
                             pair.getRight(), pair.getLeft());
                     monitorDialog.show();
@@ -75,7 +79,7 @@ public class SparkServerlessClusterOpsCtrl implements ILogger {
                 .observeOn(ideSchedulers.dispatchUIThread())
                 .subscribe(pair -> {
                     log().info(String.format("Update message received. cluster: %s, node: %s",
-                            pair.getLeft(), pair.getRight()));
+                            pair.getLeft().getName(), pair.getRight().getName()));
                     SparkServerlessClusterUpdateDialog updateDialog = new SparkServerlessClusterUpdateDialog(
                             pair.getRight(), pair.getLeft());
                     updateDialog.show();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/sparkserverless/serverexplore/ui/SparkServerlessClusterUpdateDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/sparkserverless/serverexplore/ui/SparkServerlessClusterUpdateDialog.java
@@ -62,7 +62,10 @@ public class SparkServerlessClusterUpdateDialog extends SparkServerlessProvision
             @Override
             public void windowOpened(WindowEvent e) {
                 ctrlProvider.initialize()
-                        .subscribe();
+                        .subscribe(complete -> {}, err -> {
+                            log().warn(String.format("Can't get the cluster %s details: %s", cluster.getName(), err));
+                            errorMessageField.setText("Error Loading cluster details");
+                        });
                 super.windowOpened(e);
             }
         });

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sparkserverless/serverexplore/SparkServerlessClusterProvisionCtrlProvider.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sparkserverless/serverexplore/SparkServerlessClusterProvisionCtrlProvider.java
@@ -21,6 +21,7 @@
  */
 package com.microsoft.azure.sparkserverless.serverexplore;
 
+import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.common.mvc.IdeSchedulers;
 import com.microsoft.azure.hdinsight.common.mvc.SettableControl;
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessAccount;
@@ -33,7 +34,7 @@ import rx.schedulers.Schedulers;
 
 import java.util.List;
 
-public class SparkServerlessClusterProvisionCtrlProvider {
+public class SparkServerlessClusterProvisionCtrlProvider implements ILogger {
 
     @NotNull
     private SettableControl<SparkServerlessClusterProvisionSettingsModel> controllableView;
@@ -54,6 +55,10 @@ public class SparkServerlessClusterProvisionCtrlProvider {
 
     public Observable<List<String>> getClusterNames() {
         return account.get()
+                .onErrorReturn(err -> {
+                    log().warn(String.format("Can't get the account %s details: %s", account.getName(), err));
+                    return account;
+                })
                 .flatMap(acc -> Observable.from(acc.getClusters()))
                 .map(cluster -> cluster.getName())
                 .toList();
@@ -71,6 +76,10 @@ public class SparkServerlessClusterProvisionCtrlProvider {
 
     private Observable<Integer> getTotalAU() {
         return account.get()
+                .onErrorReturn(err -> {
+                    log().warn(String.format("Can't get the account %s details: %s", account.getName(), err));
+                    return account;
+                })
                 .subscribeOn(Schedulers.io())
                 .map(account -> account.getMaxDegreeOfParallelism());
     }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sparkserverless/serverexplore/SparkServerlessClusterStatesCtrlProvider.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sparkserverless/serverexplore/SparkServerlessClusterStatesCtrlProvider.java
@@ -1,5 +1,6 @@
 package com.microsoft.azure.sparkserverless.serverexplore;
 
+import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.common.mvc.IdeSchedulers;
 import com.microsoft.azure.hdinsight.common.mvc.SettableControl;
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessCluster;
@@ -10,7 +11,7 @@ import rx.schedulers.Schedulers;
 import java.net.URI;
 import java.util.Optional;
 
-public class SparkServerlessClusterStatesCtrlProvider {
+public class SparkServerlessClusterStatesCtrlProvider implements ILogger {
     @NotNull
     private SettableControl<SparkServerlessClusterStatesModel> controllableView;
     @NotNull
@@ -56,7 +57,11 @@ public class SparkServerlessClusterStatesCtrlProvider {
                 })
                 .doOnNext(controllableView::setData)
                 .observeOn(Schedulers.io())
-                .flatMap(data -> cluster.get());
+                .flatMap(data -> cluster.get())
+                .onErrorReturn(err -> {
+                    log().warn(String.format("Can't get the cluster %s details: %s", cluster.getName(), err));
+                    return cluster;
+                });
     }
 
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sparkserverless/serverexplore/sparkserverlessnode/SparkServerlessClusterNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sparkserverless/serverexplore/sparkserverlessnode/SparkServerlessClusterNode.java
@@ -23,6 +23,7 @@
 package com.microsoft.azure.sparkserverless.serverexplore.sparkserverlessnode;
 
 import com.microsoft.azure.hdinsight.common.CommonConst;
+import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessAccount;
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessCluster;
 import com.microsoft.azure.hdinsight.sdk.rest.azure.serverless.spark.models.SparkItemGroupState;
@@ -38,7 +39,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
 
-public class SparkServerlessClusterNode extends AzureRefreshableNode {
+public class SparkServerlessClusterNode extends AzureRefreshableNode implements ILogger {
     @NotNull
     private final String CLUSTER_MODULE_ID;
     // TODO: Update icon path
@@ -64,11 +65,15 @@ public class SparkServerlessClusterNode extends AzureRefreshableNode {
 
     @Override
     protected void refreshItems() throws AzureCmdException {
-        cluster.get().toBlocking().singleOrDefault(cluster);
-        if (Optional.ofNullable(cluster.getMasterState()).orElse("")
-                .equals(SparkItemGroupState.STABLE.toString())) {
-            addAction("Update", new SparkServerlessUpdateAction(
-                    this, cluster, SparkServerlessClusterOps.getInstance().getUpdateAction()));
+        try {
+            cluster.get().toBlocking().singleOrDefault(cluster);
+            if (Optional.ofNullable(cluster.getWorkerState()).orElse("")
+                    .equals(SparkItemGroupState.STABLE.toString())) {
+                addAction("Update", new SparkServerlessUpdateAction(
+                        this, cluster, SparkServerlessClusterOps.getInstance().getUpdateAction()));
+            }
+        } catch (Exception ex) {
+            log().warn(String.format("Can't get the cluster %s details: %s", cluster.getName(), ex));
         }
     }
 


### PR DESCRIPTION
* Log and catch `Bad Request` exceptions when calling `get()` in `AzureSparkServerlessCluster` and `AzureSparkServerlessAccount`