### PR TITLE
Fix the Run Configuration open slow issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkSubmissionContentPanelConfigurable.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkSubmissionContentPanelConfigurable.java
@@ -69,7 +69,7 @@ public class SparkSubmissionContentPanelConfigurable implements SettableControl<
 
     @NotNull
     protected ImmutableList<IClusterDetail> getClusterDetails() {
-        return ClusterManagerEx.getInstance().getClusterDetails();
+        return ClusterManagerEx.getInstance().getClusterDetailsWithoutAsync(true);
     }
 
     protected void createUIComponents() {


### PR DESCRIPTION
Only force to fresh the first time, use cased clusters then.

Signed-off-by: Wei Zhang <wezhang@outlook.com>