### PR TITLE
Fix merge conflicts mistakes: Enable updating cluster when spark master is stable

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sparkserverless/serverexplore/sparkserverlessnode/SparkServerlessClusterNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sparkserverless/serverexplore/sparkserverlessnode/SparkServerlessClusterNode.java
@@ -67,7 +67,7 @@ public class SparkServerlessClusterNode extends AzureRefreshableNode implements 
     protected void refreshItems() throws AzureCmdException {
         try {
             cluster.get().toBlocking().singleOrDefault(cluster);
-            if (Optional.ofNullable(cluster.getWorkerState()).orElse("")
+            if (Optional.ofNullable(cluster.getMasterState()).orElse("")
                     .equals(SparkItemGroupState.STABLE.toString())) {
                 addAction("Update", new SparkServerlessUpdateAction(
                         this, cluster, SparkServerlessClusterOps.getInstance().getUpdateAction()));


### PR DESCRIPTION
There is a merge conflict in #1800, and I made a mistake when resolve the conflicts. This PR is to fix the mistake.