### PR TITLE
List all web apps when Run on Web App

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppDeployViewPresenter.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppDeployViewPresenter.java
@@ -129,7 +129,7 @@ public class WebAppDeployViewPresenter<V extends WebAppDeployMvpView> extends Mv
     }
 
     private void loadWebApps(boolean forceRefresh) {
-        Observable.fromCallable(() -> AzureWebAppMvpModel.getInstance().listAllWebAppsOnWindows(forceRefresh))
+        Observable.fromCallable(() -> AzureWebAppMvpModel.getInstance().listAllWebApps(forceRefresh))
                 .subscribeOn(getSchedulerProvider().io())
                 .subscribe(webAppList -> DefaultLoader.getIdeHelper().invokeLater(() -> {
                     if (isViewDetached()) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
@@ -51,6 +51,7 @@ import com.microsoft.azuretools.core.mvp.model.webapp.JdkModel;
 import com.microsoft.azuretools.utils.WebAppUtils;
 import com.microsoft.intellij.runner.webapp.webappconfig.WebAppConfiguration;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
+import com.microsoft.intellij.util.PluginUtil;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.model.MavenConstants;
@@ -461,7 +462,7 @@ public class WebAppSettingPanel extends AzureSettingPanel<WebAppConfiguration> i
         btnRefresh.setEnabled(true);
         table.getEmptyText().setText(TABLE_EMPTY_MESSAGE);
         List<ResourceEx<WebApp>> sortedList = webAppLists.stream()
-                .filter(resource -> resource.getResource().javaVersion() != JavaVersion.OFF)
+                .filter(resource -> PluginUtil.isLinuxOrWindowsJavaWebApp(resource))
                 .sorted((a, b) -> a.getSubscriptionId().compareToIgnoreCase(b.getSubscriptionId()))
                 .collect(Collectors.toList());
         cachedWebAppList = sortedList;
@@ -472,8 +473,8 @@ public class WebAppSettingPanel extends AzureSettingPanel<WebAppConfiguration> i
                 WebApp app = sortedList.get(i).getResource();
                 model.addRow(new String[]{
                         app.name(),
-                        app.javaVersion().toString(),
-                        app.javaContainer() + " " + app.javaContainerVersion(),
+                        PluginUtil.getJavaJDKVersion(app),
+                        PluginUtil.getJavaWebContainer(app),
                         app.resourceGroupName(),
                 });
                 if (Comparing.equal(app.id(), webAppConfiguration.getWebAppId())) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
@@ -22,9 +22,6 @@
 
 package com.microsoft.intellij.runner.webapp.webappconfig.ui;
 
-import com.microsoft.intellij.runner.AzureSettingPanel;
-import icons.MavenIcons;
-
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.ActionToolbarPosition;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -38,7 +35,6 @@ import com.intellij.ui.ListCellRendererWrapper;
 import com.intellij.ui.ToolbarDecorator;
 import com.intellij.ui.table.JBTable;
 import com.microsoft.azure.management.appservice.AppServicePlan;
-import com.microsoft.azure.management.appservice.JavaVersion;
 import com.microsoft.azure.management.appservice.OperatingSystem;
 import com.microsoft.azure.management.appservice.PricingTier;
 import com.microsoft.azure.management.appservice.WebApp;
@@ -49,21 +45,16 @@ import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.core.mvp.model.ResourceEx;
 import com.microsoft.azuretools.core.mvp.model.webapp.JdkModel;
 import com.microsoft.azuretools.utils.WebAppUtils;
+import com.microsoft.intellij.runner.AzureSettingPanel;
 import com.microsoft.intellij.runner.webapp.webappconfig.WebAppConfiguration;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
-import com.microsoft.intellij.util.PluginUtil;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.idea.maven.model.MavenConstants;
-import org.jetbrains.idea.maven.project.MavenProject;
-
+import icons.MavenIcons;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import javax.swing.ButtonGroup;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -74,6 +65,9 @@ import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
 import javax.swing.table.DefaultTableModel;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.idea.maven.model.MavenConstants;
+import org.jetbrains.idea.maven.project.MavenProject;
 
 public class WebAppSettingPanel extends AzureSettingPanel<WebAppConfiguration> implements WebAppDeployMvpView {
 
@@ -462,7 +456,7 @@ public class WebAppSettingPanel extends AzureSettingPanel<WebAppConfiguration> i
         btnRefresh.setEnabled(true);
         table.getEmptyText().setText(TABLE_EMPTY_MESSAGE);
         List<ResourceEx<WebApp>> sortedList = webAppLists.stream()
-                .filter(resource -> PluginUtil.isLinuxOrWindowsJavaWebApp(resource))
+                .filter(resource -> WebAppUtils.isJavaWebApp(resource.getResource()))
                 .sorted((a, b) -> a.getSubscriptionId().compareToIgnoreCase(b.getSubscriptionId()))
                 .collect(Collectors.toList());
         cachedWebAppList = sortedList;
@@ -472,10 +466,10 @@ public class WebAppSettingPanel extends AzureSettingPanel<WebAppConfiguration> i
             for (int i = 0; i < sortedList.size(); i++) {
                 WebApp app = sortedList.get(i).getResource();
                 model.addRow(new String[]{
-                        app.name(),
-                        PluginUtil.getJavaJDKVersion(app),
-                        PluginUtil.getJavaWebContainer(app),
-                        app.resourceGroupName(),
+                    app.name(),
+                    WebAppUtils.getJDKVersion(app),
+                    WebAppUtils.getWebContainer(app),
+                    app.resourceGroupName(),
                 });
                 if (Comparing.equal(app.id(), webAppConfiguration.getWebAppId())) {
                     table.setRowSelectionInterval(i, i);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/PluginUtil.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/PluginUtil.java
@@ -41,14 +41,9 @@ import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.IdeFocusManager;
-import com.microsoft.azure.management.appservice.JavaVersion;
-import com.microsoft.azure.management.appservice.WebApp;
-import com.microsoft.azuretools.core.mvp.model.ResourceEx;
 import com.microsoft.intellij.IToolWindowProcessor;
 import com.microsoft.intellij.ToolWindowKey;
 import com.microsoft.intellij.common.CommonConst;
-import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.io.File;
@@ -187,54 +182,5 @@ public class PluginUtil {
         }
 
         DialogEarthquakeShaker.shake(dialogWrapper.getPeer().getWindow());
-    }
-
-    public static String getJavaJDKVersion(@NotNull final WebApp app) {
-        try {
-            if (StringUtils.isEmpty(app.linuxFxVersion())) {
-                return app.javaVersion().toString();
-            }
-
-            final String[] linuxVersion = app.linuxFxVersion().split("-");
-            return linuxVersion[1];
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return "";
-    }
-
-    public static String getJavaWebContainer(@NotNull final WebApp app) {
-        try {
-            if (StringUtils.isEmpty(app.linuxFxVersion())) {
-                return app.javaContainer() + " " + app.javaContainerVersion();
-            }
-
-            final String[] linuxVersion = app.linuxFxVersion().split("-");
-            if (!isJavaLinuxVersionWithWebContainer(linuxVersion[0])) {
-                return "N/A";
-            }
-            final String[] container = linuxVersion[0].split("\\|");
-            return container[0] + " " + container[1];
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return "";
-    }
-
-    public static boolean isJavaLinuxVersionWithWebContainer(@NotNull final String version) {
-        return version.toLowerCase().contains("tomcat");
-    }
-
-    /**
-     * Check if the web app is windows or linux java configured web app.
-     * Docker web apps are not included.
-     * @param resourceEx
-     * @return
-     */
-    public static boolean isLinuxOrWindowsJavaWebApp(@NotNull ResourceEx<WebApp> resourceEx) {
-        final WebApp webApp = resourceEx.getResource();
-        return webApp.javaVersion() != JavaVersion.OFF ||
-                webApp.linuxFxVersion() != null &&
-                        webApp.linuxFxVersion().toLowerCase().contains("jre8");
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/PluginUtil.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/PluginUtil.java
@@ -41,9 +41,14 @@ import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.IdeFocusManager;
+import com.microsoft.azure.management.appservice.JavaVersion;
+import com.microsoft.azure.management.appservice.WebApp;
+import com.microsoft.azuretools.core.mvp.model.ResourceEx;
 import com.microsoft.intellij.IToolWindowProcessor;
 import com.microsoft.intellij.ToolWindowKey;
 import com.microsoft.intellij.common.CommonConst;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.io.File;
@@ -182,5 +187,54 @@ public class PluginUtil {
         }
 
         DialogEarthquakeShaker.shake(dialogWrapper.getPeer().getWindow());
+    }
+
+    public static String getJavaJDKVersion(@NotNull final WebApp app) {
+        try {
+            if (StringUtils.isEmpty(app.linuxFxVersion())) {
+                return app.javaVersion().toString();
+            }
+
+            final String[] linuxVersion = app.linuxFxVersion().split("-");
+            return linuxVersion[1];
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return "";
+    }
+
+    public static String getJavaWebContainer(@NotNull final WebApp app) {
+        try {
+            if (StringUtils.isEmpty(app.linuxFxVersion())) {
+                return app.javaContainer() + " " + app.javaContainerVersion();
+            }
+
+            final String[] linuxVersion = app.linuxFxVersion().split("-");
+            if (!isJavaLinuxVersionWithWebContainer(linuxVersion[0])) {
+                return "N/A";
+            }
+            final String[] container = linuxVersion[0].split("\\|");
+            return container[0] + " " + container[1];
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return "";
+    }
+
+    public static boolean isJavaLinuxVersionWithWebContainer(@NotNull final String version) {
+        return version.toLowerCase().contains("tomcat");
+    }
+
+    /**
+     * Check if the web app is windows or linux java configured web app.
+     * Docker web apps are not included.
+     * @param resourceEx
+     * @return
+     */
+    public static boolean isLinuxOrWindowsJavaWebApp(@NotNull ResourceEx<WebApp> resourceEx) {
+        final WebApp webApp = resourceEx.getResource();
+        return webApp.javaVersion() != JavaVersion.OFF ||
+                webApp.linuxFxVersion() != null &&
+                        webApp.linuxFxVersion().toLowerCase().contains("jre8");
     }
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -328,7 +328,7 @@ public class AzureWebAppMvpModel {
      * List Web Apps by Subscription ID.
      */
     @Deprecated
-    public List<ResourceEx<WebApp>> listWebAppsOnWindowsBySubscriptionId(String sid, boolean force) {
+    public List<ResourceEx<WebApp>> listWebAppsOnWindowsBySubscriptionId(final String sid, final boolean force) {
         return this.listWebAppsOnWindows(sid, force);
     }
 
@@ -352,7 +352,7 @@ public class AzureWebAppMvpModel {
      * @return list of Web App on Linux
      */
     @Deprecated
-    public List<ResourceEx<WebApp>> listWebAppsOnLinuxBySubscriptionId(String sid, boolean force) {
+    public List<ResourceEx<WebApp>> listWebAppsOnLinuxBySubscriptionId(final String sid, final boolean force) {
         return this.listWebAppsOnLinux(sid, force);
     }
 
@@ -362,7 +362,7 @@ public class AzureWebAppMvpModel {
      * @param force flag indicating whether force to fetch most updated data from server
      * @return list of Web App
      */
-    public List<ResourceEx<WebApp>> listAllWebApps(boolean force) {
+    public List<ResourceEx<WebApp>> listAllWebApps(final boolean force) {
         final List<ResourceEx<WebApp>> webApps = new ArrayList<>();
         for (final Subscription sub : AzureMvpModel.getInstance().getSelectedSubscriptions()) {
             final String sid = sub.subscriptionId();

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -385,7 +385,8 @@ public class AzureWebAppMvpModel {
      * List web apps on windows by subscription id.
      */
     public List<ResourceEx<WebApp>> listWebAppsOnWindows(@NotNull final String subscriptionId, final boolean force) {
-        return listWebApps(subscriptionId, force).stream()
+        return listWebApps(subscriptionId, force)
+            .stream()
             .filter(resourceEx -> OperatingSystem.WINDOWS.equals((resourceEx.getResource().operatingSystem())))
             .collect(Collectors.toList());
     }
@@ -402,7 +403,8 @@ public class AzureWebAppMvpModel {
         List<ResourceEx<WebApp>> webApps = new ArrayList<>();
         try {
             final Azure azure = AuthMethodManager.getInstance().getAzureClient(subscriptionId);
-            webApps = azure.webApps().list().stream()
+            webApps = azure.webApps().list()
+                .stream()
                 .map(app -> new ResourceEx<WebApp>(app, subscriptionId))
                 .collect(Collectors.toList());
             subscriptionIdToWebApps.put(subscriptionId, webApps);
@@ -471,14 +473,19 @@ public class AzureWebAppMvpModel {
         }
     }
 
+    @Deprecated
     public void cleanWebAppsOnWindows() {
-        // todo
+        // todo: remove the function
+        // todo: create a new function clearWebAppsCache clear cache web apps
         // subscriptionIdToWebAppsOnWindowsMap.clear();
+        subscriptionIdToWebApps.clear();
     }
 
+    @Deprecated
     public void cleanWebAppsOnLinux() {
-        // todo
+        // todo: remove the function
         // subscriptionIdToWebAppsOnLinuxMap.clear();
+        subscriptionIdToWebApps.clear();
     }
 
     /**

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/utils/WebAppUtils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/utils/WebAppUtils.java
@@ -375,20 +375,20 @@ public class WebAppUtils {
      * It returns values like "Tomcat|8.5-jre8" if it is a Linux with the web container Tomcat.
      */
     public static String getJDKVersion(@NotNull final WebApp webApp) {
-        final OperatingSystem operatingSystem = webApp.operatingSystem();
-        if (operatingSystem == OperatingSystem.WINDOWS) {
-            return webApp.javaVersion().toString();
-        }
-        if (operatingSystem == OperatingSystem.LINUX) {
-            final String linuxVersion = webApp.linuxFxVersion();
-            if (linuxVersion == null) {
-                return DEFAULT_VALUE_WHEN_VERSION_INVALID;
-            }
+        switch(webApp.operatingSystem()) {
+            case WINDOWS:
+                return webApp.javaVersion().toString();
+            case LINUX:
+                final String linuxVersion = webApp.linuxFxVersion();
+                if (linuxVersion == null) {
+                    return DEFAULT_VALUE_WHEN_VERSION_INVALID;
+                }
 
-            final String[] versions = linuxVersion.split("-");
-            return versions.length == 2 ? versions[1] : DEFAULT_VALUE_WHEN_VERSION_INVALID;
+                final String[] versions = linuxVersion.split("-");
+                return versions.length != 2 ? linuxVersion : versions[1];
+            default:
+                return DEFAULT_VALUE_WHEN_VERSION_INVALID;
         }
-        return DEFAULT_VALUE_WHEN_VERSION_INVALID;
     }
 
     /**
@@ -399,23 +399,23 @@ public class WebAppUtils {
      * And we will return N/A for those kind of web apps.
      */
     public static String getWebContainer(@NotNull final WebApp webApp) {
-        final OperatingSystem operatingSystem = webApp.operatingSystem();
-        if (operatingSystem == OperatingSystem.WINDOWS) {
-            return String.join(" ", webApp.javaContainer(), webApp.javaContainerVersion());
-        }
-        if (operatingSystem == OperatingSystem.LINUX) {
-            final String linuxVersion = webApp.linuxFxVersion();
-            final String[] versions = linuxVersion.split("-");
-            if (versions.length != 2) {
+        switch(webApp.operatingSystem()) {
+            case WINDOWS:
+                String.join(" ", webApp.javaContainer(), webApp.javaContainerVersion());
+            case LINUX:
+                final String linuxVersion = webApp.linuxFxVersion();
+                final String[] versions = linuxVersion.split("-");
+                if (versions.length != 2) {
+                    return linuxVersion;
+                }
+                if (StringUtils.containsIgnoreCase(versions[0], "tomcat")) {
+                    return versions[0].replace("|", " ");
+                } else {
+                    return "N/A";
+                }
+            default:
                 return DEFAULT_VALUE_WHEN_VERSION_INVALID;
-            }
-            if (StringUtils.containsIgnoreCase(versions[0], "tomcat")) {
-                return versions[0].replace("|", " ");
-            } else {
-                return "N/A";
-            }
         }
-        return DEFAULT_VALUE_WHEN_VERSION_INVALID;
     }
 
     /**

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/utils/WebAppUtils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/utils/WebAppUtils.java
@@ -401,7 +401,7 @@ public class WebAppUtils {
     public static String getWebContainer(@NotNull final WebApp webApp) {
         switch(webApp.operatingSystem()) {
             case WINDOWS:
-                String.join(" ", webApp.javaContainer(), webApp.javaContainerVersion());
+                return String.join(" ", webApp.javaContainer(), webApp.javaContainerVersion());
             case LINUX:
                 final String linuxVersion = webApp.linuxFxVersion();
                 final String[] versions = linuxVersion.split("-");

--- a/Utils/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModelTest.java
+++ b/Utils/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModelTest.java
@@ -294,7 +294,7 @@ public class AzureWebAppMvpModelTest {
         mockWebAppModel.listAllWebApps(false);
         List<ResourceEx<WebApp>> resultList = azureWebAppMvpModel.listAllWebApps(false);
 
-        verify(mockWebAppModel, times(1)).listWebApps("1");
+        verify(mockWebAppModel, times(1)).listWebApps("1", false);
         assertEquals(2, resultList.size());
 
         final WebApp app3 = mock(WebApp.class);
@@ -313,10 +313,10 @@ public class AzureWebAppMvpModelTest {
 
         when(authMethodManagerMock.getAzureClient(anyString())).thenReturn(azureMock);
 
-        final List<ResourceEx<WebApp>> webAppList = azureWebAppMvpModel.listWebAppsOnLinux(MOCK_SUBSCRIPTION);
+        final List<ResourceEx<WebApp>> webAppList = azureWebAppMvpModel.listWebAppsOnLinux(MOCK_SUBSCRIPTION, true);
         final AzureWebAppMvpModel mockWebAppModel = spy(azureWebAppMvpModel);
-        mockWebAppModel.listWebAppsOnLinux(MOCK_SUBSCRIPTION);
-        verify(mockWebAppModel, times(1)).listWebAppsOnLinux(MOCK_SUBSCRIPTION);
+        mockWebAppModel.listWebAppsOnLinux(MOCK_SUBSCRIPTION, true);
+        verify(mockWebAppModel, times(1)).listWebAppsOnLinux(MOCK_SUBSCRIPTION, true);
         assertEquals(1, webAppList.size());
     }
 
@@ -362,10 +362,10 @@ public class AzureWebAppMvpModelTest {
 
         when(authMethodManagerMock.getAzureClient(anyString())).thenReturn(azureMock);
 
-        final List<ResourceEx<WebApp>> rstList = azureWebAppMvpModel.listWebAppsOnWindows(MOCK_SUBSCRIPTION);
+        final List<ResourceEx<WebApp>> rstList = azureWebAppMvpModel.listWebAppsOnWindows(MOCK_SUBSCRIPTION, true);
         final AzureWebAppMvpModel mockWebAppModel = spy(azureWebAppMvpModel);
-        mockWebAppModel.listWebAppsOnWindows(MOCK_SUBSCRIPTION);
-        verify(mockWebAppModel, times(1)).listWebAppsOnWindows(MOCK_SUBSCRIPTION);
+        mockWebAppModel.listWebAppsOnWindows(MOCK_SUBSCRIPTION, true);
+        verify(mockWebAppModel, times(1)).listWebAppsOnWindows(MOCK_SUBSCRIPTION, true);
         assertEquals(2, rstList.size());
     }
 


### PR DESCRIPTION
#1970 

Add new API to list all web apps no matter what os it is. 
When users right-click "Run on Web App", we call this API to list all web apps and filter out web apps whose java runtime is configured.

Refactoring list web apps by subscription id related functions and create a new API to list all web apps.