### PR TITLE
Better naming the create web app related functions

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/main/java/com/microsoft/azuretools/container/ui/PublishWebAppOnLinuxDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/main/java/com/microsoft/azuretools/container/ui/PublishWebAppOnLinuxDialog.java
@@ -495,7 +495,7 @@ public class PublishWebAppOnLinuxDialog extends AzureTitleAreaDialogWrapper impl
             if (model.isCreatingNewWebAppOnLinux()) {
                 // create new WebApp
                 ConsoleLogger.info(String.format("Creating new WebApp ... [%s]", model.getWebAppName()));
-                WebApp app = AzureWebAppMvpModel.getInstance().createWebAppOnLinux(model);
+                WebApp app = AzureWebAppMvpModel.getInstance().createWebAppOnDocker(model);
 
                 if (app != null && app.name() != null) {
                     ConsoleLogger.info(String.format("URL:  http://%s.azurewebsites.net/", app.name()));
@@ -505,7 +505,7 @@ public class PublishWebAppOnLinuxDialog extends AzureTitleAreaDialogWrapper impl
             } else {
                 // update WebApp
                 ConsoleLogger.info(String.format("Updating WebApp ... [%s]", model.getWebAppName()));
-                WebApp app = AzureWebAppMvpModel.getInstance().updateWebAppOnLinux(model.getSubscriptionId(),
+                WebApp app = AzureWebAppMvpModel.getInstance().updateWebAppOnDocker(model.getSubscriptionId(),
                         model.getWebAppId(), acrInfo);
                 if (app != null && app.name() != null) {
                     ConsoleLogger.info(String.format("URL:  http://%s.azurewebsites.net/", app.name()));

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/main/java/com/microsoft/azuretools/container/ui/PublishWebAppOnLinuxDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/main/java/com/microsoft/azuretools/container/ui/PublishWebAppOnLinuxDialog.java
@@ -495,7 +495,7 @@ public class PublishWebAppOnLinuxDialog extends AzureTitleAreaDialogWrapper impl
             if (model.isCreatingNewWebAppOnLinux()) {
                 // create new WebApp
                 ConsoleLogger.info(String.format("Creating new WebApp ... [%s]", model.getWebAppName()));
-                WebApp app = AzureWebAppMvpModel.getInstance().createWebAppOnDocker(model);
+                WebApp app = AzureWebAppMvpModel.getInstance().createWebAppWithPrivateRegistryImage(model);
 
                 if (app != null && app.name() != null) {
                     ConsoleLogger.info(String.format("URL:  http://%s.azurewebsites.net/", app.name()));

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/ui/AppServiceCreateDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/ui/AppServiceCreateDialog.java
@@ -825,7 +825,7 @@ public class AppServiceCreateDialog extends AzureTitleAreaDialogWrapper {
                                 });
                             }
                             try {
-                                webApp = AzureWebAppMvpModel.getInstance().createWebApp(model);
+                                webApp = AzureWebAppMvpModel.getInstance().createWebAppOnWindows(model);
                                 if (webApp != null && packaging.equals(WebAppUtils.TYPE_JAR)) {
                                     webApp.stop();
                                     try (InputStream webConfigInput = WebAppUtils.class

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/WebAppOnLinuxDeployState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/WebAppOnLinuxDeployState.java
@@ -108,7 +108,7 @@ public class WebAppOnLinuxDeployState extends AzureRunProfileState<WebApp> {
             // create new WebApp
             processHandler.setText(String.format("Creating new WebApp ... [%s]",
                     deployModel.getWebAppName()));
-            WebApp app = AzureWebAppMvpModel.getInstance().createWebAppOnDocker(deployModel);
+            WebApp app = AzureWebAppMvpModel.getInstance().createWebAppWithPrivateRegistryImage(deployModel);
             if (app != null && app.name() != null) {
                 processHandler.setText(String.format("URL:  http://%s.azurewebsites.net/", app.name()));
                 updateConfigurationDataModel(app);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/WebAppOnLinuxDeployState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/webapponlinux/WebAppOnLinuxDeployState.java
@@ -108,7 +108,7 @@ public class WebAppOnLinuxDeployState extends AzureRunProfileState<WebApp> {
             // create new WebApp
             processHandler.setText(String.format("Creating new WebApp ... [%s]",
                     deployModel.getWebAppName()));
-            WebApp app = AzureWebAppMvpModel.getInstance().createWebAppOnLinux(deployModel);
+            WebApp app = AzureWebAppMvpModel.getInstance().createWebAppOnDocker(deployModel);
             if (app != null && app.name() != null) {
                 processHandler.setText(String.format("URL:  http://%s.azurewebsites.net/", app.name()));
                 updateConfigurationDataModel(app);
@@ -121,7 +121,7 @@ public class WebAppOnLinuxDeployState extends AzureRunProfileState<WebApp> {
             processHandler.setText(String.format("Updating WebApp ... [%s]",
                     deployModel.getWebAppName()));
             WebApp app = AzureWebAppMvpModel.getInstance()
-                    .updateWebAppOnLinux(deployModel.getSubscriptionId(), deployModel.getWebAppId(), acrInfo);
+                    .updateWebAppOnDocker(deployModel.getSubscriptionId(), deployModel.getWebAppId(), acrInfo);
             if (app != null && app.name() != null) {
                 processHandler.setText(String.format("URL:  http://%s.azurewebsites.net/", app.name()));
             }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
@@ -168,7 +168,7 @@ public class WebAppRunState extends AzureRunProfileState<WebApp> {
         if (webAppSettingModel.isCreatingNew()) {
             processHandler.setText(CREATE_WEBAPP);
             try {
-                webApp = AzureWebAppMvpModel.getInstance().createWebApp(webAppSettingModel);
+                webApp = AzureWebAppMvpModel.getInstance().createWebAppOnWindows(webAppSettingModel);
             } catch (Exception e) {
                 processHandler.setText(STOP_DEPLOY);
                 throw new Exception(String.format(CREATE_FAILED, e.getMessage()));

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -175,7 +175,7 @@ public class AzureWebAppMvpModel {
      * @return instance of created WebApp
      * @throws IOException IOExceptions
      */
-    public WebApp createWebAppOnDocker(@NotNull WebAppOnLinuxDeployModel model)
+    public WebApp createWebAppWithPrivateRegistryImage(@NotNull WebAppOnLinuxDeployModel model)
             throws IOException {
         PrivateRegistryImageSetting pr = model.getPrivateRegistryImageSetting();
         WebApp app;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -86,7 +86,7 @@ public class AzureWebAppMvpModel {
      *
      * @param model parameters
      * @return instance of created WebApp
-     * @throws IOException IOExceptions
+     * @throws Exception exception
      */
     public WebApp createWebAppOnWindows(@NotNull WebAppSettingModel model) throws Exception {
         Azure azure = AuthMethodManager.getInstance().getAzureClient(model.getSubscriptionId());
@@ -169,7 +169,7 @@ public class AzureWebAppMvpModel {
     }
 
     /**
-     * API to create Web App on Linux.
+     * API to create Web App on Docker.
      *
      * @param model parameters
      * @return instance of created WebApp

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -81,17 +81,21 @@ public class AzureWebAppMvpModel {
         return app;
     }
 
-    /**
-     * Create an Azure web app service.
+     /**
+     * API to create Web App on Windows .
+     *
+     * @param model parameters
+     * @return instance of created WebApp
+     * @throws IOException IOExceptions
      */
-    public WebApp createWebApp(@NotNull WebAppSettingModel model) throws Exception {
+    public WebApp createWebAppOnWindows(@NotNull WebAppSettingModel model) throws Exception {
         Azure azure = AuthMethodManager.getInstance().getAzureClient(model.getSubscriptionId());
 
         WebApp.DefinitionStages.WithCreate withCreate;
         if (model.isCreatingAppServicePlan()) {
-            withCreate = withCreateNewSPlan(azure, model);
+            withCreate = withCreateNewWindowsServicePlan(azure, model);
         } else {
-            withCreate = withCreateExistingSPlan(azure, model);
+            withCreate = withExistingWindowsServicePlan(azure, model);
         }
 
         return withCreate
@@ -100,9 +104,9 @@ public class AzureWebAppMvpModel {
                 .create();
     }
 
-    private WebApp.DefinitionStages.WithCreate withCreateNewSPlan(
-            @NotNull Azure azure,
-            @NotNull WebAppSettingModel model) throws Exception {
+    private WebApp.DefinitionStages.WithCreate withCreateNewWindowsServicePlan(
+            @NotNull Azure azure, @NotNull WebAppSettingModel model) throws Exception {
+
         String[] tierSize = model.getPricing().split("_");
         if (tierSize.length != 2) {
             throw new Exception("Cannot get valid price tier");
@@ -137,7 +141,7 @@ public class AzureWebAppMvpModel {
         return withCreateWebApp;
     }
 
-    private WebApp.DefinitionStages.WithCreate withCreateExistingSPlan(
+    private WebApp.DefinitionStages.WithCreate withExistingWindowsServicePlan(
             @NotNull Azure azure,
             @NotNull WebAppSettingModel model) {
         AppServicePlan servicePlan = azure.appServices().appServicePlans().getById(model.getAppServicePlanId());
@@ -171,7 +175,7 @@ public class AzureWebAppMvpModel {
      * @return instance of created WebApp
      * @throws IOException IOExceptions
      */
-    public WebApp createWebAppOnLinux(WebAppOnLinuxDeployModel model)
+    public WebApp createWebAppOnDocker(@NotNull WebAppOnLinuxDeployModel model)
             throws IOException {
         PrivateRegistryImageSetting pr = model.getPrivateRegistryImageSetting();
         WebApp app;
@@ -246,7 +250,7 @@ public class AzureWebAppMvpModel {
      * @param imageSetting new container settings
      * @return instance of the updated Web App on Linux
      */
-    public WebApp updateWebAppOnLinux(String sid, String webAppId, ImageSetting imageSetting) throws Exception {
+    public WebApp updateWebAppOnDocker(String sid, String webAppId, ImageSetting imageSetting) throws Exception {
         WebApp app = getWebAppById(sid, webAppId);
         clearTags(app);
         if (imageSetting instanceof PrivateRegistryImageSetting) {

--- a/Utils/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModelTest.java
+++ b/Utils/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModelTest.java
@@ -199,7 +199,7 @@ public class AzureWebAppMvpModelTest {
         when(def.withExistingLinuxPlan(srvPlan)).thenReturn(withGrp);
 
         try{
-            azureWebAppMvpModel.createWebAppOnDocker(model);
+            azureWebAppMvpModel.createWebAppWithPrivateRegistryImage(model);
         } catch(Exception e) {
         }
 

--- a/Utils/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModelTest.java
+++ b/Utils/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModelTest.java
@@ -140,7 +140,7 @@ public class AzureWebAppMvpModelTest {
         when(withGrp.withNewResourceGroup(settingModel.getResourceGroup())).thenReturn(with);
 
         try {
-            azureWebAppMvpModel.createWebApp(settingModel);
+            azureWebAppMvpModel.createWebAppOnWindows(settingModel);
         }catch (Exception e) {
         }
 
@@ -166,7 +166,7 @@ public class AzureWebAppMvpModelTest {
         when(def.withExistingWindowsPlan(srvPlan)).thenReturn(withGrp);
 
         try{
-            azureWebAppMvpModel.createWebApp(settingModel);
+            azureWebAppMvpModel.createWebAppOnWindows(settingModel);
         } catch (Exception e) {
         }
 
@@ -199,7 +199,7 @@ public class AzureWebAppMvpModelTest {
         when(def.withExistingLinuxPlan(srvPlan)).thenReturn(withGrp);
 
         try{
-            azureWebAppMvpModel.createWebAppOnLinux(model);
+            azureWebAppMvpModel.createWebAppOnDocker(model);
         } catch(Exception e) {
         }
 


### PR DESCRIPTION
Better naming ```createWebAppOnLinux``` to ```createWebAppWithPrivateRegistryImage``` to specifically describe what this function does.

Better naming ```createWebApp``` to ```createWebAppOnWindows``` since it creates windows kind of web app.

To prepare for real API of creating web app on Linux.