### PR TITLE
Combine JDK and Web Container into Runtime and show OS info of a web app

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
@@ -65,6 +65,7 @@ import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
 import javax.swing.table.DefaultTableModel;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.model.MavenConstants;
 import org.jetbrains.idea.maven.project.MavenProject;
@@ -467,8 +468,8 @@ public class WebAppSettingPanel extends AzureSettingPanel<WebAppConfiguration> i
                 WebApp app = sortedList.get(i).getResource();
                 model.addRow(new String[]{
                     app.name(),
-                    WebAppUtils.getJDKVersion(app),
-                    WebAppUtils.getWebContainer(app),
+                    StringUtils.capitalize(app.operatingSystem().toString()),
+                    WebAppUtils.getJavaRuntime(app),
                     app.resourceGroupName(),
                 });
                 if (Comparing.equal(app.id(), webAppConfiguration.getWebAppId())) {
@@ -521,8 +522,8 @@ public class WebAppSettingPanel extends AzureSettingPanel<WebAppConfiguration> i
             }
         };
         tableModel.addColumn("Name");
-        tableModel.addColumn("JDK");
-        tableModel.addColumn("Web container");
+        tableModel.addColumn("OS");
+        tableModel.addColumn("Runtime");
         tableModel.addColumn("Resource group");
 
         table = new JBTable(tableModel);

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/utils/WebAppUtils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/utils/WebAppUtils.java
@@ -398,7 +398,6 @@ public class WebAppUtils {
                     return DEFAULT_VALUE_WHEN_VERSION_INVALID;
                 }
 
-                // TOMCAT|8.5-jre8 -> Tomcat 8.5 (JRE8)
                 final String[] versions = linuxVersion.split("\\||-");
                 if (versions == null && versions.length != 3) {
                     return linuxVersion;
@@ -408,8 +407,10 @@ public class WebAppUtils {
                 final String webContainerVersion = versions[1];
                 final String jreVersion = versions[2];
                 if (webContainer.contains("tomcat")) {
+                    // TOMCAT|8.5-jre8 -> Tomcat 8.5 (JRE8)
                     return String.format("%s %s (%s)", StringUtils.capitalize(webContainer), webContainerVersion, jreVersion.toUpperCase());
                 } else {
+                    // JAVA|8-jre8 -> JRE8
                     return jreVersion.toUpperCase();
                 }
             default:

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/utils/WebAppUtils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/utils/WebAppUtils.java
@@ -371,60 +371,34 @@ public class WebAppUtils {
     }
 
     /**
-     * app.linuxFxVersion() is the only API we could get the version info of a Linux web app.
-     * It returns values like "Tomcat|8.5-jre8" if it is a Linux with the web container Tomcat.
-     */
-    public static String getJDKVersion(@NotNull final WebApp webApp) {
-        switch(webApp.operatingSystem()) {
-            case WINDOWS:
-                return webApp.javaVersion().toString();
-            case LINUX:
-                final String linuxVersion = webApp.linuxFxVersion();
-                if (linuxVersion == null) {
-                    return DEFAULT_VALUE_WHEN_VERSION_INVALID;
-                }
-
-                final String[] versions = linuxVersion.split("-");
-                return versions.length != 2 ? linuxVersion : versions[1];
-            default:
-                return DEFAULT_VALUE_WHEN_VERSION_INVALID;
-        }
-    }
-
-    /**
-     * app.linuxFxVersion() is the only API we could get the version info of a Linux web app.
-     * It returns "Tomcat|8.5-jre8" if it is a Linux web app with the web container Tomcat.
-     * Tomcat is the only supported web container.
-     * If the web app is a Java SE web app, which has no web container, linuxFxVersion() returns "Java|8-jre8".
-     * And we will return N/A for those kind of web apps.
-     */
-    public static String getWebContainer(@NotNull final WebApp webApp) {
-        switch(webApp.operatingSystem()) {
-            case WINDOWS:
-                return String.join(" ", webApp.javaContainer(), webApp.javaContainerVersion());
-            case LINUX:
-                final String linuxVersion = webApp.linuxFxVersion();
-                final String[] versions = linuxVersion.split("-");
-                if (versions.length != 2) {
-                    return linuxVersion;
-                }
-                if (StringUtils.containsIgnoreCase(versions[0], "tomcat")) {
-                    return versions[0].replace("|", " ");
-                } else {
-                    return "N/A";
-                }
-            default:
-                return DEFAULT_VALUE_WHEN_VERSION_INVALID;
-        }
-    }
-
-    /**
      * Check if the web app is a Windows or Linux Java configured web app.
      * Docker web apps are not included.
      */
     public static boolean isJavaWebApp(@NotNull WebApp webApp) {
-        return webApp.javaVersion() != JavaVersion.OFF ||
-            webApp.linuxFxVersion() != null &&
-                webApp.linuxFxVersion().toLowerCase().contains("jre8");
+        return webApp.javaVersion() != JavaVersion.OFF || StringUtils.containsIgnoreCase(webApp.linuxFxVersion(), "jre8");
+    }
+
+    /**
+     * For a Windows web app, APIs are separated to get jdk information and web container information.
+     * For a Linux web app, API app.linuxFxVersion() returns a combined information, like
+     * "Tomcat|8.5-jre8" if it is a Linux web app with the web container Tomcat.
+     * We return a combined and refactored information as Java Runtime.
+     */
+    public static String getJavaRuntime(@NotNull final WebApp webApp) {
+        final String delimiter = "  ";
+        switch (webApp.operatingSystem()) {
+            case WINDOWS:
+                final String refactoredJavaVersion = "Java" + webApp.javaVersion().toString();
+                return String.join(delimiter, webApp.javaContainer(), webApp.javaContainerVersion(), refactoredJavaVersion);
+            case LINUX:
+                final String linuxVersion = webApp.linuxFxVersion();
+                if (linuxVersion == null) {
+                    return DEFAULT_VALUE_WHEN_VERSION_INVALID;
+                } else {
+                    return linuxVersion.replace("|", delimiter).replace("-", delimiter);
+                }
+            default:
+                return DEFAULT_VALUE_WHEN_VERSION_INVALID;
+        }
     }
 }


### PR DESCRIPTION
Fix issue #1968 

Use table row `Runtime` to show a combined and refactored information of Linux or Windows web app.
Add new table row `OS` to show the operating system of a web app.

![image](https://user-images.githubusercontent.com/5179063/45265454-98aa2800-b47d-11e8-9252-9764856a149c.png)

After some discussion about the format, updated the format of the Runtime:

![image](https://user-images.githubusercontent.com/5179063/45284994-8929ee00-b514-11e8-9508-d503da27e265.png)
