### PR TITLE
[on hold] Enable checkstyle on Utils and IntelliJ.

### DIFF
--- a/BuildDevint
+++ b/BuildDevint
@@ -42,7 +42,7 @@ if [ $INTELLIJ_VERSION == "true" ] ; then
     ./tools/IntellijVersionHelper 2018.1
 fi
 
-(cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s -Pintellij_version=IC-2018.1 -Pdep_plugins=org.intellij.scala:2018.1.8)
+(cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean checkstyleMain buildPlugin -s -Pintellij_version=IC-2018.1 -Pdep_plugins=org.intellij.scala:2018.1.8)
 
 cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.1.zip
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -26,6 +26,7 @@ checkstyle {
     toolVersion = '7.7'
     configFile = new File('config/checkstyle/checkstyle.xml')
     showViolations = false
+    ignoreFailures = true
 }
 
 findbugs {
@@ -141,7 +142,7 @@ task cucumber() {
 
 test.dependsOn cucumber
 
-defaultTasks 'buildPlugin', 'test'
+defaultTasks 'checkstyleMain', 'buildPlugin', 'test'
 
 task wrapper(type: Wrapper) {
     gradleVersion = '4.8'

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -22,8 +22,8 @@
   ~  */
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azuretools</groupId>
     <artifactId>utils</artifactId>
@@ -84,20 +84,30 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>2.17</version>
                 <dependencies>
-	                <dependency>
-	                    <groupId>com.microsoft.azuretools</groupId>
-	                    <artifactId>check-tools</artifactId>
-	                    <version>1.0.0</version>
-	                </dependency>
-	                <dependency>
-	                    <groupId>com.puppycrawl.tools</groupId>
-	                    <artifactId>checkstyle</artifactId>
-	                    <version>7.7</version>
-	                </dependency>
+                    <dependency>
+                        <groupId>com.microsoft.azuretools</groupId>
+                        <artifactId>check-tools</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>7.7</version>
+                    </dependency>
                 </dependencies>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
+                    <failOnViolation>false</failOnViolation>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- For Utils: Enable checkstyle in validate phase.
- For IntelliJ: See [ignoreFailures](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.Checkstyle.html#org.gradle.api.plugins.quality.Checkstyle:ignoreFailures)
- For build script: Add checkstyleMain in one of the build command, so we can see the log in CI server. 