### PR TITLE
Enable checkstyle for azuretools-core and azure-explorer-common

### DIFF
--- a/Utils/azure-explorer-common/pom.xml
+++ b/Utils/azure-explorer-common/pom.xml
@@ -46,6 +46,22 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <failOnViolation>false</failOnViolation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/Utils/azuretools-core/pom.xml
+++ b/Utils/azuretools-core/pom.xml
@@ -65,6 +65,22 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <failOnViolation>false</failOnViolation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>


### PR DESCRIPTION
Enable for following modules, add `<failOnViolation>false</failOnViolation>` to unblock the build. 
- azuretools-core.
- azure-explorer-common.

Follow @wezhang 's suggestion to enable module by module. 