### PR TITLE
Rename jar artifact to app.jar for Linux Java SE web app

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/utils/Constant.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/container/utils/Constant.java
@@ -62,5 +62,4 @@ public class Constant {
     public static final String MESSAGE_DOCKER_HOST_INFO = "Current docker host: %s";
     public static final String MESSAGE_EXECUTE_DOCKER_RUN = "Executing Docker Run...";
     public static final String DOCKERFILE_ARTIFACT_PLACEHOLDER = "<artifact>";
-    public static final String LINUX_JAVA_SE_RUNTIME = "JAVA|8-jre8";
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/Constants.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/Constants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.microsoft.intellij.runner.webapp;
+
+public class Constants {
+    public static final String LINUX_JAVA_SE_RUNTIME = "JAVA|8-jre8";
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
@@ -36,6 +36,7 @@ import com.microsoft.azuretools.utils.AzureUIRefreshEvent;
 import com.microsoft.azuretools.utils.WebAppUtils;
 import com.microsoft.intellij.runner.AzureRunProfileState;
 import com.microsoft.intellij.runner.RunProcessHandler;
+import com.microsoft.intellij.runner.container.utils.Constant;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
 import java.io.File;
 import java.io.FileInputStream;
@@ -225,8 +226,9 @@ public class WebAppRunState extends AzureRunProfileState<WebApp> {
                                   @NotNull RunProcessHandler processHandler,
                                   @NotNull Map<String, String> telemetryMap) throws Exception {
         final File targetZipFile = File.createTempFile(TEMP_FILE_PREFIX, ".zip");
-        // todo: Java SE web app needs the artifact named app.jar
-        final String artifactName = "ROOT.jar";
+        // Java SE web app needs the artifact named app.jar
+        final String artifactName = Constant.LINUX_JAVA_SE_RUNTIME.equalsIgnoreCase(webApp.linuxFxVersion())
+            ? "app.jar" : "ROOT.jar";
         final File jarArtifact = prepareJarArtifact(fileName, artifactName);
 
         final File[] files;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
@@ -22,12 +22,26 @@
 
 package com.microsoft.intellij.runner.webapp.webappconfig;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Map;
+
+import org.apache.commons.net.ftp.FTPClient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.idea.maven.model.MavenConstants;
+
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Comparing;
 import com.microsoft.azure.management.appservice.OperatingSystem;
 import com.microsoft.azure.management.appservice.PublishingProfile;
 import com.microsoft.azure.management.appservice.WebApp;
+import com.microsoft.azuretools.Constants;
 import com.microsoft.azuretools.azurecommons.util.FileUtil;
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.azuretools.core.mvp.model.webapp.WebAppSettingModel;
@@ -36,19 +50,7 @@ import com.microsoft.azuretools.utils.AzureUIRefreshEvent;
 import com.microsoft.azuretools.utils.WebAppUtils;
 import com.microsoft.intellij.runner.AzureRunProfileState;
 import com.microsoft.intellij.runner.RunProcessHandler;
-import com.microsoft.intellij.runner.container.utils.Constant;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.util.Map;
-import org.apache.commons.net.ftp.FTPClient;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.idea.maven.model.MavenConstants;
 
 public class WebAppRunState extends AzureRunProfileState<WebApp> {
 
@@ -227,7 +229,7 @@ public class WebAppRunState extends AzureRunProfileState<WebApp> {
                                   @NotNull Map<String, String> telemetryMap) throws Exception {
         final File targetZipFile = File.createTempFile(TEMP_FILE_PREFIX, ".zip");
         // Java SE web app needs the artifact named app.jar
-        final String artifactName = Constant.LINUX_JAVA_SE_RUNTIME.equalsIgnoreCase(webApp.linuxFxVersion())
+        final String artifactName = Constants.LINUX_JAVA_SE_RUNTIME.equalsIgnoreCase(webApp.linuxFxVersion())
             ? "app.jar" : "ROOT.jar";
         final File jarArtifact = prepareJarArtifact(fileName, artifactName);
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
@@ -41,7 +41,6 @@ import com.intellij.openapi.util.Comparing;
 import com.microsoft.azure.management.appservice.OperatingSystem;
 import com.microsoft.azure.management.appservice.PublishingProfile;
 import com.microsoft.azure.management.appservice.WebApp;
-import com.microsoft.azuretools.Constants;
 import com.microsoft.azuretools.azurecommons.util.FileUtil;
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.azuretools.core.mvp.model.webapp.WebAppSettingModel;
@@ -50,6 +49,7 @@ import com.microsoft.azuretools.utils.AzureUIRefreshEvent;
 import com.microsoft.azuretools.utils.WebAppUtils;
 import com.microsoft.intellij.runner.AzureRunProfileState;
 import com.microsoft.intellij.runner.RunProcessHandler;
+import com.microsoft.intellij.runner.webapp.Constants;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
 
 public class WebAppRunState extends AzureRunProfileState<WebApp> {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
@@ -64,12 +64,12 @@ import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.resources.Location;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.azure.management.resources.Subscription;
+import com.microsoft.azuretools.Constants;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.core.mvp.model.ResourceEx;
 import com.microsoft.azuretools.core.mvp.model.webapp.JdkModel;
 import com.microsoft.azuretools.utils.WebAppUtils;
 import com.microsoft.intellij.runner.AzureSettingPanel;
-import com.microsoft.intellij.runner.container.utils.Constant;
 import com.microsoft.intellij.runner.webapp.webappconfig.WebAppConfiguration;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
 
@@ -553,7 +553,7 @@ public class WebAppSettingPanel extends AzureSettingPanel<WebAppConfiguration> i
         if (rdoUseExist.isSelected()) {
             final WebApp app = selectedWebApp.getResource();
             return app.operatingSystem() == OperatingSystem.WINDOWS ||
-                !Constant.LINUX_JAVA_SE_RUNTIME.equalsIgnoreCase(app.linuxFxVersion());
+                !Constants.LINUX_JAVA_SE_RUNTIME.equalsIgnoreCase(app.linuxFxVersion());
         }
 
         return rdoWindowsOS.isSelected() ||

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
@@ -64,12 +64,12 @@ import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.resources.Location;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.azure.management.resources.Subscription;
-import com.microsoft.azuretools.Constants;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.core.mvp.model.ResourceEx;
 import com.microsoft.azuretools.core.mvp.model.webapp.JdkModel;
 import com.microsoft.azuretools.utils.WebAppUtils;
 import com.microsoft.intellij.runner.AzureSettingPanel;
+import com.microsoft.intellij.runner.webapp.Constants;
 import com.microsoft.intellij.runner.webapp.webappconfig.WebAppConfiguration;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
 

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/Constants.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/Constants.java
@@ -22,9 +22,6 @@
 
 package com.microsoft.azuretools;
 
-/**
- * Created by vlashch on 8/18/16.
- */
 public class Constants {
     public static String resourceVault = "https://vault.azure.net";
 
@@ -32,5 +29,4 @@ public class Constants {
     public static String clientId = "61d65f5a-6e3b-468b-af73-a033f5098c5c";
     public static String redirectUri = "https://msopentech.com/";
     public static int connection_read_timeout_ms = 10000;
-    public static final String LINUX_JAVA_SE_RUNTIME = "JAVA|8-jre8";
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/Constants.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/Constants.java
@@ -32,4 +32,5 @@ public class Constants {
     public static String clientId = "61d65f5a-6e3b-468b-af73-a033f5098c5c";
     public static String redirectUri = "https://msopentech.com/";
     public static int connection_read_timeout_ms = 10000;
+    public static final String LINUX_JAVA_SE_RUNTIME = "JAVA|8-jre8";
 }


### PR DESCRIPTION
Linux Java SE web app requires the artifact to be named as `app.jar` to run.