### PR TITLE
Ensure kotlin-maven-plugin execute before maven-compiler-plugin

### DIFF
--- a/Utils/hdinsight-node-common/pom.xml
+++ b/Utils/hdinsight-node-common/pom.xml
@@ -162,8 +162,17 @@
                 <executions>
                     <!-- Replacing default-testCompile as it is treated specially by maven -->
                     <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
                         <id>default-testCompile</id>
                         <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals> <goal>compile</goal> </goals>
                     </execution>
                     <execution>
                         <id>java-test-compile</id>


### PR DESCRIPTION
Refer to [this post](https://www.baeldung.com/kotlin-maven-java-project)
> Frequently, Maven plugins executions happen according to the declaration order. So we should place maven-compiler-plugin after kotlin-maven-plugin. But the former has two specific executions that are executed before everything else during the phases: default-compile and default-testCompile.
We need to disable them and enable java-compile and java-test-compile instead to ensure that kotlin-maven-plugin execution will happen before maven-compiler-plugin:

