### PR TITLE
Use stack and version instead of RuntimeStack in web app configuration

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppConfiguration.java
@@ -22,6 +22,11 @@
 
 package com.microsoft.intellij.runner.webapp.webappconfig;
 
+import java.io.IOException;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.ConfigurationFactory;
@@ -38,11 +43,6 @@ import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.azurecommons.util.Utils;
 import com.microsoft.azuretools.core.mvp.model.webapp.WebAppSettingModel;
 import com.microsoft.intellij.runner.AzureRunConfigurationBase;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.io.IOException;
 
 public class WebAppConfiguration extends AzureRunConfigurationBase<WebAppSettingModel> {
 
@@ -254,16 +254,20 @@ public class WebAppConfiguration extends AzureRunConfigurationBase<WebAppSetting
         return webAppSettingModel.getOS();
     }
 
-    public RuntimeStack getLinuxRuntime() {
-        return webAppSettingModel.getLinuxRuntime();
-    }
-
     public void setOS(OperatingSystem value) {
         webAppSettingModel.setOS(value);
     }
 
-    public void setLinuxRuntime(RuntimeStack value) {
-        webAppSettingModel.setLinuxRuntime(value);
+    public void setStack(String value) {
+        webAppSettingModel.setStack(value);
+    }
+
+    public void setVersion(String value) {
+        webAppSettingModel.setVersion(value);
+    }
+
+    public RuntimeStack getLinuxRuntime() {
+        return webAppSettingModel.getLinuxRuntime();
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/ui/WebAppSettingPanel.java
@@ -450,7 +450,8 @@ public class WebAppSettingPanel extends AzureSettingPanel<WebAppConfiguration> i
                 webAppConfiguration.setOS(OperatingSystem.LINUX);
                 RuntimeStack linuxRuntime = (RuntimeStack)cbLinuxRuntime.getSelectedItem();
                 if (linuxRuntime != null) {
-                    webAppConfiguration.setLinuxRuntime(linuxRuntime);
+                    webAppConfiguration.setStack(linuxRuntime.stack());
+                    webAppConfiguration.setVersion(linuxRuntime.version());
                 }
             }
             if (rdoWindowsOS.isSelected()) {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/WebAppSettingModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/WebAppSettingModel.java
@@ -50,7 +50,9 @@ public class WebAppSettingModel {
     private String region = "";
     private String pricing = "";
     private JavaVersion jdkVersion = JavaVersion.JAVA_8_NEWEST;
-    private RuntimeStack linuxRuntime = RuntimeStack.TOMCAT_8_5_JRE8;
+    private String stack = "TOMCAT";
+    private String version = "8.5-jre8";
+
     private OperatingSystem os = OperatingSystem.LINUX;
 
     public String getWebAppId() {
@@ -181,12 +183,24 @@ public class WebAppSettingModel {
         this.jdkVersion = jdkVersion;
     }
 
-    public RuntimeStack getLinuxRuntime() {
-        return linuxRuntime;
+    public String getStack() {
+        return this.stack;
     }
 
-    public void setLinuxRuntime(final RuntimeStack value) {
-        this.linuxRuntime = value;
+    public void setStack(final String value) {
+        this.stack = value;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public void setVersion(final String value) {
+        this.version = value;
+    }
+
+    public RuntimeStack getLinuxRuntime() {
+        return new RuntimeStack(this.stack, this.version);
     }
 
     public OperatingSystem getOS() {


### PR DESCRIPTION
Fix issue #2024  
`RuntimeStack` has no default constructor and it causes an exception when deserializing the configuration.
Use `stack` and `version` of `RuntimeStack` instead and create a new `RuntimeStack` instance by the values.