### PR TITLE
Revert "Remove the reflection invoking for Spark Runconfig producer after IDEA 2018"

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobLocalRunConfigurationProducer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobLocalRunConfigurationProducer.java
@@ -33,7 +33,6 @@ import com.intellij.execution.configurations.ConfigurationUtil;
 import com.intellij.execution.junit.JavaRunConfigurationProducerBase;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.TestSourcesFilter;
 import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -68,9 +67,7 @@ public class SparkBatchJobLocalRunConfigurationProducer extends JavaRunConfigura
         return Optional.ofNullable(context.getModule())
                 .map(Module::getProject)
                 .flatMap(project -> getMainClassFromContext(context)
-                                        .filter(mcPair -> isSparkContext(project, mcPair.getKey().getContainingFile()))
-                                        .filter(mcPair -> !TestSourcesFilter.isTestSources(
-                                                mcPair.getKey().getContainingFile().getVirtualFile(), project)))
+                                        .filter(mcPair -> isSparkContext(project, mcPair.getKey().getContainingFile())))
                 .map(mcPair -> {
                     setupConfiguration(configuration, mcPair.getValue(), context);
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobLocalRunConfigurationProducer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobLocalRunConfigurationProducer.java
@@ -48,14 +48,15 @@ import com.microsoft.azure.hdinsight.spark.common.SparkBatchJobConfigurableModel
 import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfiguration;
 import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfigurationType;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.plugins.scala.runner.ScalaMainMethodUtil;
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition;
 import scala.Option;
 import scala.Tuple2;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 
 public class SparkBatchJobLocalRunConfigurationProducer extends JavaRunConfigurationProducerBase<RemoteDebugRunConfiguration> {
     public SparkBatchJobLocalRunConfigurationProducer() {
@@ -135,15 +136,45 @@ public class SparkBatchJobLocalRunConfigurationProducer extends JavaRunConfigura
 
     private static Optional<SimpleImmutableEntry<PsiElement, PsiClass>> findJavaMainClass(PsiElement element) {
         return Optional.ofNullable(ApplicationConfigurationType.getMainClass(element))
-                .map(clazz -> new SimpleImmutableEntry<>(clazz, clazz));
+                .map(clazz -> new SimpleImmutableEntry<PsiElement, PsiClass>(clazz, clazz));
     }
 
     private static Optional<SimpleImmutableEntry<PsiElement, PsiClass>> findScalaMainClass(PsiElement element) {
-        Option<Tuple2<PsiClass, PsiElement>> ceOption = ScalaMainMethodUtil.findMainClassAndSourceElem(element);
+        // TODO: Replace with the following code after IDEA 2018.1
+        // Option<Tuple2<PsiClass, PsiElement>> ceOption = ScalaMainMethodUtil.findMainClassAndSourceElem(element);
+        try {
+            // Added from IDEA 2017.2
+            Method findMainClassAndSourceElemMethod = Class
+                    .forName("org.jetbrains.plugins.scala.runner.ScalaMainMethodUtil")
+                    .getDeclaredMethod("findMainClassAndSourceElem", PsiElement.class);
 
-        return ceOption.isDefined() ?
-                Optional.of(new SimpleImmutableEntry<>(ceOption.get()._1(), ceOption.get()._1())) :
-                Optional.empty();
+            Option<Tuple2<PsiClass, PsiElement>> ceOption =
+                    (Option<Tuple2<PsiClass, PsiElement>>) findMainClassAndSourceElemMethod.invoke(null, element);
+
+            return ceOption.isDefined() ?
+                    Optional.of(new SimpleImmutableEntry<>(ceOption.get()._1(), ceOption.get()._1())) :
+                    Optional.empty();
+        } catch (NoSuchMethodException ignored) {
+            // Use old one for IDEA 2017.1
+            try {
+                Method findContainingMainMethod = Class
+                        .forName("org.jetbrains.plugins.scala.runner.ScalaMainMethodUtil")
+                        .getDeclaredMethod("findContainingMainMethod", PsiElement.class);
+
+                Option<ScFunctionDefinition> funDefOption =
+                        (Option<ScFunctionDefinition>) findContainingMainMethod.invoke(null, element);
+
+                return funDefOption.isDefined() ?
+                        Optional.of(new SimpleImmutableEntry<PsiElement, PsiClass>(
+                                funDefOption.get().containingClass(),
+                                funDefOption.get().containingClass())) :
+                        Optional.empty();
+            } catch (Exception ignore) {
+                return Optional.empty();
+            }
+        } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException ignored) {
+            return Optional.empty();
+        }
     }
 
     private static Optional<SimpleImmutableEntry<PsiElement, PsiClass>> getMainClassFromContext(ConfigurationContext context) {
@@ -151,7 +182,7 @@ public class SparkBatchJobLocalRunConfigurationProducer extends JavaRunConfigura
 
         return location
                 .map(JavaExecutionUtil::stepIntoSingleClass)
-                .map((Function<Location, PsiElement>) Location::getPsiElement)
+                .map(Location::getPsiElement)
                 .filter(PsiElement::isPhysical)
                 .flatMap(element -> {
                     Optional<SimpleImmutableEntry<PsiElement, PsiClass>> mcPair = findMainMethod(element);


### PR DESCRIPTION
Reverts Microsoft/azure-tools-for-java#1878

Address #2033