### PR TITLE
Sleep 5 seconds for each retry in zip deploy

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
@@ -265,6 +265,7 @@ public class WebAppRunState extends AzureRunProfileState<WebApp> {
     }
 
     // Add retry logic here to avoid Kudu's socket timeout issue.
+    // For each try, the method will wait 5 seconds.
     // More details: https://github.com/Microsoft/azure-maven-plugins/issues/339
     private int uploadFileViaZipDeploy(@NotNull WebApp webapp, @NotNull File zipFile,
                                        @NotNull RunProcessHandler processHandler) throws Exception {
@@ -272,6 +273,7 @@ public class WebAppRunState extends AzureRunProfileState<WebApp> {
         while (uploadCount < UPLOADING_MAX_TRY) {
             uploadCount += 1;
             try {
+                Thread.sleep(SLEEP_TIME);
                 webapp.zipDeploy(zipFile);
                 processHandler.setText(UPLOADING_SUCCESSFUL);
                 return uploadCount;


### PR DESCRIPTION
Follow the FTP deploy, sleep 5 seconds for each retry in zip deploy to give more time for the new created web app to warm up.