### PR TITLE
Update jar file name in web.config

### DIFF
--- a/Utils/azuretools-core/resources/webapp/web.config
+++ b/Utils/azuretools-core/resources/webapp/web.config
@@ -5,7 +5,7 @@
       <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
     </handlers>
     <httpPlatform processPath="%JAVA_HOME%\bin\java.exe"
-        arguments="-Djava.net.preferIPv4Stack=true -Dserver.port=%HTTP_PLATFORM_PORT% -jar &quot;%HOME%\site\wwwroot\ROOT.jar&quot;">
+        arguments="-Djava.net.preferIPv4Stack=true -Dserver.port=%HTTP_PLATFORM_PORT% -jar &quot;%HOME%\site\wwwroot\app.jar&quot;">
     </httpPlatform>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
 When workaround issue https://github.com/Microsoft/azure-tools-for-java/issues/2042, We renamed the `ROOT.jar` to `app.jar`, we also need to update the jar file name in web.config to make it work.