### PR TITLE
Disable building Eclipse plugin to speed up CI jobs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ jdk:
 before_install:
 - export MAVEN_OPTS="-Xmx768M"
 script:
-- travis_wait 40 ./BuildDevint -q
+- travis_wait 40 ./BuildDevint -q -e eclipse

--- a/BuildDevint
+++ b/BuildDevint
@@ -7,12 +7,21 @@ cd "$SCRIPTPATH"
 
 MAVEN_QUIET=""
 INTELLIJ_VERSION=false
+BUILD_ECLIPSE=true
+BUILD_INTELLIJ=true
 
-while getopts ":hqv" option; do
+while getopts "hqve:" option; do
+  echo $option
     case $option in
-        h) echo "usage: $0 [-h] [-q] [-v]"; exit ;;
+        h) echo "usage: $0 [-h] [-q] [-v] [-e eclipse/intellij]"; exit ;;
         q) MAVEN_QUIET="-q" ;;
         v) INTELLIJ_VERSION=true ;;
+        e)
+          shopt -s nocasematch
+          case $OPTARG in 
+            eclipse) BUILD_ECLIPSE=false ;;
+            intellij) BUILD_INTELLIJ=false ;;
+          esac ;;
         ?) echo "error: option -$OPTARG is not implemented"; exit ;;
     esac
 done
@@ -28,30 +37,38 @@ fi
 set -x
 
 # Build Utils
+echo "Building Utils ..."
 mvn install -f $SCRIPTPATH/Utils/pom.xml -Dmaven.repo.local=$SCRIPTPATH/.repository $MAVEN_QUIET
 mvn install -f $SCRIPTPATH/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml -Dmaven.repo.local=$SCRIPTPATH/.repository $MAVEN_QUIET
 
-# # Build eclipse plugin
-mvn clean install -f $SCRIPTPATH/PluginsAndFeatures/azure-toolkit-for-eclipse/pom.xml $MAVEN_QUIET
-cp ./PluginsAndFeatures/azure-toolkit-for-eclipse/WindowsAzurePlugin4EJ/target/WindowsAzurePlugin4EJ*.zip ./$ARTIFACTS_DIR/WindowsAzurePlugin4EJ.zip
-
-chmod +x ./tools/IntellijVersionHelper
-
-# Build intellij 2018.1 plugin
-if [ $INTELLIJ_VERSION == "true" ] ; then
-    ./tools/IntellijVersionHelper 2018.1
+# Build Eclipse plugin
+if $BUILD_ECLIPSE; then
+  echo "Building Eclipse plugin ..."
+  mvn clean install -f $SCRIPTPATH/PluginsAndFeatures/azure-toolkit-for-eclipse/pom.xml $MAVEN_QUIET
+  cp ./PluginsAndFeatures/azure-toolkit-for-eclipse/WindowsAzurePlugin4EJ/target/WindowsAzurePlugin4EJ*.zip ./$ARTIFACTS_DIR/WindowsAzurePlugin4EJ.zip
 fi
 
-(cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s -Pintellij_version=IC-2018.1 -Pdep_plugins=org.intellij.scala:2018.1.8)
+# Build IntelliJ plugin
+if $BUILD_INTELLIJ; then
+  echo "Building IntelliJ plugin ..."
+  chmod +x ./tools/IntellijVersionHelper
+  ## Build intellij 2018.1 plugin
+  if [ $INTELLIJ_VERSION == "true" ] ; then
+      ./tools/IntellijVersionHelper 2018.1
+  fi
 
-cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.1.zip
+  (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s -Pintellij_version=IC-2018.1 -Pdep_plugins=org.intellij.scala:2018.1.8)
 
-# Build intellij 2018.2 compatible plugin
-if [ $INTELLIJ_VERSION == "true" ] ; then
-    ./tools/IntellijVersionHelper 2018.2
+  cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.1.zip
+
+  ## Build intellij 2018.2 compatible plugin
+  if [ $INTELLIJ_VERSION == "true" ] ; then
+      ./tools/IntellijVersionHelper 2018.2
+  fi
+
+  (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s)
+
+  cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.2.zip
 fi
 
-(cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s)
-
-cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.2.zip
 echo "ALL BUILD SUCCESSFUL"


### PR DESCRIPTION
Currently we are focusing on IntelliJ IDEA, so we'd like to disable it for Eclipse to save time. 

Eclipse plugin will still be built in daily job, so we will be notified if there's any failure.