### PR TITLE
Keep application insights dependencies version to fix regression

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     compile 'com.microsoft.sqlserver:mssql-jdbc:6.1.0.jre8'
     compile 'commons-io:commons-io:2.5'
     compile 'net.minidev:json-smart:2.3'
+    compile 'com.microsoft.azure:applicationinsights-web:2.1.2'
     compile 'com.microsoft.azure:azure-client-runtime:1.6.2', { force = true }
     compile 'com.microsoft.azure:azure-client-authentication:1.6.2', { force = true }
     compile 'com.microsoft.azuretools:azuretools-core:3.12.0', {

--- a/Utils/azuretools-core/pom.xml
+++ b/Utils/azuretools-core/pom.xml
@@ -162,6 +162,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>applicationinsights-web</artifactId>
+            <version>2.1.2</version>
         </dependency>
         <dependency>
             <groupId>eu.infomas</groupId>


### PR DESCRIPTION
After upgrade Azure SDK to v1.16.0, the `com.microsoft.azure:applicationinsights-web` are upgraded to v2.2.0 and it causes regression #2122.

Issue https://github.com/Microsoft/ApplicationInsights-Java/issues/755 was created in their side to track the issue. Now we keep using the 2.1.2 as our workaround.
