### PR TITLE
Add workaround for application insights sdk regression

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/com/microsoft/intellij/ui/messages/messages.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/com/microsoft/intellij/ui/messages/messages.properties
@@ -1198,10 +1198,13 @@ saveErrMsg=Error occurred while saving configuration files
 fileCrtErrMsg=Error occurred while creating web.xml
 fileErrMsg= file does not exists.
 exprFltMapping=/web-app/filter-mapping[filter-name/text()='ACSAuthFilter']
+exprListener=/web-app/listener[listener-class/text()='com.microsoft.applicationinsights.web.internal.ApplicationInsightsServletContextListener']
 filterTag=filter
 filterMapTag=filter-mapping
+listenerTag=listener
 urlPatternTag=url-pattern
 filterEle=filter-name
+listenerClassEle=listener-class
 initPar=init-param
 parName=param-name
 parVal=param-value
@@ -1250,6 +1253,7 @@ AIPrivacy=About Data in Application Insights
 lnkInstrumentationKey=http://go.microsoft.com/fwlink/?LinkId=526877
 lnkAIPrivacy=http://go.microsoft.com/fwlink/?LinkId=526878
 aiWebfilter=ApplicationInsightsWebFilter
+aiServletContextListener=com.microsoft.applicationinsights.web.internal.ApplicationInsightsServletContextListener
 aiWebFilterClassName=com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter
 aiErrTitle=Application Insights configuration error
 aiInstrumentationKeyNull=Instrumentation Key is empty

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/libraries/AILibraryHandler.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/libraries/AILibraryHandler.java
@@ -123,6 +123,34 @@ public class AILibraryHandler {
     }
 
     /**
+     * This method add a servlet context listener in web.xml.
+     */
+    public void setAIServletContextListener() {
+        if (webXMLDoc == null) {
+            return;
+        }
+        try {
+            final XPath xpath = XPathFactory.newInstance().newXPath();
+            final Element eleListenerMapping = (Element) xpath.evaluate(message("exprListener"), webXMLDoc, XPathConstants.NODE);
+            if (eleListenerMapping == null) {
+                final Element listenerMapping = webXMLDoc.createElement(message("listenerTag"));
+                final Element listenerName = webXMLDoc.createElement(message("listenerClassEle"));
+                listenerName.setTextContent(message("aiServletContextListener"));
+                listenerMapping.appendChild(listenerName);
+
+                final NodeList existingListenerNodeList = webXMLDoc.getElementsByTagName(message("listenerTag"));
+                final Node existingListenerNode = existingListenerNodeList != null
+                    && existingListenerNodeList.getLength() > 0
+                    ? existingListenerNodeList.item(0) : null;
+
+                webXMLDoc.getDocumentElement().insertBefore(listenerMapping, existingListenerNode);
+            }
+        } catch (Exception ex) {
+            AzurePlugin.log(ex.getMessage(), ex);
+        }
+    }
+
+    /**
      * This method adds filter mapping tags in web.xml.
      */
     private void setFilterMapping() {
@@ -206,6 +234,24 @@ public class AILibraryHandler {
             }
 
         } catch (Exception ex) {
+            ex.printStackTrace();
+            AzurePlugin.log(ex.getMessage(), ex);
+            throw new Exception(String.format("%s%s", message("aiRemoveErr"), ex.getMessage()));
+        }
+    }
+
+    public void removeAIServletContextListener() throws Exception {
+        if (webXMLDoc == null) {
+            return;
+        }
+        try {
+            final XPath xpath = XPathFactory.newInstance().newXPath();
+            final String exprListener = message("exprListener");
+            final Element eleListener = (Element) xpath.evaluate(exprListener, webXMLDoc, XPathConstants.NODE);
+            if (eleListener != null) {
+                eleListener.getParentNode().removeChild(eleListener);
+            }
+        } catch(Exception ex) {
             ex.printStackTrace();
             AzurePlugin.log(ex.getMessage(), ex);
             throw new Exception(String.format("%s%s", message("aiRemoveErr"), ex.getMessage()));

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/libraries/ApplicationInsightsPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/libraries/ApplicationInsightsPanel.java
@@ -193,6 +193,7 @@ public class ApplicationInsightsPanel implements AzureAbstractPanel {
             try {
                 handler.disableAIFilterConfiguration(true);
                 handler.removeAIFilterDef();
+                handler.removeAIServletContextListener();
                 handler.save();
             } catch (Exception e) {
                 PluginUtil.displayErrorDialog(message("aiErrTitle"), message("aiConfigRemoveError") + e.getLocalizedMessage());
@@ -253,6 +254,11 @@ public class ApplicationInsightsPanel implements AzureAbstractPanel {
         if (new File(xmlPath).exists()) {
             handler.parseWebXmlPath(xmlPath);
             handler.setAIFilterConfig();
+
+            // workaround for application insights v2.2.0 regression:
+            // An exception occurred when stop the tomcat application with application insights configured.
+            // Issue was logged to track: https://github.com/Microsoft/ApplicationInsights-Java/issues/755
+            handler.setAIServletContextListener();
         } else { // create web.xml
             int choice = Messages.showYesNoDialog(message("depDescMsg"), message("depDescTtl"), Messages.getQuestionIcon());
             if (choice == Messages.YES) {


### PR DESCRIPTION
After upgrade Azure SDK to v1.16.0, the com.microsoft.azure:applicationinsights-web are upgraded to v2.2.0 and it causes regression #2122.

Issue Microsoft/ApplicationInsights-Java#755 was created in their side to track the issue. Now we use the proposal by application insights SDK team to work around the issue.