### PR TITLE
Fix the filter element not removed issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/com/microsoft/intellij/ui/messages/messages.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/com/microsoft/intellij/ui/messages/messages.properties
@@ -1197,7 +1197,7 @@ acsErrTtl=Deployment Descriptor Error
 saveErrMsg=Error occurred while saving configuration files
 fileCrtErrMsg=Error occurred while creating web.xml
 fileErrMsg= file does not exists.
-exprFltMapping=/web-app/filter-mapping[filter-name/text()='ACSAuthFilter']
+exprFltMapping=/web-app/filter-mapping[filter-name/text()='ApplicationInsightsWebFilter']
 filterTag=filter
 filterMapTag=filter-mapping
 urlPatternTag=url-pattern


### PR DESCRIPTION
Fix issue #2143 

The text of `filter-name` is incorrect, which cause the `filter` element is not removed when disabling the telemetry with application insights.