### PR TITLE
Improve user experience of the survey notification. 

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -281,6 +281,7 @@
     <action id="AzureToolkit.AzureSignIn" class="com.microsoft.azuretools.ijidea.actions.AzureSignInAction" text="Azure Sign In..." />
     <action id="AzureToolkit.SelectSubscriptions" class="com.microsoft.azuretools.ijidea.actions.SelectSubscriptionsAction" text="Select Subscriptions..."
             description="ShowSubscriptionsAction" />
+    <action class="com.microsoft.azuretools.ijidea.actions.GithubSurveyAction" id="AzureToolkit.Survey" text="Provide Feedback..." />
     <action id="Actions.WebDeployAction" class="com.microsoft.intellij.actions.WebDeployAction"
             text="Run on Web App" description="Run on Web App"
             icon="/icons/PublishWebApp_16.png">
@@ -360,6 +361,8 @@
       <reference ref="AzureToolkit.SelectSubscriptions"/>
       <separator/>
       <reference ref="AzureToolkit.AzureSignIn"/>
+      <separator/>
+      <reference ref="AzureToolkit.Survey"/>
     </group>
 
     <group id="SparkConsoleGroup" text="Spark Console" description="Spark Console" popup="true">

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/GithubSurveyAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/GithubSurveyAction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azuretools.ijidea.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
+import com.microsoft.intellij.feedback.GithubIssue;
+import com.microsoft.intellij.feedback.ReportableSurvey;
+
+
+public class GithubSurveyAction extends AzureAnAction {
+    public GithubSurveyAction() {
+        super("user satisfaction survey");
+    }
+
+    @Override
+    public void onActionPerformed(AnActionEvent anActionEvent) {
+        new GithubIssue<>(new ReportableSurvey("User feedback")).withLabel("Feedback").report();
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzurePlugin.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzurePlugin.java
@@ -94,6 +94,8 @@ public class AzurePlugin extends AbstractProjectComponent {
 
     private String _hashmac = GetHashMac.GetHashMac();
 
+    private Boolean firstInstallationByVersion;
+
     public AzurePlugin(Project project) {
         super(project);
         this.azureSettings = AzureSettings.getSafeInstance(project);
@@ -108,6 +110,10 @@ public class AzurePlugin extends AbstractProjectComponent {
     }
 
     private void initializeFeedbackNotification() {
+        if (!isFirstInstallationByVersion()) {
+            return;
+        }
+
         Notification feedbackNotification = new Notification(
                 "Azure Toolkit plugin",
                 "We're listening",
@@ -131,6 +137,7 @@ public class AzurePlugin extends AbstractProjectComponent {
     public void initComponent() {
         if (!IS_ANDROID_STUDIO) {
             LOG.info("Starting Azure Plugin");
+            firstInstallationByVersion = new Boolean(isFirstInstallationByVersion());
             try {
                 //this code is for copying componentset.xml in plugins folder
                 copyPluginComponents();
@@ -373,6 +380,10 @@ public class AzurePlugin extends AbstractProjectComponent {
     private static final String HTML_ZIP_FILE_NAME = "/hdinsight_jobview_html.zip";
 
     private boolean isFirstInstallationByVersion() {
+        if (firstInstallationByVersion != null) {
+            return firstInstallationByVersion.booleanValue();
+        }
+
         if (new File(dataFile).exists()) {
             String version = DataOperations.getProperty(dataFile, message("pluginVersion"));
             if (!StringHelper.isNullOrWhiteSpace(version) && version.equals(PLUGIN_VERSION)) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzurePlugin.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzurePlugin.java
@@ -43,13 +43,11 @@ import com.microsoft.azuretools.azurecommons.deploy.DeploymentEventListener;
 import com.microsoft.azuretools.azurecommons.helpers.StringHelper;
 import com.microsoft.azuretools.azurecommons.util.*;
 import com.microsoft.azuretools.azurecommons.xmlhandling.DataOperations;
+import com.microsoft.azuretools.ijidea.actions.GithubSurveyAction;
 import com.microsoft.azuretools.telemetry.AppInsightsClient;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
 import com.microsoft.azuretools.utils.TelemetryUtils;
 import com.microsoft.intellij.common.CommonConst;
-import com.microsoft.intellij.feedback.GithubIssue;
-import com.microsoft.intellij.feedback.NewGithubIssueAction;
-import com.microsoft.intellij.feedback.ReportableSurvey;
 import com.microsoft.intellij.ui.libraries.AILibraryHandler;
 import com.microsoft.intellij.ui.libraries.AzureLibrary;
 import com.microsoft.intellij.ui.messages.AzureBundle;
@@ -116,9 +114,7 @@ public class AzurePlugin extends AbstractProjectComponent {
                 "Thanks for helping Microsoft improve Azure Toolkit experience!\nYour feedback is important. Please take a minute to fill out our",
                 NotificationType.INFORMATION);
 
-        feedbackNotification.addAction(new NewGithubIssueAction(
-                        new GithubIssue<>(new ReportableSurvey("User feedback")).withLabel("Feedback"),
-                        "user satisfaction survey"));
+        feedbackNotification.addAction(new GithubSurveyAction());
 
         Observable.timer(30, TimeUnit.SECONDS)
                 .take(1)


### PR DESCRIPTION
Previously the survey notification occurs whenever a project is open, which is complained by users in #1840 #1871 #2142 

This PR includes these changes:
* Change the survey notification to a one-time thing, it only pops up once the plugin is upgraded to a new version. 
* Add an entry in Tools menu for the survey, users can are able to provide feedback if they want to. 

![image](https://user-images.githubusercontent.com/2351748/46642413-ad2b2e80-cba9-11e8-9a60-8f589b97f625.png)

