### PR TITLE
Handle exception when deleting web app

### DIFF
--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppModule.java
@@ -24,6 +24,7 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
 
 import java.io.IOException;
 
+import com.microsoft.azure.CloudException;
 import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
@@ -67,7 +68,7 @@ public class WebAppModule extends AzureRefreshableNode implements WebAppModuleVi
         try {
             webAppModulePresenter.onDeleteWebApp(sid, id);
             removeDirectChildNode(node);
-        } catch (Exception e) {
+        } catch (IOException | CloudException e) {
             DefaultLoader.getUIHelper().showException("An error occurred while attempting to delete the Web App ",
                     e, "Azure Services Explorer - Error Deleting Web App for Containers", false, true);
         }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppModule.java
@@ -67,7 +67,7 @@ public class WebAppModule extends AzureRefreshableNode implements WebAppModuleVi
         try {
             webAppModulePresenter.onDeleteWebApp(sid, id);
             removeDirectChildNode(node);
-        } catch (IOException e) {
+        } catch (Exception e) {
             DefaultLoader.getUIHelper().showException("An error occurred while attempting to delete the Web App ",
                     e, "Azure Services Explorer - Error Deleting Web App for Containers", false, true);
         }


### PR DESCRIPTION
A `CloudException` might occur when deleting a web app, we should handle this kind of exception too. Update the caught exception type to generic `Exception` to handle the exceptions during deleting a web app.