### PR TITLE
Move shared logic of web app and slot to abstract parent class

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
@@ -36,6 +36,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.table.DefaultTableModel;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.ActionToolbarPosition;
@@ -60,14 +61,13 @@ import com.microsoft.intellij.ui.components.AzureActionListenerWrapper;
 import com.microsoft.intellij.ui.util.UIUtils;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyMvpView;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
 public class WebAppPropertyView extends BaseEditor implements WebAppPropertyMvpView {
 
     public static final String ID = "com.microsoft.intellij.helpers.webapp.WebAppPropertyView";
 
-    private final WebAppPropertyViewPresenter<WebAppPropertyView> presenter;
-    private final String sid;
-    private final String resId;
+    private final WebAppBasePropertyViewPresenter presenter;
     private final Map<String, String> cachedAppSettings;
     private final Map<String, String> editedAppSettings;
     private final StatusBar statusBar;
@@ -118,20 +118,22 @@ public class WebAppPropertyView extends BaseEditor implements WebAppPropertyMvpV
     /**
      * Initialize the Web App Property View and return it.
      */
-    public static WebAppPropertyView create(@NotNull Project project, @NotNull String sid, @NotNull String resId) {
-        WebAppPropertyView view = new WebAppPropertyView(project, sid, resId);
-        view.onLoadWebAppProperty();
+    public static WebAppPropertyView create(@NotNull final Project project, @NotNull final String sid,
+                                            @NotNull final String webAppId, @Nullable final String name,
+                                            @NotNull final WebAppBasePropertyViewPresenter presenter) {
+        WebAppPropertyView view = new WebAppPropertyView(project, sid, webAppId, name, presenter);
+        view.onLoadWebAppProperty(sid, webAppId, name);
         return view;
     }
 
-    private WebAppPropertyView(@NotNull Project project, @NotNull String sid, @NotNull String resId) {
-        this.sid = sid;
-        this.resId = resId;
+    private WebAppPropertyView(@NotNull final Project project, @NotNull final String sid,
+                               @NotNull final String webAppId, @Nullable final String name,
+                               @NotNull final WebAppBasePropertyViewPresenter presenter) {
         cachedAppSettings = new LinkedHashMap<>();
         editedAppSettings = new LinkedHashMap<>();
         statusBar = WindowManager.getInstance().getStatusBar(project);
         $$$setupUI$$$(); // tell IntelliJ to call createUIComponents() here.
-        this.presenter = new WebAppPropertyViewPresenter<>();
+        this.presenter = presenter;
         this.presenter.onAttachView(this);
 
         // initialize widgets...
@@ -159,7 +161,7 @@ public class WebAppPropertyView extends BaseEditor implements WebAppPropertyMvpV
                 fileChooserDescriptor.setTitle(FILE_SELECTOR_TITLE);
                 final VirtualFile file = FileChooser.chooseFile(fileChooserDescriptor, null, null);
                 if (file != null) {
-                    presenter.onGetPublishingProfileXmlWithSecrets(sid, resId, file.getPath());
+                    presenter.onGetPublishingProfileXmlWithSecrets(sid, webAppId, name, file.getPath());
                 }
             }
         });
@@ -179,7 +181,7 @@ public class WebAppPropertyView extends BaseEditor implements WebAppPropertyMvpV
             @Override
             public void actionPerformedFunc(ActionEvent event) {
                 setBtnEnableStatus(false);
-                presenter.onUpdateWebAppProperty(sid, resId, cachedAppSettings, editedAppSettings);
+                presenter.onUpdateWebAppProperty(sid, webAppId, name, cachedAppSettings, editedAppSettings);
             }
         });
 
@@ -287,8 +289,8 @@ public class WebAppPropertyView extends BaseEditor implements WebAppPropertyMvpV
     }
 
     @Override
-    public void onLoadWebAppProperty() {
-        presenter.onLoadWebAppProperty(this.sid, this.resId);
+    public void onLoadWebAppProperty(final String sid, final String webAppId, final String name) {
+        presenter.onLoadWebAppProperty(sid, webAppId, name);
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyViewProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyViewProvider.java
@@ -30,6 +30,7 @@ import com.intellij.openapi.fileEditor.FileEditorProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.microsoft.intellij.helpers.UIHelperImpl;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
 
 public class WebAppPropertyViewProvider implements FileEditorProvider {
 
@@ -43,9 +44,10 @@ public class WebAppPropertyViewProvider implements FileEditorProvider {
     @NotNull
     @Override
     public FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile virtualFile) {
-        String sid = virtualFile.getUserData(UIHelperImpl.SUBSCRIPTION_ID);
-        String id = virtualFile.getUserData(UIHelperImpl.RESOURCE_ID);
-        return WebAppPropertyView.create(project, sid, id);
+        final String sid = virtualFile.getUserData(UIHelperImpl.SUBSCRIPTION_ID);
+        final String id = virtualFile.getUserData(UIHelperImpl.RESOURCE_ID);
+        final WebAppPropertyViewPresenter presenter = new WebAppPropertyViewPresenter();
+        return WebAppPropertyView.create(project, sid, id, null, presenter);
     }
 
     @NotNull

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyMvpView.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyMvpView.java
@@ -4,7 +4,7 @@ import com.microsoft.azuretools.core.mvp.ui.base.MvpView;
 import com.microsoft.azuretools.core.mvp.ui.webapp.WebAppProperty;
 
 public interface WebAppPropertyMvpView extends MvpView {
-    public void onLoadWebAppProperty();
+    public void onLoadWebAppProperty(String subscriptionId, String webAppId, String name);
 
     public void showProperty(WebAppProperty property);
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBasePropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBasePropertyViewPresenter.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.appservice.AppServicePlan;
+import com.microsoft.azure.management.appservice.AppSetting;
+import com.microsoft.azure.management.appservice.DeploymentSlot;
+import com.microsoft.azure.management.appservice.WebAppBase;
+import com.microsoft.azuretools.authmanage.AuthMethodManager;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
+import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
+import com.microsoft.azuretools.core.mvp.ui.webapp.WebAppProperty;
+import com.microsoft.azuretools.telemetry.AppInsightsClient;
+import com.microsoft.tooling.msservices.components.DefaultLoader;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyMvpView;
+
+import rx.Observable;
+
+public abstract class WebAppBasePropertyViewPresenter<V extends WebAppPropertyMvpView, E extends String> extends MvpPresenter<V> {
+    public static final String KEY_NAME = "name";
+    public static final String KEY_TYPE = "type";
+    public static final String KEY_RESOURCE_GRP = "resourceGroup";
+    public static final String KEY_LOCATION = "location";
+    public static final String KEY_SUB_ID = "subscription";
+    public static final String KEY_STATUS = "status";
+    public static final String KEY_PLAN = "servicePlan";
+    public static final String KEY_URL = "url";
+    public static final String KEY_PRICING = "pricingTier";
+    public static final String KEY_JAVA_VERSION = "javaVersion";
+    public static final String KEY_JAVA_CONTAINER = "javaContainer";
+    public static final String KEY_JAVA_CONTAINER_VERSION = "javaContainerVersion";
+    public static final String KEY_OPERATING_SYS = "operatingSystem";
+    public static final String KEY_APP_SETTING = "appSetting";
+
+    private static final String CANNOT_GET_WEB_APP_PROPERTY = "Cannot get Web App's property.";
+
+    public void onLoadWebAppProperty(final String sid, @NotNull final String webAppId, @Nullable final String name) {
+        Observable.fromCallable(() -> {
+            final Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
+            final WebAppBase appBase = getWebApp(sid, webAppId, name);
+            final AppServicePlan plan = azure.appServices().appServicePlans().getById(appBase.appServicePlanId());
+            return generateProperty(appBase, plan);
+        }).subscribeOn(getSchedulerProvider().io())
+            .subscribe(property -> DefaultLoader.getIdeHelper().invokeLater(() -> {
+                if (isViewDetached()) {
+                    return;
+                }
+                getMvpView().showProperty(property);
+            }), e -> errorHandler((Exception) e));
+    }
+
+    protected WebAppProperty generateProperty(@NotNull final WebAppBase webAppBase, @NotNull final AppServicePlan plan) {
+        final Map<String, String> appSettingsMap = new HashMap<>();
+        final Map<String, AppSetting> appSetting = webAppBase.getAppSettings();
+        for (final String key : appSetting.keySet()) {
+            final AppSetting setting = appSetting.get(key);
+            if (setting != null) {
+                appSettingsMap.put(setting.key(), setting.value());
+            }
+        }
+        final Map<String, Object> propertyMap = new HashMap<>();
+        propertyMap.put(KEY_NAME, webAppBase.name());
+        propertyMap.put(KEY_TYPE, webAppBase.type());
+        propertyMap.put(KEY_RESOURCE_GRP, webAppBase.resourceGroupName());
+        propertyMap.put(KEY_LOCATION, webAppBase.regionName());
+        propertyMap.put(KEY_SUB_ID, webAppBase.manager().subscriptionId());
+        propertyMap.put(KEY_STATUS, webAppBase.state());
+        propertyMap.put(KEY_PLAN, plan.name());
+        propertyMap.put(KEY_URL, webAppBase.defaultHostName());
+        propertyMap.put(KEY_PRICING, plan.pricingTier().toString());
+        final String javaVersion = webAppBase.javaVersion().toString();
+        if (!javaVersion.equals("null")) {
+            propertyMap.put(KEY_JAVA_VERSION, webAppBase.javaVersion().toString());
+            propertyMap.put(KEY_JAVA_CONTAINER, webAppBase.javaContainer());
+            propertyMap.put(KEY_JAVA_CONTAINER_VERSION, webAppBase.javaContainerVersion());
+        }
+        propertyMap.put(KEY_OPERATING_SYS, webAppBase.operatingSystem());
+        propertyMap.put(KEY_APP_SETTING, appSettingsMap);
+
+        return new WebAppProperty(propertyMap);
+    }
+
+    protected abstract WebAppBase getWebApp(@NotNull String sid, @NotNull String webAppId,
+                                            @Nullable String name) throws Exception;
+
+    protected abstract void updateAppSettings(@NotNull String sid, @NotNull String webAppId, @Nullable String name,
+                                              @NotNull Map toUpdate, @NotNull Set toRemove) throws Exception;
+
+    protected abstract boolean getPublishingProfile(@NotNull String sid, @NotNull String webAppId, @Nullable String name,
+                                                    @NotNull String filePath) throws Exception;
+
+    public void onUpdateWebAppProperty(@NotNull final String sid, @NotNull final String webAppId,
+                                       @Nullable final String name,
+                                       @NotNull final Map<String, String> cacheSettings,
+                                       @NotNull final Map<String, String> editedSettings) {
+        final Map<String, String> telemetryMap = new HashMap<>();
+        telemetryMap.put("SubscriptionId", sid);
+        Observable.fromCallable(() -> {
+            final Set<String> toRemove = new HashSet<>();
+            for (String key : cacheSettings.keySet()) {
+                if (!editedSettings.containsKey(key)) {
+                    toRemove.add(key);
+                }
+            }
+            updateAppSettings(sid, webAppId, name, editedSettings, toRemove);
+            return true;
+        }).subscribeOn(getSchedulerProvider().io())
+            .subscribe(property -> DefaultLoader.getIdeHelper().invokeLater(() -> {
+                if (isViewDetached()) {
+                    return;
+                }
+                getMvpView().showPropertyUpdateResult(true);
+                sendTelemetry("UpdateAppSettings", telemetryMap, true, null);
+            }), e -> {
+                errorHandler((Exception) e);
+                if (isViewDetached()) {
+                    return;
+                }
+                getMvpView().showPropertyUpdateResult(false);
+                sendTelemetry("UpdateAppSettings", telemetryMap, false, e.getMessage());
+            });
+    }
+
+    public void onGetPublishingProfileXmlWithSecrets(@NotNull final String sid, @NotNull final String webAppId,
+                                                     @Nullable final String name, @NotNull final String filePath) {
+        final Map<String, String> telemetryMap = new HashMap<>();
+        telemetryMap.put("SubscriptionId", sid);
+        Observable.fromCallable(() -> getPublishingProfile(sid, webAppId, name, filePath))
+            .subscribeOn(getSchedulerProvider().io()).subscribe(res -> DefaultLoader.getIdeHelper().invokeLater(() -> {
+            if (isViewDetached()) {
+                return;
+            }
+            getMvpView().showGetPublishingProfileResult(res);
+            sendTelemetry("DownloadPublishProfile", telemetryMap, true, null);
+        }), e -> {
+            errorHandler((Exception) e);
+            if (isViewDetached()) {
+                return;
+            }
+            getMvpView().showGetPublishingProfileResult(false);
+            sendTelemetry("DownloadPublishProfile", telemetryMap, false, e.getMessage());
+        });
+    }
+
+    protected void errorHandler(final Exception e) {
+        DefaultLoader.getIdeHelper().invokeLater(() -> {
+            if (isViewDetached()) {
+                return;
+            }
+            getMvpView().onErrorWithException(CANNOT_GET_WEB_APP_PROPERTY, e);
+        });
+    }
+
+    protected void sendTelemetry(@NotNull final String actionName, @NotNull final Map<String, String> telemetryMap,
+                                 final boolean success, @Nullable final String errorMsg) {
+        telemetryMap.put("Success", String.valueOf(success));
+        if (!success) {
+            telemetryMap.put("ErrorMsg", errorMsg);
+        }
+        AppInsightsClient.createByType(AppInsightsClient.EventType.Action, "WebApp", actionName, telemetryMap);
+    }
+}

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
+package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot;
 
 import java.util.List;
 import java.util.Map;
@@ -33,24 +33,25 @@ import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
-public class WebAppPropertyViewPresenter extends WebAppBasePropertyViewPresenter {
+public class DeploymentSlotPropertyViewPresenter extends WebAppBasePropertyViewPresenter {
     @Override
     protected void updateAppSettings(@NotNull final String sid, @NotNull final String webAppId,
                                      @Nullable final String name, final Map toUpdate,
                                      final Set toRemove) throws Exception {
-        AzureWebAppMvpModel.getInstance().updateWebAppSettings(sid, webAppId, toUpdate, toRemove);
+        AzureWebAppMvpModel.getInstance().updateDeploymentSlotAppSettings(sid, webAppId, name, toUpdate, toRemove);
     }
 
     @Override
-    protected boolean getPublishingProfile(@NotNull final String sid, @NotNull final String webAppId,
+    protected boolean getPublishingProfile(@NotNull final String subscriptionId, @NotNull final String webAppId,
                                            @Nullable final String name,
                                            @NotNull final String filePath) throws Exception {
-        return AzureWebAppMvpModel.getInstance().getPublishingProfileXmlWithSecrets(sid, webAppId, filePath);
+        return AzureWebAppMvpModel.getInstance()
+            .getSlotPublishingProfileXmlWithSecrets(subscriptionId, webAppId, name, filePath);
     }
 
     @Override
     protected WebAppBase getWebApp(@NotNull final String sid, @NotNull final String webAppId,
                                    @Nullable final String name) throws Exception {
-        return AzureWebAppMvpModel.getInstance().getWebAppById(sid, webAppId);
+        return AzureWebAppMvpModel.getInstance().getWebAppById(sid, webAppId).deploymentSlots().getByName(name);
     }
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -47,6 +47,7 @@ import com.microsoft.azure.management.appservice.PricingTier;
 import com.microsoft.azure.management.appservice.PublishingProfileFormat;
 import com.microsoft.azure.management.appservice.RuntimeStack;
 import com.microsoft.azure.management.appservice.WebApp;
+import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.Subscription;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
@@ -377,6 +378,22 @@ public class AzureWebAppMvpModel {
         update.apply();
     }
 
+    /**
+     * Update app settings of deployment slot.
+     */
+    public void updateDeploymentSlotAppSettings(final String subsciptionId, final String webAppId,
+                                                final String slotName, final Map<String, String> toUpdate,
+                                                final Set<String> toRemove) throws Exception {
+        final DeploymentSlot slot = getWebAppById(subsciptionId, webAppId).deploymentSlots().getByName(slotName);
+        clearTags(slot);
+        com.microsoft.azure.management.appservice.WebAppBase.Update<DeploymentSlot> update = slot.update()
+            .withAppSettings(toUpdate);
+        for (String key : toRemove) {
+            update = update.withoutAppSetting(key);
+        }
+        update.apply();
+    }
+
     public void deleteWebAppOnLinux(String sid, String appid) throws IOException {
         deleteWebApp(sid, appid);
     }
@@ -586,7 +603,7 @@ public class AzureWebAppMvpModel {
     }
 
     /**
-     * Download publish profile.
+     * Download publish profile of web app.
      *
      * @param sid      subscription id
      * @param webAppId webapp id
@@ -603,6 +620,29 @@ public class AzureWebAppMvpModel {
                 .listPublishingProfileXmlWithSecrets(app.resourceGroupName(), app.name(),
                         PublishingProfileFormat.FTP);
              OutputStream outputStream = new FileOutputStream(file);
+        ) {
+            IOUtils.copy(inputStream, outputStream);
+            return true;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Download publish profile of deployment slot.
+     */
+    public boolean getSlotPublishingProfileXmlWithSecrets(final String sid, final String webAppId,
+                                                          final String slotName,
+                                                          final String filePath) throws Exception {
+        final WebApp app = getWebAppById(sid, webAppId);
+        final DeploymentSlot slot = app.deploymentSlots().getByName(slotName);
+        final File file = new File(
+            Paths.get(filePath, slotName + "_" + System.currentTimeMillis() + ".PublishSettings").toString());
+        file.createNewFile();
+        try (final InputStream inputStream = slot.manager().inner().webApps().listPublishingProfileXmlWithSecretsSlot(
+            slot.resourceGroupName(), app.name(), slotName, PublishingProfileFormat.FTP);
+             final OutputStream outputStream = new FileOutputStream(file);
         ) {
             IOUtils.copy(inputStream, outputStream);
             return true;
@@ -634,7 +674,7 @@ public class AzureWebAppMvpModel {
      * An issue is logged at https://github.com/Azure/azure-sdk-for-java/issues/1755 .
      * Remove all tags here to make it work.
      */
-    private void clearTags(@NotNull final WebApp app) {
+    private void clearTags(@NotNull final WebAppBase app) {
         app.inner().withTags(null);
     }
 


### PR DESCRIPTION
Presenter part of implementing the show property of deploymnet slots.

The `WebAppPropertyViewPresenter` and `DeploymentSlotPropertyViewPresenter` share a lot of logic, move the shared logic to `WebAppBasePropertyViewPresenter`.

Since the web app and deployment slot call different APIs to perform real work on update application settings and get publishing profile, the base class is dedigned as an abstract class with abstract methods:
- updateAppSettings
- getPublishingProfile

So the child classed `WebAppPropertyViewPresenter` and `DeploymentSlotPropertyViewPresenter` could override them as their own need.