### PR TITLE
Add show property operation for deployment slots

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/UIHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/helpers/UIHelperImpl.java
@@ -373,4 +373,9 @@ public class UIHelperImpl implements UIHelper {
         IEditorDescriptor descriptor = workbench.getEditorRegistry().findEditor(WebAppPropertyEditor.ID);
         openEditor(EditorType.WEBAPP_EXPLORER, input, descriptor);
     }
+
+    @Override
+    public void openDeploymentSlotPropertyView(final DeploymentSlotNode node) {
+        // todo
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -225,6 +225,7 @@
     <fileEditorProvider implementation="com.microsoft.intellij.helpers.rediscache.RedisCacheExplorerProvider"/>
     <fileEditorProvider implementation="com.microsoft.intellij.helpers.containerregistry.ContainerRegistryPropertyViewProvider"/>
     <fileEditorProvider implementation="com.microsoft.intellij.helpers.webapp.WebAppPropertyViewProvider"/>
+    <fileEditorProvider implementation="com.microsoft.intellij.helpers.webapp.DeploymentSlotPropertyViewProvider"/>
     <toolWindow
           anchor="left"
           factoryClass="com.microsoft.intellij.components.ServerExplorerToolWindowFactory"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/UIHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/UIHelperImpl.java
@@ -397,11 +397,11 @@ public class UIHelperImpl implements UIHelper {
             return;
         }
         LightVirtualFile itemVirtualFile = searchExistingFile(fileEditorManager,
-                WebAppPropertyViewProvider.getType(), resId);
+            WebAppPropertyViewProvider.TYPE, resId);
         if (itemVirtualFile == null) {
             String iconPath = webAppNode.getParent() == null ? webAppNode.getIconPath()
                     : webAppNode.getParent().getIconPath();
-            itemVirtualFile = createVirtualFile(webAppName, WebAppPropertyViewProvider.getType(), iconPath, sid, resId);
+            itemVirtualFile = createVirtualFile(webAppName, WebAppPropertyViewProvider.TYPE, iconPath, sid, resId);
         }
         fileEditorManager.openFile(itemVirtualFile, true /*focusEditor*/, true /*searchForOpen*/);
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyView.java
@@ -53,8 +53,6 @@ public class DeploymentSlotPropertyView extends WebAppBasePropertyView {
 
     @Override
     protected WebAppBasePropertyViewPresenter createPresenter() {
-        final DeploymentSlotPropertyViewPresenter presenter = new DeploymentSlotPropertyViewPresenter();
-        presenter.onAttachView(this);
-        return presenter;
+        return new DeploymentSlotPropertyViewPresenter();
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyView.java
@@ -25,9 +25,11 @@ package com.microsoft.intellij.helpers.webapp;
 import org.jetbrains.annotations.NotNull;
 
 import com.intellij.openapi.project.Project;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotPropertyViewPresenter;
 
 public class DeploymentSlotPropertyView extends WebAppBasePropertyView {
+    private static final String ID = "com.microsoft.intellij.helpers.webapp.DeploymentSlotPropertyView";
 
     /**
      * Initialize the Web App Property View and return it.
@@ -42,8 +44,17 @@ public class DeploymentSlotPropertyView extends WebAppBasePropertyView {
     private DeploymentSlotPropertyView(@NotNull final Project project, @NotNull final String sid,
                                        @NotNull final String webAppId, @NotNull final String slotName) {
         super(project, sid, webAppId, slotName);
-        this.id = "com.microsoft.intellij.helpers.webapp.DeploymentSlotPropertyView";
-        presenter = new DeploymentSlotPropertyViewPresenter();
+    }
+
+    @Override
+    protected String getId() {
+        return this.ID;
+    }
+
+    @Override
+    protected WebAppBasePropertyViewPresenter createPresenter() {
+        final DeploymentSlotPropertyViewPresenter presenter = new DeploymentSlotPropertyViewPresenter();
         presenter.onAttachView(this);
+        return presenter;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyView.java
@@ -1,0 +1,32 @@
+package com.microsoft.intellij.helpers.webapp;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.intellij.openapi.project.Project;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotPropertyViewPresenter;
+
+public class DeploymentSlotPropertyView extends WebAppBasePropertyView {
+
+    /**
+     * Initialize the Web App Property View and return it.
+     */
+    public static WebAppBasePropertyView create(@NotNull Project project, @NotNull String sid,
+                                                @NotNull String resId, @NotNull String name) {
+        DeploymentSlotPropertyView view = new DeploymentSlotPropertyView(project, sid, resId, name);
+        view.onLoadWebAppProperty(sid, resId, name);
+        return view;
+    }
+
+    private DeploymentSlotPropertyView(@NotNull final Project project, @NotNull final String sid,
+                                       @NotNull final String webAppId, @NotNull final String name) {
+        super(project, sid, webAppId);
+        presenter = new DeploymentSlotPropertyViewPresenter();
+        presenter.onAttachView(this);
+    }
+
+    @Override
+    public void onLoadWebAppProperty(@NotNull String sid, @NotNull String webAppId, @Nullable String name) {
+        this.presenter.onLoadWebAppProperty(sid, webAppId, name);
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyView.java
@@ -1,7 +1,28 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.intellij.helpers.webapp;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import com.intellij.openapi.project.Project;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotPropertyViewPresenter;
@@ -11,22 +32,18 @@ public class DeploymentSlotPropertyView extends WebAppBasePropertyView {
     /**
      * Initialize the Web App Property View and return it.
      */
-    public static WebAppBasePropertyView create(@NotNull Project project, @NotNull String sid,
-                                                @NotNull String resId, @NotNull String name) {
-        DeploymentSlotPropertyView view = new DeploymentSlotPropertyView(project, sid, resId, name);
-        view.onLoadWebAppProperty(sid, resId, name);
+    public static WebAppBasePropertyView create(@NotNull final Project project, @NotNull final String sid,
+                                                @NotNull final String resId, @NotNull final String slotName) {
+        DeploymentSlotPropertyView view = new DeploymentSlotPropertyView(project, sid, resId, slotName);
+        view.onLoadWebAppProperty(sid, resId, slotName);
         return view;
     }
 
     private DeploymentSlotPropertyView(@NotNull final Project project, @NotNull final String sid,
-                                       @NotNull final String webAppId, @NotNull final String name) {
-        super(project, sid, webAppId);
+                                       @NotNull final String webAppId, @NotNull final String slotName) {
+        super(project, sid, webAppId, slotName);
+        this.id = "com.microsoft.intellij.helpers.webapp.DeploymentSlotPropertyView";
         presenter = new DeploymentSlotPropertyViewPresenter();
         presenter.onAttachView(this);
-    }
-
-    @Override
-    public void onLoadWebAppProperty(@NotNull String sid, @NotNull String webAppId, @Nullable String name) {
-        this.presenter.onLoadWebAppProperty(sid, webAppId, name);
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyViewProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyViewProvider.java
@@ -1,0 +1,26 @@
+package com.microsoft.intellij.helpers.webapp;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.microsoft.intellij.helpers.UIHelperImpl;
+
+public class DeploymentSlotPropertyViewProvider extends WebAppBasePropertyViewProvider {
+    public static final String TYPE ="DEPLOYMENT_SLOT_PROPERTY";
+
+    @NotNull
+    @Override
+    public FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile virtualFile) {
+        final String sid = virtualFile.getUserData(UIHelperImpl.SUBSCRIPTION_ID);
+        final String id = virtualFile.getUserData(UIHelperImpl.RESOURCE_ID);
+        final String name = virtualFile.getName();
+        return DeploymentSlotPropertyView.create(project, sid, id, name);
+    }
+
+    @Override
+    protected String getType() {
+        return TYPE;
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyViewProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyViewProvider.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.intellij.helpers.webapp;
 
 import org.jetbrains.annotations.NotNull;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.form
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.microsoft.intellij.helpers.webapp.WebAppPropertyView">
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.microsoft.intellij.helpers.webapp.WebAppBasePropertyView">
   <grid id="27dc6" binding="pnlMain" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
@@ -61,11 +61,11 @@ import com.microsoft.intellij.ui.util.UIUtils;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyMvpView;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
 
-public class WebAppPropertyView extends BaseEditor implements WebAppPropertyMvpView {
+public class WebAppBasePropertyView extends BaseEditor implements WebAppPropertyMvpView {
 
-    public static final String ID = "com.microsoft.intellij.helpers.webapp.WebAppPropertyView";
+    public static final String ID = "com.microsoft.intellij.helpers.webapp.WebAppBasePropertyView";
 
-    private final WebAppPropertyViewPresenter<WebAppPropertyView> presenter;
+    private final WebAppPropertyViewPresenter<WebAppBasePropertyView> presenter;
     private final String sid;
     private final String resId;
     private final Map<String, String> cachedAppSettings;
@@ -86,7 +86,7 @@ public class WebAppPropertyView extends BaseEditor implements WebAppPropertyMvpV
     private static final String NOTIFY_PROPERTY_UPDATE_SUCCESS = "Properties updated.";
     private static final String NOTIFY_PROFILE_GET_SUCCESS = "Publish Profile saved.";
     private static final String NOTIFY_PROFILE_GET_FAIL = "Failed to get Publish Profile.";
-    private static final String INSIGHT_NAME = "AzurePlugin.IntelliJ.Editor.WebAppPropertyView";
+    private static final String INSIGHT_NAME = "AzurePlugin.IntelliJ.Editor.WebAppBasePropertyView";
 
     private JPanel pnlMain;
     private JButton btnGetPublishFile;
@@ -118,13 +118,13 @@ public class WebAppPropertyView extends BaseEditor implements WebAppPropertyMvpV
     /**
      * Initialize the Web App Property View and return it.
      */
-    public static WebAppPropertyView create(@NotNull Project project, @NotNull String sid, @NotNull String resId) {
-        WebAppPropertyView view = new WebAppPropertyView(project, sid, resId);
+    public static WebAppBasePropertyView create(@NotNull Project project, @NotNull String sid, @NotNull String resId) {
+        WebAppBasePropertyView view = new WebAppBasePropertyView(project, sid, resId);
         view.onLoadWebAppProperty();
         return view;
     }
 
-    private WebAppPropertyView(@NotNull Project project, @NotNull String sid, @NotNull String resId) {
+    private WebAppBasePropertyView(@NotNull Project project, @NotNull String sid, @NotNull String resId) {
         this.sid = sid;
         this.resId = resId;
         cachedAppSettings = new LinkedHashMap<>();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
@@ -36,6 +36,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.table.DefaultTableModel;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.ActionToolbarPosition;
@@ -62,10 +63,8 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPrope
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
-public abstract class WebAppBasePropertyView extends BaseEditor implements WebAppPropertyMvpView {
-
-    public static final String ID = "com.microsoft.intellij.helpers.webapp.WebAppBasePropertyView";
-
+public class WebAppBasePropertyView extends BaseEditor implements WebAppPropertyMvpView {
+    public String id;
     protected WebAppBasePropertyViewPresenter presenter;
     private final Map<String, String> cachedAppSettings;
     private final Map<String, String> editedAppSettings;
@@ -114,7 +113,8 @@ public abstract class WebAppBasePropertyView extends BaseEditor implements WebAp
     private AnActionButton btnRemove;
     private AnActionButton btnEdit;
 
-    protected WebAppBasePropertyView(@NotNull Project project, @NotNull String sid, @NotNull String resId) {
+    protected WebAppBasePropertyView(@NotNull Project project, @NotNull String sid,
+                                     @NotNull String resId, @Nullable String slotName) {
         cachedAppSettings = new LinkedHashMap<>();
         editedAppSettings = new LinkedHashMap<>();
         statusBar = WindowManager.getInstance().getStatusBar(project);
@@ -145,7 +145,7 @@ public abstract class WebAppBasePropertyView extends BaseEditor implements WebAp
                 fileChooserDescriptor.setTitle(FILE_SELECTOR_TITLE);
                 final VirtualFile file = FileChooser.chooseFile(fileChooserDescriptor, null, null);
                 if (file != null) {
-                    presenter.onGetPublishingProfileXmlWithSecrets(sid, resId, null, file.getPath());
+                    presenter.onGetPublishingProfileXmlWithSecrets(sid, resId, slotName, file.getPath());
                 }
             }
         });
@@ -165,12 +165,20 @@ public abstract class WebAppBasePropertyView extends BaseEditor implements WebAp
             @Override
             public void actionPerformedFunc(ActionEvent event) {
                 setBtnEnableStatus(false);
-                presenter.onUpdateWebAppProperty(sid, resId, null, cachedAppSettings, editedAppSettings);
+                presenter.onUpdateWebAppProperty(sid, resId, slotName, cachedAppSettings, editedAppSettings);
             }
         });
 
         lnkUrl.setHyperlinkText("<Loading...>");
         setTextFieldStyle();
+    }
+
+
+
+    @Override
+    public void onLoadWebAppProperty(@NotNull final String sid, @NotNull final String webAppId,
+                                     @Nullable final String slotName) {
+        this.presenter.onLoadWebAppProperty(sid, webAppId, slotName);
     }
 
     @NotNull
@@ -182,7 +190,7 @@ public abstract class WebAppBasePropertyView extends BaseEditor implements WebAp
     @NotNull
     @Override
     public String getName() {
-        return ID;
+        return id;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
@@ -59,13 +59,13 @@ import com.microsoft.azuretools.core.mvp.ui.webapp.WebAppProperty;
 import com.microsoft.intellij.helpers.base.BaseEditor;
 import com.microsoft.intellij.ui.components.AzureActionListenerWrapper;
 import com.microsoft.intellij.ui.util.UIUtils;
-import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyMvpView;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppBasePropertyMvpView;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
-public class WebAppBasePropertyView extends BaseEditor implements WebAppPropertyMvpView {
-    public String id;
-    protected WebAppBasePropertyViewPresenter presenter;
+public abstract class WebAppBasePropertyView extends BaseEditor implements WebAppBasePropertyMvpView {
+    public final String id;
+    protected final WebAppBasePropertyViewPresenter presenter;
     private final Map<String, String> cachedAppSettings;
     private final Map<String, String> editedAppSettings;
     private final StatusBar statusBar;
@@ -115,6 +115,8 @@ public class WebAppBasePropertyView extends BaseEditor implements WebAppProperty
 
     protected WebAppBasePropertyView(@NotNull Project project, @NotNull String sid,
                                      @NotNull String resId, @Nullable String slotName) {
+        this.id = getId();
+        this.presenter = createPresenter();
         cachedAppSettings = new LinkedHashMap<>();
         editedAppSettings = new LinkedHashMap<>();
         statusBar = WindowManager.getInstance().getStatusBar(project);
@@ -174,6 +176,11 @@ public class WebAppBasePropertyView extends BaseEditor implements WebAppProperty
     }
 
 
+
+
+    protected abstract String getId();
+
+    protected abstract WebAppBasePropertyViewPresenter createPresenter();
 
     @Override
     public void onLoadWebAppProperty(@NotNull final String sid, @NotNull final String webAppId,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
@@ -62,13 +62,11 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPrope
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
-public class WebAppBasePropertyView extends BaseEditor implements WebAppPropertyMvpView {
+public abstract class WebAppBasePropertyView extends BaseEditor implements WebAppPropertyMvpView {
 
     public static final String ID = "com.microsoft.intellij.helpers.webapp.WebAppBasePropertyView";
 
-    private WebAppBasePropertyViewPresenter presenter;
-    private final String sid;
-    private final String resId;
+    protected WebAppBasePropertyViewPresenter presenter;
     private final Map<String, String> cachedAppSettings;
     private final Map<String, String> editedAppSettings;
     private final StatusBar statusBar;
@@ -116,18 +114,7 @@ public class WebAppBasePropertyView extends BaseEditor implements WebAppProperty
     private AnActionButton btnRemove;
     private AnActionButton btnEdit;
 
-    /**
-     * Initialize the Web App Property View and return it.
-     */
-    public static WebAppBasePropertyView create(@NotNull Project project, @NotNull String sid, @NotNull String resId) {
-        WebAppBasePropertyView view = new WebAppBasePropertyView(project, sid, resId);
-        view.onLoadWebAppProperty();
-        return view;
-    }
-
-    private WebAppBasePropertyView(@NotNull Project project, @NotNull String sid, @NotNull String resId) {
-        this.sid = sid;
-        this.resId = resId;
+    protected WebAppBasePropertyView(@NotNull Project project, @NotNull String sid, @NotNull String resId) {
         cachedAppSettings = new LinkedHashMap<>();
         editedAppSettings = new LinkedHashMap<>();
         statusBar = WindowManager.getInstance().getStatusBar(project);
@@ -283,11 +270,6 @@ public class WebAppBasePropertyView extends BaseEditor implements WebAppProperty
         ToolbarDecorator tableToolbarDecorator = ToolbarDecorator.createDecorator(tblAppSetting)
                 .addExtraActions(btnAdd, btnRemove, btnEdit).setToolbarPosition(ActionToolbarPosition.RIGHT);
         pnlAppSettings = tableToolbarDecorator.createPanel();
-    }
-
-    @Override
-    public void onLoadWebAppProperty() {
-        presenter.onLoadWebAppProperty(this.sid, this.resId, null);
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
@@ -60,12 +60,13 @@ import com.microsoft.intellij.ui.components.AzureActionListenerWrapper;
 import com.microsoft.intellij.ui.util.UIUtils;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyMvpView;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
 public class WebAppBasePropertyView extends BaseEditor implements WebAppPropertyMvpView {
 
     public static final String ID = "com.microsoft.intellij.helpers.webapp.WebAppBasePropertyView";
 
-    private final WebAppPropertyViewPresenter<WebAppBasePropertyView> presenter;
+    private WebAppBasePropertyViewPresenter presenter;
     private final String sid;
     private final String resId;
     private final Map<String, String> cachedAppSettings;
@@ -131,8 +132,6 @@ public class WebAppBasePropertyView extends BaseEditor implements WebAppProperty
         editedAppSettings = new LinkedHashMap<>();
         statusBar = WindowManager.getInstance().getStatusBar(project);
         $$$setupUI$$$(); // tell IntelliJ to call createUIComponents() here.
-        this.presenter = new WebAppPropertyViewPresenter<>();
-        this.presenter.onAttachView(this);
 
         // initialize widgets...
         HideableDecorator overviewDecorator = new HideableDecorator(pnlOverviewHolder, PNL_OVERVIEW,
@@ -159,7 +158,7 @@ public class WebAppBasePropertyView extends BaseEditor implements WebAppProperty
                 fileChooserDescriptor.setTitle(FILE_SELECTOR_TITLE);
                 final VirtualFile file = FileChooser.chooseFile(fileChooserDescriptor, null, null);
                 if (file != null) {
-                    presenter.onGetPublishingProfileXmlWithSecrets(sid, resId, file.getPath());
+                    presenter.onGetPublishingProfileXmlWithSecrets(sid, resId, null, file.getPath());
                 }
             }
         });
@@ -179,7 +178,7 @@ public class WebAppBasePropertyView extends BaseEditor implements WebAppProperty
             @Override
             public void actionPerformedFunc(ActionEvent event) {
                 setBtnEnableStatus(false);
-                presenter.onUpdateWebAppProperty(sid, resId, cachedAppSettings, editedAppSettings);
+                presenter.onUpdateWebAppProperty(sid, resId, null, cachedAppSettings, editedAppSettings);
             }
         });
 
@@ -288,7 +287,7 @@ public class WebAppBasePropertyView extends BaseEditor implements WebAppProperty
 
     @Override
     public void onLoadWebAppProperty() {
-        presenter.onLoadWebAppProperty(this.sid, this.resId);
+        presenter.onLoadWebAppProperty(this.sid, this.resId, null);
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
@@ -65,7 +65,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebApp
 
 public abstract class WebAppBasePropertyView extends BaseEditor implements WebAppBasePropertyMvpView {
     public final String id;
-    protected final WebAppBasePropertyViewPresenter presenter;
+    protected final WebAppBasePropertyViewPresenter<WebAppBasePropertyMvpView> presenter;
     private final Map<String, String> cachedAppSettings;
     private final Map<String, String> editedAppSettings;
     private final StatusBar statusBar;
@@ -117,6 +117,7 @@ public abstract class WebAppBasePropertyView extends BaseEditor implements WebAp
                                      @NotNull String resId, @Nullable String slotName) {
         this.id = getId();
         this.presenter = createPresenter();
+        this.presenter.onAttachView(this);
         cachedAppSettings = new LinkedHashMap<>();
         editedAppSettings = new LinkedHashMap<>();
         statusBar = WindowManager.getInstance().getStatusBar(project);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyViewProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyViewProvider.java
@@ -1,0 +1,29 @@
+package com.microsoft.intellij.helpers.webapp;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.intellij.openapi.fileEditor.FileEditorPolicy;
+import com.intellij.openapi.fileEditor.FileEditorProvider;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+
+public abstract class WebAppBasePropertyViewProvider implements FileEditorProvider {
+    @Override
+    public boolean accept(@NotNull Project project, @NotNull VirtualFile virtualFile) {
+        return virtualFile.getFileType().getName().equals(getType());
+    }
+
+    @NotNull
+    @Override
+    public String getEditorTypeId() {
+        return getType();
+    }
+
+    @NotNull
+    @Override
+    public FileEditorPolicy getPolicy() {
+        return FileEditorPolicy.HIDE_DEFAULT_EDITOR;
+    }
+
+    protected abstract String getType();
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyViewProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyViewProvider.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.intellij.helpers.webapp;
 
 import org.jetbrains.annotations.NotNull;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
@@ -26,8 +26,10 @@ import org.jetbrains.annotations.NotNull;
 
 import com.intellij.openapi.project.Project;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
 public class WebAppPropertyView extends WebAppBasePropertyView {
+    private static final String ID = "com.microsoft.intellij.helpers.webapp.WebAppBasePropertyView";
     /**
      * Initialize the Web App Property View and return it.
      */
@@ -41,8 +43,17 @@ public class WebAppPropertyView extends WebAppBasePropertyView {
     private WebAppPropertyView(@NotNull final Project project, @NotNull final String sid,
                                @NotNull final String webAppId) {
         super(project, sid, webAppId, null);
-        this.id = "com.microsoft.intellij.helpers.webapp.WebAppBasePropertyView";
-        presenter = new WebAppPropertyViewPresenter();
+    }
+
+    @Override
+    protected String getId() {
+        return this.ID;
+    }
+
+    @Override
+    protected WebAppBasePropertyViewPresenter createPresenter() {
+        final WebAppPropertyViewPresenter presenter = new WebAppPropertyViewPresenter();
         presenter.onAttachView(this);
+        return presenter;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
@@ -1,13 +1,33 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.microsoft.intellij.helpers.webapp;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import com.intellij.openapi.project.Project;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
 
 public class WebAppPropertyView extends WebAppBasePropertyView {
-
     /**
      * Initialize the Web App Property View and return it.
      */
@@ -20,13 +40,9 @@ public class WebAppPropertyView extends WebAppBasePropertyView {
 
     private WebAppPropertyView(@NotNull final Project project, @NotNull final String sid,
                                @NotNull final String webAppId) {
-        super(project, sid, webAppId);
+        super(project, sid, webAppId, null);
+        this.id = "com.microsoft.intellij.helpers.webapp.WebAppBasePropertyView";
         presenter = new WebAppPropertyViewPresenter();
         presenter.onAttachView(this);
-    }
-
-    @Override
-    public void onLoadWebAppProperty(@NotNull final String sid, @NotNull final String webAppId, @Nullable final String name) {
-        this.presenter.onLoadWebAppProperty(sid, webAppId, name);
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
@@ -52,8 +52,6 @@ public class WebAppPropertyView extends WebAppBasePropertyView {
 
     @Override
     protected WebAppBasePropertyViewPresenter createPresenter() {
-        final WebAppPropertyViewPresenter presenter = new WebAppPropertyViewPresenter();
-        presenter.onAttachView(this);
-        return presenter;
+        return new WebAppPropertyViewPresenter();
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
@@ -1,0 +1,32 @@
+package com.microsoft.intellij.helpers.webapp;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.intellij.openapi.project.Project;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
+
+public class WebAppPropertyView extends WebAppBasePropertyView {
+
+    /**
+     * Initialize the Web App Property View and return it.
+     */
+    public static WebAppBasePropertyView create(@NotNull final Project project, @NotNull final String sid,
+                                                @NotNull final String webAppId) {
+        WebAppPropertyView view = new WebAppPropertyView(project, sid, webAppId);
+        view.onLoadWebAppProperty(sid, webAppId, null);
+        return view;
+    }
+
+    private WebAppPropertyView(@NotNull final Project project, @NotNull final String sid,
+                               @NotNull final String webAppId) {
+        super(project, sid, webAppId);
+        presenter = new WebAppPropertyViewPresenter();
+        presenter.onAttachView(this);
+    }
+
+    @Override
+    public void onLoadWebAppProperty(@NotNull final String sid, @NotNull final String webAppId, @Nullable final String name) {
+        this.presenter.onLoadWebAppProperty(sid, webAppId, name);
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyViewProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyViewProvider.java
@@ -45,7 +45,7 @@ public class WebAppPropertyViewProvider implements FileEditorProvider {
     public FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile virtualFile) {
         String sid = virtualFile.getUserData(UIHelperImpl.SUBSCRIPTION_ID);
         String id = virtualFile.getUserData(UIHelperImpl.RESOURCE_ID);
-        return WebAppPropertyView.create(project, sid, id);
+        return WebAppBasePropertyView.create(project, sid, id);
     }
 
     @NotNull

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyViewProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyViewProvider.java
@@ -25,42 +25,22 @@ package com.microsoft.intellij.helpers.webapp;
 import org.jetbrains.annotations.NotNull;
 
 import com.intellij.openapi.fileEditor.FileEditor;
-import com.intellij.openapi.fileEditor.FileEditorPolicy;
-import com.intellij.openapi.fileEditor.FileEditorProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.microsoft.intellij.helpers.UIHelperImpl;
 
-public class WebAppPropertyViewProvider implements FileEditorProvider {
-
-    private static final String TYPE = "WEB_APP_PROPERTY";
-
-    @Override
-    public boolean accept(@NotNull Project project, @NotNull VirtualFile virtualFile) {
-        return virtualFile.getFileType().getName().equals(TYPE);
-    }
-
+public class WebAppPropertyViewProvider extends WebAppBasePropertyViewProvider {
+    public static final String TYPE = "WEB_APP_PROPERTY";
     @NotNull
     @Override
     public FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile virtualFile) {
         String sid = virtualFile.getUserData(UIHelperImpl.SUBSCRIPTION_ID);
         String id = virtualFile.getUserData(UIHelperImpl.RESOURCE_ID);
-        return WebAppBasePropertyView.create(project, sid, id);
+        return WebAppPropertyView.create(project, sid, id);
     }
 
-    @NotNull
     @Override
-    public String getEditorTypeId() {
-        return TYPE;
-    }
-
-    @NotNull
-    @Override
-    public FileEditorPolicy getPolicy() {
-        return FileEditorPolicy.HIDE_DEFAULT_EDITOR;
-    }
-
-    public static String getType() {
+    protected String getType() {
         return TYPE;
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/helpers/UIHelper.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/helpers/UIHelper.java
@@ -34,6 +34,7 @@ import com.microsoft.tooling.msservices.model.storage.Table;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.container.ContainerRegistryNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.rediscache.RedisCacheNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppNode;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotNode;
 
 public interface UIHelper {
     void showException(@NotNull String message,
@@ -73,6 +74,8 @@ public interface UIHelper {
     void openContainerRegistryPropertyView(@NotNull ContainerRegistryNode node);
 
     void openWebAppPropertyView(@NotNull WebAppNode node);
+
+    void openDeploymentSlotPropertyView(@NotNull DeploymentSlotNode node);
 
     @Nullable
     <T extends StorageServiceTreeItem> Object getOpenedFile(@NotNull Object projectObject,

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppBasePropertyMvpView.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppBasePropertyMvpView.java
@@ -3,7 +3,7 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpView;
 import com.microsoft.azuretools.core.mvp.ui.webapp.WebAppProperty;
 
-public interface WebAppPropertyMvpView extends MvpView {
+public interface WebAppBasePropertyMvpView extends MvpView {
     public void onLoadWebAppProperty(String sid, String webAppId, String slotName);
 
     public void showProperty(WebAppProperty property);

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyMvpView.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyMvpView.java
@@ -4,7 +4,7 @@ import com.microsoft.azuretools.core.mvp.ui.base.MvpView;
 import com.microsoft.azuretools.core.mvp.ui.webapp.WebAppProperty;
 
 public interface WebAppPropertyMvpView extends MvpView {
-    public void onLoadWebAppProperty(String sid, String webAppId, String name);
+    public void onLoadWebAppProperty(String sid, String webAppId, String slotName);
 
     public void showProperty(WebAppProperty property);
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyMvpView.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyMvpView.java
@@ -4,7 +4,7 @@ import com.microsoft.azuretools.core.mvp.ui.base.MvpView;
 import com.microsoft.azuretools.core.mvp.ui.webapp.WebAppProperty;
 
 public interface WebAppPropertyMvpView extends MvpView {
-    public void onLoadWebAppProperty();
+    public void onLoadWebAppProperty(String sid, String webAppId, String name);
 
     public void showProperty(WebAppProperty property);
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyViewPresenter.java
@@ -22,25 +22,35 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.microsoft.azure.management.appservice.DeploymentSlot;
 import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
 public class WebAppPropertyViewPresenter extends WebAppBasePropertyViewPresenter {
     @Override
-    protected void performUpdateSettings(@NotNull final String sid, @NotNull final WebAppBase webAppBase,
-                                         final Map toUpdate, final Set toRemove) throws Exception {
-        AzureWebAppMvpModel.getInstance().updateWebAppSettings(sid, webAppBase.id(), toUpdate, toRemove);
+    protected void updateAppSettings(@NotNull final String sid, @NotNull final String webAppId,
+                                     @Nullable final String name, final Map toUpdate,
+                                     final Set toRemove) throws Exception {
+        AzureWebAppMvpModel.getInstance().updateWebAppSettings(sid, webAppId, toUpdate, toRemove);
     }
 
     @Override
-    protected boolean performGetPublishingProfile(@NotNull final String sid, @NotNull final WebAppBase webAppBase,
-                                                  @NotNull final String filePath) throws Exception {
-        return AzureWebAppMvpModel.getInstance().getPublishingProfileXmlWithSecrets(
-            sid, webAppBase.id(), filePath);
+    protected boolean getPublishingProfile(@NotNull final String sid, @NotNull final String webAppId,
+                                           @Nullable final String name,
+                                           @NotNull final String filePath) throws Exception {
+        return AzureWebAppMvpModel.getInstance().getPublishingProfileXmlWithSecrets(sid, webAppId, filePath);
+    }
+
+    @Override
+    protected WebAppBase getWebApp(@NotNull final String sid, @NotNull final String webAppId,
+                                   @Nullable final String name) throws Exception {
+        return AzureWebAppMvpModel.getInstance().getWebAppById(sid, webAppId);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyViewPresenter.java
@@ -49,8 +49,8 @@ public class WebAppPropertyViewPresenter extends WebAppBasePropertyViewPresenter
     }
 
     @Override
-    protected WebAppBase getWebApp(@NotNull final String sid, @NotNull final String webAppId,
-                                   @Nullable final String name) throws Exception {
+    protected WebAppBase getWebAppBase(@NotNull final String sid, @NotNull final String webAppId,
+                                       @Nullable final String name) throws Exception {
         return AzureWebAppMvpModel.getInstance().getWebAppById(sid, webAppId);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBasePropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBasePropertyViewPresenter.java
@@ -42,7 +42,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppBaseP
 
 import rx.Observable;
 
-public abstract class WebAppBasePropertyViewPresenter<V extends WebAppBasePropertyMvpView, E extends String> extends MvpPresenter<V> {
+public abstract class WebAppBasePropertyViewPresenter<V extends WebAppBasePropertyMvpView> extends MvpPresenter<V> {
     public static final String KEY_NAME = "name";
     public static final String KEY_TYPE = "type";
     public static final String KEY_RESOURCE_GRP = "resourceGroup";
@@ -58,7 +58,7 @@ public abstract class WebAppBasePropertyViewPresenter<V extends WebAppBaseProper
     public static final String KEY_OPERATING_SYS = "operatingSystem";
     public static final String KEY_APP_SETTING = "appSetting";
 
-    private static final String CANNOT_GET_WEB_APP_PROPERTY = "Exception occurred when getting the application settings.";
+    private static final String CANNOT_GET_WEB_APP_PROPERTY = "An exception occurred when getting the application settings.";
 
     public void onLoadWebAppProperty(final String sid, @NotNull final String webAppId, @Nullable final String name) {
         Observable.fromCallable(() -> {

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBasePropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBasePropertyViewPresenter.java
@@ -24,14 +24,12 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.appservice.AppServicePlan;
 import com.microsoft.azure.management.appservice.AppSetting;
-import com.microsoft.azure.management.appservice.DeploymentSlot;
 import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
@@ -40,11 +38,11 @@ import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
 import com.microsoft.azuretools.core.mvp.ui.webapp.WebAppProperty;
 import com.microsoft.azuretools.telemetry.AppInsightsClient;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
-import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyMvpView;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppBasePropertyMvpView;
 
 import rx.Observable;
 
-public abstract class WebAppBasePropertyViewPresenter<V extends WebAppPropertyMvpView, E extends String> extends MvpPresenter<V> {
+public abstract class WebAppBasePropertyViewPresenter<V extends WebAppBasePropertyMvpView, E extends String> extends MvpPresenter<V> {
     public static final String KEY_NAME = "name";
     public static final String KEY_TYPE = "type";
     public static final String KEY_RESOURCE_GRP = "resourceGroup";
@@ -60,12 +58,12 @@ public abstract class WebAppBasePropertyViewPresenter<V extends WebAppPropertyMv
     public static final String KEY_OPERATING_SYS = "operatingSystem";
     public static final String KEY_APP_SETTING = "appSetting";
 
-    private static final String CANNOT_GET_WEB_APP_PROPERTY = "Cannot get Web App's property.";
+    private static final String CANNOT_GET_WEB_APP_PROPERTY = "Exception occurred when getting the application settings.";
 
     public void onLoadWebAppProperty(final String sid, @NotNull final String webAppId, @Nullable final String name) {
         Observable.fromCallable(() -> {
             final Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
-            final WebAppBase appBase = getWebApp(sid, webAppId, name);
+            final WebAppBase appBase = getWebAppBase(sid, webAppId, name);
             final AppServicePlan plan = azure.appServices().appServicePlans().getById(appBase.appServicePlanId());
             return generateProperty(appBase, plan);
         }).subscribeOn(getSchedulerProvider().io())
@@ -108,8 +106,8 @@ public abstract class WebAppBasePropertyViewPresenter<V extends WebAppPropertyMv
         return new WebAppProperty(propertyMap);
     }
 
-    protected abstract WebAppBase getWebApp(@NotNull String sid, @NotNull String webAppId,
-                                            @Nullable String name) throws Exception;
+    protected abstract WebAppBase getWebAppBase(@NotNull String sid, @NotNull String webAppId,
+                                                @Nullable String name) throws Exception;
 
     protected abstract void updateAppSettings(@NotNull String sid, @NotNull String webAppId, @Nullable String name,
                                               @NotNull Map toUpdate, @NotNull Set toRemove) throws Exception;

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBasePropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBasePropertyViewPresenter.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.appservice.AppServicePlan;
+import com.microsoft.azure.management.appservice.AppSetting;
+import com.microsoft.azure.management.appservice.WebAppBase;
+import com.microsoft.azuretools.authmanage.AuthMethodManager;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
+import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
+import com.microsoft.azuretools.core.mvp.ui.webapp.WebAppProperty;
+import com.microsoft.azuretools.telemetry.AppInsightsClient;
+import com.microsoft.tooling.msservices.components.DefaultLoader;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyMvpView;
+
+import rx.Observable;
+
+public abstract class WebAppBasePropertyViewPresenter<V extends WebAppPropertyMvpView, E extends String> extends MvpPresenter<V> {
+    public static final String KEY_NAME = "name";
+    public static final String KEY_TYPE = "type";
+    public static final String KEY_RESOURCE_GRP = "resourceGroup";
+    public static final String KEY_LOCATION = "location";
+    public static final String KEY_SUB_ID = "subscription";
+    public static final String KEY_STATUS = "status";
+    public static final String KEY_PLAN = "servicePlan";
+    public static final String KEY_URL = "url";
+    public static final String KEY_PRICING = "pricingTier";
+    public static final String KEY_JAVA_VERSION = "javaVersion";
+    public static final String KEY_JAVA_CONTAINER = "javaContainer";
+    public static final String KEY_JAVA_CONTAINER_VERSION = "javaContainerVersion";
+    public static final String KEY_OPERATING_SYS = "operatingSystem";
+    public static final String KEY_APP_SETTING = "appSetting";
+    private static final String CANNOT_GET_WEB_APP_PROPERTY = "Cannot get Web App's property.";
+
+    public void onLoadWebAppProperty(final String sid, @NotNull final WebAppBase webAppBase) {
+        Observable.fromCallable(() -> {
+            final Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
+            final AppServicePlan plan = azure.appServices().appServicePlans().getById(webAppBase.appServicePlanId());
+            return generateProperty(webAppBase, plan);
+        }).subscribeOn(getSchedulerProvider().io())
+            .subscribe(property -> DefaultLoader.getIdeHelper().invokeLater(() -> {
+                if (isViewDetached()) {
+                    return;
+                }
+                getMvpView().showProperty(property);
+            }), e -> errorHandler((Exception) e));
+    }
+
+    protected WebAppProperty generateProperty(@NotNull final WebAppBase webAppBase, @NotNull final AppServicePlan plan) {
+        final Map<String, String> appSettingsMap = new HashMap<>();
+        final Map<String, AppSetting> appSetting = webAppBase.getAppSettings();
+        for (final String key : appSetting.keySet()) {
+            final AppSetting setting = appSetting.get(key);
+            if (setting != null) {
+                appSettingsMap.put(setting.key(), setting.value());
+            }
+        }
+        final Map<String, Object> propertyMap = new HashMap<>();
+        propertyMap.put(KEY_NAME, webAppBase.name());
+        propertyMap.put(KEY_TYPE, webAppBase.type());
+        propertyMap.put(KEY_RESOURCE_GRP, webAppBase.resourceGroupName());
+        propertyMap.put(KEY_LOCATION, webAppBase.regionName());
+        propertyMap.put(KEY_SUB_ID, webAppBase.manager().subscriptionId());
+        propertyMap.put(KEY_STATUS, webAppBase.state());
+        propertyMap.put(KEY_PLAN, plan.name());
+        propertyMap.put(KEY_URL, webAppBase.defaultHostName());
+        propertyMap.put(KEY_PRICING, plan.pricingTier().toString());
+        final String javaVersion = webAppBase.javaVersion().toString();
+        if (!javaVersion.equals("null")) {
+            propertyMap.put(KEY_JAVA_VERSION, webAppBase.javaVersion().toString());
+            propertyMap.put(KEY_JAVA_CONTAINER, webAppBase.javaContainer());
+            propertyMap.put(KEY_JAVA_CONTAINER_VERSION, webAppBase.javaContainerVersion());
+        }
+        propertyMap.put(KEY_OPERATING_SYS, webAppBase.operatingSystem());
+        propertyMap.put(KEY_APP_SETTING, appSettingsMap);
+
+        return new WebAppProperty(propertyMap);
+    }
+
+    protected abstract void performUpdateSettings(@NotNull String sid, @NotNull WebAppBase webAppBase,
+                                                  @NotNull Map toUpdate, @NotNull Set toRemove) throws Exception;
+
+    protected abstract boolean performGetPublishingProfile(@NotNull String sid, @NotNull WebAppBase webAppBase,
+                                                           @NotNull String filePath) throws Exception;
+
+    public void onUpdateWebAppProperty(@NotNull final String sid, @NotNull final WebAppBase webAppBase,
+                                       @NotNull final Map<String, String> cacheSettings,
+                                       @NotNull final Map<String, String> editedSettings) {
+        final Map<String, String> telemetryMap = new HashMap<>();
+        telemetryMap.put("SubscriptionId", sid);
+        Observable.fromCallable(() -> {
+            final Set<String> toRemove = new HashSet<>();
+            for (String key : cacheSettings.keySet()) {
+                if (!editedSettings.containsKey(key)) {
+                    toRemove.add(key);
+                }
+            }
+            performUpdateSettings(sid, webAppBase, editedSettings, toRemove);
+            return true;
+        }).subscribeOn(getSchedulerProvider().io())
+            .subscribe(property -> DefaultLoader.getIdeHelper().invokeLater(() -> {
+                if (isViewDetached()) {
+                    return;
+                }
+                getMvpView().showPropertyUpdateResult(true);
+                sendTelemetry("UpdateAppSettings", telemetryMap, true, null);
+            }), e -> {
+                errorHandler((Exception) e);
+                if (isViewDetached()) {
+                    return;
+                }
+                getMvpView().showPropertyUpdateResult(false);
+                sendTelemetry("UpdateAppSettings", telemetryMap, false, e.getMessage());
+            });
+    }
+
+    public void onGetPublishingProfileXmlWithSecrets(@NotNull String sid, @NotNull WebAppBase webAppBase,
+                                                     @NotNull String filePath) {
+        final Map<String, String> telemetryMap = new HashMap<>();
+        telemetryMap.put("SubscriptionId", sid);
+        Observable.fromCallable(() -> performGetPublishingProfile(sid, webAppBase, filePath))
+            .subscribeOn(getSchedulerProvider().io()).subscribe(res -> DefaultLoader.getIdeHelper().invokeLater(() -> {
+            if (isViewDetached()) {
+                return;
+            }
+            getMvpView().showGetPublishingProfileResult(res);
+            sendTelemetry("DownloadPublishProfile", telemetryMap, true, null);
+        }), e -> {
+            errorHandler((Exception) e);
+            if (isViewDetached()) {
+                return;
+            }
+            getMvpView().showGetPublishingProfileResult(false);
+            sendTelemetry("DownloadPublishProfile", telemetryMap, false, e.getMessage());
+        });
+    }
+
+    protected void errorHandler(final Exception e) {
+        DefaultLoader.getIdeHelper().invokeLater(() -> {
+            if (isViewDetached()) {
+                return;
+            }
+            getMvpView().onErrorWithException(CANNOT_GET_WEB_APP_PROPERTY, e);
+        });
+    }
+
+    protected void sendTelemetry(@NotNull final String actionName, @NotNull final Map<String, String> telemetryMap,
+                                 final boolean success, @Nullable final String errorMsg) {
+        telemetryMap.put("Success", String.valueOf(success));
+        if (!success) {
+            telemetryMap.put("ErrorMsg", errorMsg);
+        }
+        AppInsightsClient.createByType(AppInsightsClient.EventType.Action, "WebApp", actionName, telemetryMap);
+    }
+}

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNode.java
@@ -25,6 +25,7 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deployment
 import java.io.IOException;
 import java.util.List;
 
+import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeAction;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
@@ -50,6 +51,10 @@ public class DeploymentSlotNode extends WebAppBaseNode implements DeploymentSlot
         loadActions();
     }
 
+    public String getWebAppId() {
+        return this.webAppId;
+    }
+
     @Override
     public List<NodeAction> getNodeActions() {
         getNodeActionByName(ACTION_SWAP_WITH_PRODUCTION).setEnabled(this.state == WebAppBaseState.RUNNING);
@@ -70,6 +75,12 @@ public class DeploymentSlotNode extends WebAppBaseNode implements DeploymentSlot
             @Override
             protected void actionPerformed(NodeActionEvent e) {
                 DefaultLoader.getUIHelper().openInBrowser("http://" + hostName);
+            }
+        });
+        addAction(ACTION_SHOW_PROPERTY, new NodeActionListener() {
+            @Override
+            protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
+                DefaultLoader.getUIHelper().openDeploymentSlotPropertyView(DeploymentSlotNode.this);
             }
         });
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
@@ -50,8 +50,8 @@ public class DeploymentSlotPropertyViewPresenter extends WebAppBasePropertyViewP
     }
 
     @Override
-    protected WebAppBase getWebApp(@NotNull final String sid, @NotNull final String webAppId,
-                                   @Nullable final String name) throws Exception {
+    protected WebAppBase getWebAppBase(@NotNull final String sid, @NotNull final String webAppId,
+                                       @Nullable final String name) throws Exception {
         return AzureWebAppMvpModel.getInstance().getWebAppById(sid, webAppId).deploymentSlots().getByName(name);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
@@ -22,25 +22,36 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.microsoft.azure.management.appservice.DeploymentSlot;
 import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
+import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
 public class DeploymentSlotPropertyViewPresenter extends WebAppBasePropertyViewPresenter {
     @Override
-    protected void performUpdateSettings(@NotNull final String sid, @NotNull final WebAppBase webAppBase,
-                                         final Map toUpdate, final Set toRemove) throws Exception {
+    protected void updateAppSettings(@NotNull final String sid, @NotNull final String webAppId,
+                                     @Nullable final String name, final Map toUpdate,
+                                     final Set toRemove) throws Exception {
         // todo
     }
 
     @Override
-    protected boolean performGetPublishingProfile(@NotNull final String subscriptionId,
-                                                  @NotNull final WebAppBase webAppBase,
-                                                  @NotNull final String filePath) throws Exception {
+    protected boolean getPublishingProfile(@NotNull final String subscriptionId, @NotNull final String webAppId,
+                                           @Nullable final String name,
+                                           @NotNull final String filePath) throws Exception {
         // todo
         return false;
+    }
+
+    @Override
+    protected WebAppBase getWebApp(@NotNull final String sid, @NotNull final String webAppId,
+                                   @Nullable final String name) throws Exception {
+        return AzureWebAppMvpModel.getInstance().getWebAppById(sid, webAppId).deploymentSlots().getByName(name);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
@@ -20,27 +20,27 @@
  * SOFTWARE.
  */
 
-package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
+package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot;
 
 import java.util.Map;
 import java.util.Set;
 
 import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
-import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
-public class WebAppPropertyViewPresenter extends WebAppBasePropertyViewPresenter {
+public class DeploymentSlotPropertyViewPresenter extends WebAppBasePropertyViewPresenter {
     @Override
     protected void performUpdateSettings(@NotNull final String sid, @NotNull final WebAppBase webAppBase,
                                          final Map toUpdate, final Set toRemove) throws Exception {
-        AzureWebAppMvpModel.getInstance().updateWebAppSettings(sid, webAppBase.id(), toUpdate, toRemove);
+        // todo
     }
 
     @Override
-    protected boolean performGetPublishingProfile(@NotNull final String sid, @NotNull final WebAppBase webAppBase,
+    protected boolean performGetPublishingProfile(@NotNull final String subscriptionId,
+                                                  @NotNull final WebAppBase webAppBase,
                                                   @NotNull final String filePath) throws Exception {
-        return AzureWebAppMvpModel.getInstance().getPublishingProfileXmlWithSecrets(
-            sid, webAppBase.id(), filePath);
+        // todo
+        return false;
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
@@ -38,15 +38,15 @@ public class DeploymentSlotPropertyViewPresenter extends WebAppBasePropertyViewP
     protected void updateAppSettings(@NotNull final String sid, @NotNull final String webAppId,
                                      @Nullable final String name, final Map toUpdate,
                                      final Set toRemove) throws Exception {
-        // todo
+        AzureWebAppMvpModel.getInstance().updateDeploymentSlotAppSettings(sid, webAppId, name, toUpdate, toRemove);
     }
 
     @Override
     protected boolean getPublishingProfile(@NotNull final String subscriptionId, @NotNull final String webAppId,
                                            @Nullable final String name,
                                            @NotNull final String filePath) throws Exception {
-        // todo
-        return false;
+        return AzureWebAppMvpModel.getInstance()
+            .getSlotPublishingProfileXmlWithSecrets(subscriptionId, webAppId, name, filePath);
     }
 
     @Override

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -671,7 +671,7 @@ public class AzureWebAppMvpModel {
      * Work Around:
      * When a web app is created from Azure Portal, there are hidden tags associated with the app.
      * It will be messed up when calling "update" API.
-     * An issue is logged at https://github.com/Azure/azure-sdk-for-java/issues/1755 .
+     * An issue is logged at https://github.com/Azure/azure-libraries-for-java/issues/508 .
      * Remove all tags here to make it work.
      */
     private void clearTags(@NotNull final WebAppBase app) {


### PR DESCRIPTION
#2212 
The PR includes all the changes to add the operation "Show properties" for deployment slots. The changes could be grouped into following parts and reflect in different commits:
- Change existing `WebAppPropertyView` to an abstract base class`WebAppBasePropertyView`, and create new `WebAppPropertyView` and `DeploymentSlotPropertyView` extending from the base class, let them override the abstract methods to handle their different UI logic
- Change exisitng `WebAppPropertyViewProvider` to an abstract base class `WebAppBasePropertyViewProvider`, and create new classes `WebAppPropertyViewProvider` and `DeploymentSlotPropertyViewProvider` extending from the base class, let them override the abstract methods to handle their differnt logic
- Change existing `WebAppPropertyViewPresenter` to an abstract base class`WebAppBasePropertyViewPresenter`, and create new classes `WebAppPropertyViewPresenter` and `DeploymentSlotPropertyViewPresenter` extending from the base class, let them override the abstract methods to handle their different presenting logic
- Add new interface `openDeploymentSlotPropertyView` to handle the deployment slot operations
- Add new API in `AzureWebAppMvpModel` to handle deployment slot backend operations