### PR TITLE
Fix 183 EAP build regression 

### DIFF
--- a/BuildDevint
+++ b/BuildDevint
@@ -6,17 +6,29 @@ SCRIPTPATH=$(pwd -P)
 cd "$SCRIPTPATH"
 
 MAVEN_QUIET=""
+
+# Utils
 SKIP_CHECKSTYLE=$TRAVIS
-INTELLIJ_VERSION=false
+
+# Eclipse
 BUILD_ECLIPSE=true
+
+#IntelliJ
 BUILD_INTELLIJ=true
+INJECT_INTELLIJ_VERSION=false
+
+IJ_VERSION_LATEST=183.3795.13
+IJ_SCALA_VERSION_LATEST=2018.3.2
+
+IJ_VERSION_FALLBACK=2018.2
+IJ_SCALA_VERSION_FALLBACK=2018.2.11
 
 while getopts "hqve:" option; do
   echo $option
     case $option in
         h) echo "usage: $0 [-h] [-q] [-v] [-e eclipse/intellij]"; exit ;;
         q) MAVEN_QUIET="-q" ;;
-        v) INTELLIJ_VERSION=true ;;
+        v) INJECT_INTELLIJ_VERSION=true ;;
         e)
           shopt -s nocasematch
           case $OPTARG in 
@@ -53,23 +65,23 @@ fi
 if $BUILD_INTELLIJ; then
   echo "Building IntelliJ plugin ..."
   chmod +x ./tools/IntellijVersionHelper
-  ## Build intellij 2018.1 plugin
-  if [ $INTELLIJ_VERSION == "true" ] ; then
-      ./tools/IntellijVersionHelper 2018.1
+  ## Build intellij plugin for latest version
+  if [ $INJECT_INTELLIJ_VERSION == "true" ] ; then
+      ./tools/IntellijVersionHelper $IJ_VERSION_LATEST
   fi
 
-  (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s -Pintellij_version=IC-2018.1 -Pdep_plugins=org.intellij.scala:2018.1.8)
+  (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s -Pintellij_version=IC-$IJ_VERSION_LATEST -Pdep_plugins=org.intellij.scala:$IJ_SCALA_VERSION_LATEST)
 
-  cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.1.zip
+  cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-$IJ_VERSION_LATEST.zip
 
-  ## Build intellij 2018.2 compatible plugin
-  if [ $INTELLIJ_VERSION == "true" ] ; then
-      ./tools/IntellijVersionHelper 2018.2
+  ## Build intellij plugin for fallback version
+  if [ $INJECT_INTELLIJ_VERSION == "true" ] ; then
+      ./tools/IntellijVersionHelper $IJ_VERSION_FALLBACK
   fi
 
-  (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s)
+  (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s -Pintellij_version=IC-$IJ_VERSION_FALLBACK -Pdep_plugins=org.intellij.scala:$IJ_SCALA_VERSION_FALLBACK)
 
-  cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-2018.2.zip
+  cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-$IJ_VERSION_FALLBACK.zip
 fi
 
 echo "ALL BUILD SUCCESSFUL"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version "0.3.4"
+    id "org.jetbrains.intellij" version "0.3.12"
     id "org.jetbrains.kotlin.jvm" version "1.2.50"
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -1,7 +1,7 @@
 javaVersion=1.8
 org.gradle.jvmargs='-Duser.language=en'
 sources=false
-intellij_version=IC-2018.2
-dep_plugins=org.intellij.scala:2018.2.1
+intellij_version=IC-LATEST-EAP-SNAPSHOT
+dep_plugins=org.intellij.scala:2018.3.2
 applicationinsights.key=57cc111a-36a8-44b3-b044-25d293b8b77c
 updateVersionRange=true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/projects/SbtProjectGenerator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/projects/SbtProjectGenerator.java
@@ -196,7 +196,7 @@ public class SbtProjectGenerator {
             return;
         }
 
-        final VirtualFile projectFile = VfsUtil.findFile(Paths.get(root + "/build.sbt"), true);
+        final VirtualFile projectFile = VfsUtil.findFile(Paths.get(root, "build.sbt"), true);
         if (projectFile != null) {
             ApplicationManager.getApplication().invokeLater(() -> {
                 AddModuleWizard wizard = ImportModuleAction.createImportWizard(project,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/actions/SparkAppSubmitContext.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/actions/SparkAppSubmitContext.kt
@@ -28,7 +28,7 @@ import com.intellij.openapi.actionSystem.DataKey
 class SparkAppSubmitContext : DataContext {
     private val dataStore = mutableMapOf<String, Any>()
 
-    override fun getData(key: String?): Any? {
+    override fun getData(key: String): Any? {
         return dataStore[key]
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/actions/SparkSubmitJobAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/actions/SparkSubmitJobAction.kt
@@ -47,12 +47,8 @@ class SparkSubmitJobAction : AzureAnAction() {
         submit(runConfigurationSetting, clusterName, mainClassName)
     }
 
-    override fun update(event: AnActionEvent?) {
+    override fun update(event: AnActionEvent) {
         super.update(event)
-
-        if (event == null) {
-            return
-        }
 
         event.presentation.isEnabledAndVisible = getRunConfigurationFromDataContext(event.dataContext) != null
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/RunSparkConsoleActionDelegate.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/RunSparkConsoleActionDelegate.kt
@@ -40,8 +40,8 @@ open class RunSparkConsoleActionDelegate(sparkScalaActionClassName: String) : Az
     private val actionPerformedMethod: Method?
         get() = delegate.getMethod("actionPerformed", AnActionEvent::class.java)
 
-    override fun update(actionEvent: AnActionEvent?) {
-        val presentation = actionEvent?.presentation ?: return
+    override fun update(actionEvent: AnActionEvent) {
+        val presentation = actionEvent.presentation
 
         // Hide for the Scala plugin not installed
         presentation.isVisible = isEnabled

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/RunSparkScalaConsoleAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/RunSparkScalaConsoleAction.kt
@@ -23,10 +23,10 @@
 package com.microsoft.azure.hdinsight.spark.console
 
 import com.intellij.execution.*
+import com.intellij.execution.configuration.AbstractRunConfiguration
 import com.intellij.execution.configurations.ConfigurationType
 import com.intellij.execution.configurations.ConfigurationTypeUtil.findConfigurationType
 import com.intellij.execution.configurations.RunConfiguration
-import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.configurations.RunProfile
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder
@@ -36,14 +36,13 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.psi.PsiFile
+import com.microsoft.azure.hdinsight.common.logger.ILogger
+import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfiguration
 import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfigurationType
-import com.microsoft.azuretools.ijidea.utility.AzureAnAction
+import com.microsoft.intellij.util.runInReadAction
 import org.jetbrains.plugins.scala.console.RunConsoleAction
 import org.jetbrains.plugins.scala.console.ScalaConsoleRunConfigurationFactory
 import org.jetbrains.plugins.scala.lang.psi.api.ScalaFile
-import com.microsoft.azure.hdinsight.common.logger.ILogger
-import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfiguration
-import com.microsoft.intellij.util.runInReadAction
 import scala.Function1
 import scala.runtime.BoxedUnit
 
@@ -132,7 +131,7 @@ abstract class RunSparkScalaConsoleAction
     }
 
     open fun checkSettingsBeforeRun(runProfile: RunProfile?) {
-        (runProfile as? RunConfigurationBase)?.checkSettingsBeforeRun()
+        (runProfile as? AbstractRunConfiguration)?.checkSettingsBeforeRun()
     }
 
     override fun getMyConfigurationType(): RemoteDebugRunConfigurationType? =

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/RunSparkScalaLivyConsoleAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/RunSparkScalaLivyConsoleAction.kt
@@ -22,7 +22,7 @@
 
 package com.microsoft.azure.hdinsight.spark.console
 
-import com.intellij.execution.configurations.RunConfigurationBase
+import com.intellij.execution.configuration.AbstractRunConfiguration
 import com.intellij.execution.configurations.RunProfile
 import com.microsoft.azure.hdinsight.common.logger.ILogger
 import org.jetbrains.plugins.scala.console.ScalaConsoleRunConfigurationFactory
@@ -32,7 +32,7 @@ class RunSparkScalaLivyConsoleAction : RunSparkScalaConsoleAction(), ILogger {
         get() = SparkScalaLivyConsoleConfigurationType().confFactory()
 
     override fun checkSettingsBeforeRun(runProfile: RunProfile?) {
-        (runProfile as? RunConfigurationBase)?.checkSettingsBeforeRun()
+        (runProfile as? AbstractRunConfiguration)?.checkSettingsBeforeRun()
     }
 
     override fun getNewSettingName(): String = "Spark Livy Interactive Session Console(Scala)"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkConsoleExecuteAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkConsoleExecuteAction.kt
@@ -35,8 +35,8 @@ import java.io.IOException
 import java.nio.charset.StandardCharsets.UTF_8
 
 class SparkConsoleExecuteAction() : AzureAnAction(), DumbAware, ILogger {
-    override fun update(e: AnActionEvent?) {
-        val editor = e?.getData(EDITOR) ?: return
+    override fun update(e: AnActionEvent) {
+        val editor = e.getData(EDITOR) ?: return
 
         if (editor !is EditorEx) {
             e.presentation.isEnabled = false

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfiguration.kt
@@ -23,6 +23,7 @@
 package com.microsoft.azure.hdinsight.spark.console
 
 import com.intellij.execution.Executor
+import com.intellij.execution.configuration.AbstractRunConfiguration
 import com.intellij.execution.configurations.*
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.module.Module
@@ -30,11 +31,9 @@ import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.microsoft.azure.hdinsight.common.ClusterManagerEx
-import com.microsoft.azure.hdinsight.sdk.cluster.HDInsightLivyLinkClusterDetail
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail
 import com.microsoft.azure.hdinsight.sdk.cluster.LivyCluster
 import com.microsoft.azure.hdinsight.sdk.common.livy.interactive.SparkSession
-import com.microsoft.azure.hdinsight.spark.jobs.JobUtils
 import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfiguration
 import java.net.URI
 
@@ -42,7 +41,7 @@ class SparkScalaLivyConsoleRunConfiguration(project: Project,
                                             configurationFactory: SparkScalaLivyConsoleRunConfigurationFactory,
                                             batchRunConfiguration: RemoteDebugRunConfiguration?,
                                             name: String)
-    : ModuleBasedConfiguration<RunConfigurationModule>(
+    : AbstractRunConfiguration (
         name, batchRunConfiguration?.configurationModule ?: RunConfigurationModule(project), configurationFactory)
 {
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfigurationFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfigurationFactory.kt
@@ -33,12 +33,12 @@ class SparkScalaLivyConsoleRunConfigurationFactory(sparkConsoleType: SparkScalaL
         return SparkScalaLivyConsoleRunConfiguration(project, this, null, "")
     }
 
-    override fun createConfiguration(name: String, template: RunConfiguration): RunConfiguration {
+    override fun createConfiguration(name: String?, template: RunConfiguration): RunConfiguration {
         // Create a Spark Scala Livy run configuration based on Spark Batch run configuration
         return SparkScalaLivyConsoleRunConfiguration(
                 template.project,
                 this,
                 template as? RemoteDebugRunConfiguration,
-                "${template.name} >> Spark Livy Interactive Session Console(Scala)")
+                "${template.name ?: ""} >> Spark Livy Interactive Session Console(Scala)")
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkSendSelectionToConsoleAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkSendSelectionToConsoleAction.kt
@@ -33,8 +33,8 @@ import org.jetbrains.plugins.scala.lang.psi.api.ScalaFile
 import java.nio.charset.StandardCharsets.UTF_8
 
 class SparkSendSelectionToConsoleAction : AzureAnAction(), ILogger {
-    override fun update(actionEvent: AnActionEvent?) {
-        val presentation = actionEvent?.presentation ?: return
+    override fun update(actionEvent: AnActionEvent) {
+        val presentation = actionEvent.presentation
 
         fun setEnabled(v: Boolean) {
             presentation.isEnabled = v

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkRunConfigurationAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkRunConfigurationAction.kt
@@ -23,9 +23,10 @@
 package com.microsoft.azure.hdinsight.spark.run.action
 
 import com.intellij.execution.*
-import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.configurations.RunProfile
+import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder
+import com.intellij.execution.runners.ProgramRunner
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
@@ -83,7 +84,7 @@ abstract class SparkRunConfigurationAction : AzureAnAction, ILogger {
 
         try {
             val environment = ExecutionEnvironmentBuilder.create(runExecutor, configuration).build()
-            checkSettingsBeforeRun(environment.runProfile)
+            checkRunnerSettings(environment.runProfile, runner)
 
             runner.execute(environment)
         } catch (e: ExecutionException) {
@@ -91,8 +92,8 @@ abstract class SparkRunConfigurationAction : AzureAnAction, ILogger {
         }
     }
 
-    open fun checkSettingsBeforeRun(runProfile: RunProfile?) {
-        (runProfile as? RunConfigurationBase)?.checkSettingsBeforeRun()
+    open fun checkRunnerSettings(runProfile: RunProfile?, runner: ProgramRunner<RunnerSettings>) {
+        (runProfile as? RemoteDebugRunConfiguration)?.checkRunnerSettings(runner, null, null)
     }
 
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkRunConfigurationAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkRunConfigurationAction.kt
@@ -47,10 +47,10 @@ abstract class SparkRunConfigurationAction : AzureAnAction, ILogger {
             setting.configuration is RemoteDebugRunConfiguration &&
                     RunnerRegistry.getInstance().getRunner(runExecutor.id, setting.configuration) != null
 
-    override fun update(actionEvent: AnActionEvent?) {
+    override fun update(actionEvent: AnActionEvent) {
         super.update(actionEvent)
 
-        val project = actionEvent?.project ?: return
+        val project = actionEvent.project ?: return
         val runManagerEx = RunManagerEx.getInstanceEx(project)
         val selectedConfigSettings = runManagerEx.selectedConfiguration ?: return
         val presentation = actionEvent.presentation

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/RemoteDebugRunConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/RemoteDebugRunConfiguration.java
@@ -22,10 +22,10 @@
 package com.microsoft.azure.hdinsight.spark.run.configuration;
 
 import com.intellij.compiler.options.CompileStepBeforeRun;
-import com.intellij.execution.BeforeRunTask;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.JavaExecutionUtil;
+import com.intellij.execution.configuration.AbstractRunConfiguration;
 import com.intellij.execution.configurations.*;
 import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.executors.DefaultRunExecutor;
@@ -55,7 +55,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class RemoteDebugRunConfiguration extends ModuleBasedConfiguration<RunConfigurationModule>
+public class RemoteDebugRunConfiguration extends AbstractRunConfiguration
 {
     enum RunMode {
         LOCAL,
@@ -178,24 +178,24 @@ public class RemoteDebugRunConfiguration extends ModuleBasedConfiguration<RunCon
 
     @NotNull
     @Override
-    public List<BeforeRunTask> getBeforeRunTasks() {
-        Stream<BeforeRunTask> compileTask = super.getBeforeRunTasks().stream()
+    public List getBeforeRunTasks() {
+        Stream compileTask = super.getBeforeRunTasks().stream()
                 .filter(task -> task instanceof CompileStepBeforeRun.MakeBeforeRunTask);
-        Stream<BeforeRunTask> buildArtifactTask = super.getBeforeRunTasks().stream()
+        Stream buildArtifactTask = super.getBeforeRunTasks().stream()
                 .filter(task -> task instanceof BuildArtifactsBeforeRunTask);
 
         switch (mode) {
         case LOCAL:
-            compileTask.forEach(task -> task.setEnabled(true));
-            buildArtifactTask.forEach(task -> task.setEnabled(false));
+            compileTask.forEach(task -> ((CompileStepBeforeRun.MakeBeforeRunTask) task).setEnabled(true));
+            buildArtifactTask.forEach(task -> ((BuildArtifactsBeforeRunTask) task).setEnabled(false));
             break;
         case REMOTE:
-            compileTask.forEach(task -> task.setEnabled(false));
-            buildArtifactTask.forEach(task -> task.setEnabled(true));
+            compileTask.forEach(task -> ((CompileStepBeforeRun.MakeBeforeRunTask) task).setEnabled(false));
+            buildArtifactTask.forEach(task -> ((BuildArtifactsBeforeRunTask) task).setEnabled(true));
             break;
         case REMOTE_DEBUG_EXECUTOR:
-            compileTask.forEach(task -> task.setEnabled(false));
-            buildArtifactTask.forEach(task -> task.setEnabled(false));
+            compileTask.forEach(task -> ((CompileStepBeforeRun.MakeBeforeRunTask) task).setEnabled(false));
+            buildArtifactTask.forEach(task -> ((BuildArtifactsBeforeRunTask) task).setEnabled(false));
             break;
         }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/SparkFailureTaskDebugConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/SparkFailureTaskDebugConfiguration.kt
@@ -23,6 +23,7 @@
 package com.microsoft.azure.hdinsight.spark.run.configuration
 
 import com.intellij.execution.Executor
+import com.intellij.execution.configuration.AbstractRunConfiguration
 import com.intellij.execution.configurations.*
 import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.execution.executors.DefaultRunExecutor
@@ -37,7 +38,7 @@ import org.jdom.Element
 class SparkFailureTaskDebugConfiguration(name: String,
                                          val module: SparkFailureTaskDebugConfigurableModel,
                                          factory: ConfigurationFactory) :
-        ModuleBasedConfiguration<RunConfigurationModule>(name, module, factory) {
+        AbstractRunConfiguration(name, module, factory) {
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
         return SparkFailureTaskDebugSettingsEditor(module.project)
     }


### PR DESCRIPTION
There are following type issues solved:

1. More strict NPE checking for Kotlin codes.
   - Fix it by removing `?` from the type.
2. 183 EAP API generic type changes, such as: `RunConfigurationBase` -> `RunConfigurationBase<T>`
   - Leverage Java class to bypass the check. Java code ignore the generic type checking.
3. Some class names are changed in the new version Scala plugin, such as: `SbtSystemSettings` -> `SbtSettings`
   - Remove that dependency by invoking from `ExternalSystemManager` and `ProjectImportProvider` level API.