### PR TITLE
Support interactive console for Spark on Cosmos

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/ServerlessSparkScalaLivyConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/ServerlessSparkScalaLivyConsoleRunConfiguration.kt
@@ -25,7 +25,6 @@ package com.microsoft.azure.hdinsight.spark.console
 import com.intellij.execution.Executor
 import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.configurations.RuntimeConfigurationError
-import com.intellij.execution.configurations.RuntimeConfigurationWarning
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.project.Project
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessCluster
@@ -41,19 +40,18 @@ class ServerlessSparkScalaLivyConsoleRunConfiguration(project: Project,
     : SparkScalaLivyConsoleRunConfiguration(
         project, configurationFactory, batchRunConfiguration, name)
 {
-    override var clusterName : String = getSubmitModel()?.submissionParameter?.clusterName
-            ?: throw RuntimeConfigurationWarning("An Azure Data Lake Spark Run Configuration should be selected to start a console")
+    override val runConfigurationTypeName = "Azure Data Lake Spark Run Configuration"
 
     override fun getState(executor: Executor, env: ExecutionEnvironment): RunProfileState? {
-        var sparkCluster = cluster as? AzureSparkServerlessCluster ?: return null
+        val sparkCluster = cluster as? AzureSparkServerlessCluster ?: return null
 
-        var livyUrl = (sparkCluster?.livyUri?.toString()?:return null).trimEnd('/') + '/'
+        val livyUrl = (sparkCluster.livyUri?.toString() ?: return null).trimEnd('/') + "/"
 
         val session = ServerlessSparkSession(
                 name,
                 URI.create(livyUrl),
-                sparkCluster?.tenantId,
-                sparkCluster?.account)
+                sparkCluster.tenantId,
+                sparkCluster.account)
 
         return SparkScalaLivyConsoleRunProfileState(SparkScalaConsoleBuilder(project), session)
     }
@@ -63,6 +61,6 @@ class ServerlessSparkScalaLivyConsoleRunConfiguration(project: Project,
                 .getInstance()
                 .clusters
                 .find { it.name == this.clusterName }
-                ?:throw RuntimeConfigurationError("Can't find the target cluster $clusterName");
+                ?:throw RuntimeConfigurationError("Can't find the target cluster $clusterName")
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/ServerlessSparkScalaLivyConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/ServerlessSparkScalaLivyConsoleRunConfiguration.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.hdinsight.spark.console
+
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.RunProfileState
+import com.intellij.execution.configurations.RuntimeConfigurationError
+import com.intellij.execution.configurations.RuntimeConfigurationWarning
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.project.Project
+import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessCluster
+import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessClusterManager
+import com.microsoft.azure.hdinsight.sdk.common.livy.interactive.ServerlessSparkSession
+import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfiguration
+import java.net.URI
+
+class ServerlessSparkScalaLivyConsoleRunConfiguration(project: Project,
+                                            configurationFactory: SparkScalaLivyConsoleRunConfigurationFactory,
+                                            batchRunConfiguration: RemoteDebugRunConfiguration?,
+                                            name: String)
+    : SparkScalaLivyConsoleRunConfiguration(
+        project, configurationFactory, batchRunConfiguration, name)
+{
+    override var clusterName : String = getSubmitModel()?.submissionParameter?.clusterName
+            ?: throw RuntimeConfigurationWarning("An Azure Data Lake Spark Run Configuration should be selected to start a console")
+
+    override fun getState(executor: Executor, env: ExecutionEnvironment): RunProfileState? {
+        var sparkCluster = cluster as? AzureSparkServerlessCluster ?: return null
+
+        var livyUrl = (sparkCluster?.livyUri?.toString()?:return null).trimEnd('/') + '/'
+
+        val session = ServerlessSparkSession(
+                name,
+                URI.create(livyUrl),
+                sparkCluster?.tenantId,
+                sparkCluster?.account)
+
+        return SparkScalaLivyConsoleRunProfileState(SparkScalaConsoleBuilder(project), session)
+    }
+
+    override fun checkSettingsBeforeRun() {
+        cluster = AzureSparkServerlessClusterManager
+                .getInstance()
+                .clusters
+                .find { it.name == this.clusterName }
+                ?:throw RuntimeConfigurationError("Can't find the target cluster $clusterName");
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfiguration.kt
@@ -34,21 +34,25 @@ import com.microsoft.azure.hdinsight.common.ClusterManagerEx
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail
 import com.microsoft.azure.hdinsight.sdk.cluster.LivyCluster
 import com.microsoft.azure.hdinsight.sdk.common.livy.interactive.SparkSession
+import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel
 import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfiguration
 import java.net.URI
 
-class SparkScalaLivyConsoleRunConfiguration(project: Project,
+open class SparkScalaLivyConsoleRunConfiguration(project: Project,
                                             configurationFactory: SparkScalaLivyConsoleRunConfigurationFactory,
                                             batchRunConfiguration: RemoteDebugRunConfiguration?,
                                             name: String)
     : AbstractRunConfiguration (
         name, batchRunConfiguration?.configurationModule ?: RunConfigurationModule(project), configurationFactory)
 {
+    protected open var batchRunConfiguration = batchRunConfiguration
 
-    var clusterName = batchRunConfiguration?.submitModel?.submissionParameter?.clusterName
+    protected open fun getSubmitModel() : SparkSubmitModel? = batchRunConfiguration?.submitModel?: null
+
+    protected open var clusterName : String = getSubmitModel()?.submissionParameter?.clusterName
             ?: throw RuntimeConfigurationWarning("A Spark Run Configuration should be selected to start a console")
 
-    private lateinit var cluster: IClusterDetail
+    protected lateinit var cluster: IClusterDetail
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> =
             SparkScalaLivyConsoleRunConfigurationEditor()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfiguration.kt
@@ -39,18 +39,20 @@ import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfi
 import java.net.URI
 
 open class SparkScalaLivyConsoleRunConfiguration(project: Project,
-                                            configurationFactory: SparkScalaLivyConsoleRunConfigurationFactory,
-                                            batchRunConfiguration: RemoteDebugRunConfiguration?,
-                                            name: String)
+                                                 configurationFactory: SparkScalaLivyConsoleRunConfigurationFactory,
+                                                 private val batchRunConfiguration: RemoteDebugRunConfiguration?,
+                                                 name: String)
     : AbstractRunConfiguration (
         name, batchRunConfiguration?.configurationModule ?: RunConfigurationModule(project), configurationFactory)
 {
-    protected open var batchRunConfiguration = batchRunConfiguration
+    open val runConfigurationTypeName = "HDInsight Spark Run Configuration"
 
-    protected open fun getSubmitModel() : SparkSubmitModel? = batchRunConfiguration?.submitModel?: null
+    protected open val submitModel : SparkSubmitModel?
+        get() = batchRunConfiguration?.submitModel
 
-    protected open var clusterName : String = getSubmitModel()?.submissionParameter?.clusterName
-            ?: throw RuntimeConfigurationWarning("A Spark Run Configuration should be selected to start a console")
+    protected open var clusterName : String = ""
+        get() = submitModel?.submissionParameter?.clusterName
+            ?: throw RuntimeConfigurationWarning("A $runConfigurationTypeName should be selected to start a console")
 
     protected lateinit var cluster: IClusterDetail
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfigurationFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfigurationFactory.kt
@@ -34,12 +34,21 @@ class SparkScalaLivyConsoleRunConfigurationFactory(sparkConsoleType: SparkScalaL
         return SparkScalaLivyConsoleRunConfiguration(project, this, null, "")
     }
 
-    override fun createConfiguration(name: String?, template: RunConfiguration): RunConfiguration {
-        // Create a Spark Scala Livy run configuration based on Spark Batch run configuration
-        if(template is ServerlessSparkConfiguration) {
-            return ServerlessSparkScalaLivyConsoleRunConfiguration(template.project, this, template, "${template.name} >> Azure Data Lake Spark Livy Interactive Session Console(Scala)")
-        } else {
-            return SparkScalaLivyConsoleRunConfiguration(template.project, this, template as RemoteDebugRunConfiguration, "${template.name} >> Spark Livy Interactive Session Console(Scala)")
-        }
-    }
+    override fun createConfiguration(name: String?, template: RunConfiguration): RunConfiguration =
+            // Create a Spark Scala Livy run configuration based on Spark Batch run configuration
+            if (template is ServerlessSparkConfiguration) {
+                ServerlessSparkScalaLivyConsoleRunConfiguration(
+                        template.project,
+                        this,
+                        template,
+                        "${template.name} >> Azure Data Lake Spark Livy Interactive Session Console(Scala)"
+                )
+            } else {
+                SparkScalaLivyConsoleRunConfiguration(
+                        template.project,
+                        this,
+                        template as RemoteDebugRunConfiguration,
+                        "${template.name} >> Spark Livy Interactive Session Console(Scala)"
+                )
+            }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfigurationFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfigurationFactory.kt
@@ -25,6 +25,7 @@ package com.microsoft.azure.hdinsight.spark.console
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.project.Project
 import com.microsoft.azure.hdinsight.spark.run.configuration.RemoteDebugRunConfiguration
+import com.microsoft.azure.hdinsight.spark.run.configuration.ServerlessSparkConfiguration
 import org.jetbrains.plugins.scala.console.ScalaConsoleRunConfigurationFactory
 
 class SparkScalaLivyConsoleRunConfigurationFactory(sparkConsoleType: SparkScalaLivyConsoleConfigurationType)
@@ -35,10 +36,10 @@ class SparkScalaLivyConsoleRunConfigurationFactory(sparkConsoleType: SparkScalaL
 
     override fun createConfiguration(name: String?, template: RunConfiguration): RunConfiguration {
         // Create a Spark Scala Livy run configuration based on Spark Batch run configuration
-        return SparkScalaLivyConsoleRunConfiguration(
-                template.project,
-                this,
-                template as? RemoteDebugRunConfiguration,
-                "${template.name ?: ""} >> Spark Livy Interactive Session Console(Scala)")
+        if(template is ServerlessSparkConfiguration) {
+            return ServerlessSparkScalaLivyConsoleRunConfiguration(template.project, this, template, "${template.name} >> Azure Data Lake Spark Livy Interactive Session Console(Scala)")
+        } else {
+            return SparkScalaLivyConsoleRunConfiguration(template.project, this, template as RemoteDebugRunConfiguration, "${template.name} >> Spark Livy Interactive Session Console(Scala)")
+        }
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/ServerlessSparkHttpObservable.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/ServerlessSparkHttpObservable.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.hdinsight.sdk.common;
+
+import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessAccount;
+
+import com.microsoft.azuretools.authmanage.CommonSettings;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+
+public class ServerlessSparkHttpObservable extends AzureHttpObservable {
+    public static final String KOBO_ACCOUNT_HEADER_NAME = "x-ms-kobo-account-name";
+
+    private AzureSparkServerlessAccount adlAccount;
+
+    public ServerlessSparkHttpObservable(@NotNull String tenantId, @NotNull AzureSparkServerlessAccount adlAccount) {
+        super(tenantId, "");
+        this.adlAccount = adlAccount;
+    }
+
+    @Override
+    public Header[] getDefaultHeaders() throws IOException {
+        Header[] defaultHeaders = super.getDefaultHeaders();
+        List<Header> headers = Arrays.stream(defaultHeaders)
+                      .filter(header -> !header.getName().equals(KOBO_ACCOUNT_HEADER_NAME))
+                      .collect(Collectors.toList());
+
+        headers.add(new BasicHeader(KOBO_ACCOUNT_HEADER_NAME, adlAccount.getName()));
+
+        return headers.toArray(new Header[0]);
+    }
+}

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/livy/interactive/ServerlessSparkSession.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/livy/interactive/ServerlessSparkSession.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.hdinsight.sdk.common.livy.interactive;
+
+import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessAccount;
+import com.microsoft.azure.hdinsight.sdk.common.ServerlessSparkHttpObservable;
+import com.microsoft.azure.hdinsight.sdk.common.HttpObservable;
+import com.microsoft.azure.hdinsight.sdk.rest.livy.interactive.SessionKind;
+import com.microsoft.azuretools.authmanage.AdAuthManager;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.ArrayList;
+
+import rx.Observable;
+
+public class ServerlessSparkSession extends SparkSession {
+    @NotNull
+    private ServerlessSparkHttpObservable http;
+
+    public ServerlessSparkSession(@NotNull String name, @NotNull URI baseUrl, @NotNull String tenantId, @NotNull AzureSparkServerlessAccount adlAccount) throws Exception {
+        super(name, baseUrl);
+        this.http = new ServerlessSparkHttpObservable(tenantId, adlAccount);
+    }
+
+    @Override
+    @NotNull
+    public HttpObservable getHttp() {
+        return this.http;
+    }    
+}

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/livy/interactive/ServerlessSparkSession.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/livy/interactive/ServerlessSparkSession.java
@@ -25,23 +25,15 @@ package com.microsoft.azure.hdinsight.sdk.common.livy.interactive;
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessAccount;
 import com.microsoft.azure.hdinsight.sdk.common.ServerlessSparkHttpObservable;
 import com.microsoft.azure.hdinsight.sdk.common.HttpObservable;
-import com.microsoft.azure.hdinsight.sdk.rest.livy.interactive.SessionKind;
-import com.microsoft.azuretools.authmanage.AdAuthManager;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 
-import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
-import java.util.List;
-import java.util.ArrayList;
-
-import rx.Observable;
 
 public class ServerlessSparkSession extends SparkSession {
     @NotNull
     private ServerlessSparkHttpObservable http;
 
-    public ServerlessSparkSession(@NotNull String name, @NotNull URI baseUrl, @NotNull String tenantId, @NotNull AzureSparkServerlessAccount adlAccount) throws Exception {
+    public ServerlessSparkSession(@NotNull String name, @NotNull URI baseUrl, @NotNull String tenantId, @NotNull AzureSparkServerlessAccount adlAccount) {
         super(name, baseUrl);
         this.http = new ServerlessSparkHttpObservable(tenantId, adlAccount);
     }


### PR DESCRIPTION
Support interactive console for Spark on Cosmos. Containing the following changes
1. Add ServerlessSparkSession which extends Session with support for kobo account name and access token.
2. Add ServerlessSparkScalaLivyConsoleRunConfiguration which overrides checkSettingsBeforeRun and getState of SparkScalaLivyConsoleRunConfiguration.
3. Modify ServerlessSparkConfiguration to create ConsoleRunConfiguration based on RunConfiguration.
