### PR TITLE
Fix background of device login dialog.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/DeviceLoginWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/DeviceLoginWindow.java
@@ -67,6 +67,7 @@ public class DeviceLoginWindow extends AzureDialogWrapper {
         this.deviceCode = deviceCode;
         setModal(true);
         setTitle(TITLE);
+        editorPanel.setBackground(jPanel.getBackground());
         editorPanel.setText(createHtmlFormatMessage());
         editorPanel.addHyperlinkListener(e -> {
             if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {


### PR DESCRIPTION
To fix: #2493 

Set the text zone to the same background color with its parent panel. 
<img width="527" alt="screen shot 2018-12-12 at 1 27 39 pm" src="https://user-images.githubusercontent.com/2351748/49848829-f26e1580-fe11-11e8-9a05-5e37cbca0b35.png">
<img width="529" alt="screen shot 2018-12-12 at 1 27 15 pm" src="https://user-images.githubusercontent.com/2351748/49848830-f39f4280-fe11-11e8-9ba2-7562162431e8.png">
