### PR TITLE
Make aris node paralleled as azure node

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/forms/AddNewClusterForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/forms/AddNewClusterForm.java
@@ -209,7 +209,7 @@ public class AddNewClusterForm extends AzureTitleAreaDialogWrapper implements Se
     protected void okPressed() {
         ctrlProvider.validateAndAdd()
                 .subscribe(toUpdate -> {
-                    hdInsightModule.refreshWithoutAsync();
+                    hdInsightModule.load(false);
                     AppInsightsClient.create(Messages.HDInsightAddNewClusterAction, null);
 
                     super.okPressed();

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/forms/AddNewEmulatorForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/forms/AddNewEmulatorForm.java
@@ -320,7 +320,7 @@ public class AddNewEmulatorForm extends AzureTitleAreaDialogWrapper {
 			EmulatorClusterDetail emulatorClusterDetail = new EmulatorClusterDetail(clusterName, userName, password,
 					livyEndpoint, sshEndpoint, sparkHistoryEndpoint, ambariEndpoint);
 			ClusterManagerEx.getInstance().addEmulatorCluster(emulatorClusterDetail);
-			hdInsightModule.refreshWithoutAsync();
+			hdInsightModule.load(false);
 			super.okPressed();
 		} else {
 			errorMessageField.setText(errorMessage);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewClusterForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewClusterForm.java
@@ -183,7 +183,7 @@ public class AddNewClusterForm extends DialogWrapper implements SettableControl<
                 .validateAndAdd()
                 .doOnEach(notification -> getOKAction().setEnabled(true))
                 .subscribe(toUpdate -> {
-                    hdInsightModule.refreshWithoutAsync();
+                    hdInsightModule.load(false);
                     AppInsightsClient.create(HDInsightBundle.message("HDInsightAddNewClusterAction"), null);
 
                     super.doOKAction();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewClusterForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewClusterForm.java
@@ -32,13 +32,13 @@ import com.microsoft.azure.hdinsight.common.mvc.SettableControl;
 import com.microsoft.azure.hdinsight.sdk.cluster.SparkClusterType;
 import com.microsoft.azure.hdinsight.serverexplore.AddNewClusterCtrlProvider;
 import com.microsoft.azure.hdinsight.serverexplore.AddNewClusterModel;
-import com.microsoft.azure.hdinsight.serverexplore.hdinsightnode.HDInsightRootModule;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.ijidea.ui.HintTextField;
 import com.microsoft.azuretools.telemetry.AppInsightsClient;
 import com.microsoft.intellij.hdinsight.messages.HDInsightBundle;
 import com.microsoft.intellij.rxjava.IdeaSchedulers;
+import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.*;
@@ -75,13 +75,13 @@ public class AddNewClusterForm extends DialogWrapper implements SettableControl<
     protected JLabel passwordLabel;
     protected JLabel livyClusterNameLabel;
     @NotNull
-    private HDInsightRootModule hdInsightModule;
+    private RefreshableNode hdInsightModule;
     @NotNull
     protected AddNewClusterCtrlProvider ctrlProvider;
 
     private static final String HELP_URL = "https://go.microsoft.com/fwlink/?linkid=866472";
 
-    public AddNewClusterForm(@Nullable final Project project, @NotNull HDInsightRootModule hdInsightModule) {
+    public AddNewClusterForm(@Nullable final Project project, @NotNull RefreshableNode hdInsightModule) {
         super(project, true);
         this.ctrlProvider = new AddNewClusterCtrlProvider(this, new IdeaSchedulers(project));
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewEmulatorForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewEmulatorForm.java
@@ -231,7 +231,7 @@ public class AddNewEmulatorForm extends DialogWrapper {
         if (isCarryOnNextStep) {
             EmulatorClusterDetail emulatorClusterDetail = new EmulatorClusterDetail(clusterName, userName, password,livyEndpoint, sshEndpoint, sparkHistoryEndpoint, ambariEndpoint);
             ClusterManagerEx.getInstance().addEmulatorCluster(emulatorClusterDetail);
-            hdInsightModule.refreshWithoutAsync();
+            hdInsightModule.load(false);
             SwingUtilities.invokeLater(new Runnable() {
                 @Override
                 public void run() {

--- a/Utils/azure-explorer-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/HDInsightRootModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/HDInsightRootModule.java
@@ -36,8 +36,6 @@ public abstract class HDInsightRootModule extends AzureRefreshableNode {
 
     public abstract HDInsightRootModule getNewNode(Node parent);
 
-    public abstract void refreshWithoutAsync();
-
     public boolean isFeatureEnabled() {
         return false;
     }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/RefreshableNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/RefreshableNode.java
@@ -46,7 +46,7 @@ public abstract class RefreshableNode extends Node {
     public RefreshableNode(String id, String name, Node parent, String iconPath, boolean delayActionLoading) {
         super(id, name, parent, iconPath, delayActionLoading);
     }
-    
+
     @Override
     protected void loadActions() {
         addAction(REFRESH, DefaultLoader.getUIHelper().isDarkTheme() ? REFRESH_ICON_DARK : REFRESH_ICON_LIGHT, new NodeActionListener() {
@@ -125,13 +125,17 @@ public abstract class RefreshableNode extends Node {
                     public void run() {
                         if (!loading) {
                             final String nodeName = node.getName();
-                            updateName(nodeName + " (Refreshing...)", null);
-//                        node.setName(nodeName + " (Refreshing...)");
+                            DefaultLoader.getIdeHelper().invokeLater(new Runnable() {
+                                @Override
+                                public void run() {
+                                    updateName(nodeName + " (Refreshing...)", null);
+                                }
+                            });
 
                             Futures.addCallback(future, new FutureCallback<List<Node>>() {
                                 @Override
                                 public void onSuccess(List<Node> nodes) {
-                                    DefaultLoader.getIdeHelper().invokeAndWait(new Runnable() {
+                                    DefaultLoader.getIdeHelper().invokeLater(new Runnable() {
                                         @Override
                                         public void run() {
                                             updateName(nodeName, null);
@@ -143,7 +147,7 @@ public abstract class RefreshableNode extends Node {
 
                                 @Override
                                 public void onFailure(Throwable throwable) {
-                                    DefaultLoader.getIdeHelper().invokeAndWait(new Runnable() {
+                                    DefaultLoader.getIdeHelper().invokeLater(new Runnable() {
                                         @Override
                                         public void run() {
                                             updateName(nodeName, throwable);

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/RefreshableNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/RefreshableNode.java
@@ -103,6 +103,9 @@ public abstract class RefreshableNode extends Node {
         }
     }
 
+    public void refreshWithoutAsync() {
+    }
+
     protected void refreshFromAzure() throws Exception {
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/RefreshableNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/RefreshableNode.java
@@ -25,12 +25,10 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.core.mvp.ui.base.NodeContent;
+import com.microsoft.tooling.msservices.components.DefaultLoader;
 
-import javax.swing.*;
-import javax.swing.tree.TreePath;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -103,9 +101,6 @@ public abstract class RefreshableNode extends Node {
         }
     }
 
-    public void refreshWithoutAsync() {
-    }
-
     protected void refreshFromAzure() throws Exception {
     }
 
@@ -136,16 +131,26 @@ public abstract class RefreshableNode extends Node {
                             Futures.addCallback(future, new FutureCallback<List<Node>>() {
                                 @Override
                                 public void onSuccess(List<Node> nodes) {
-                                    updateName(nodeName, null);
-                                    updateNodeNameAfterLoading();
-                                    expandNodeAfterLoading();
+                                    DefaultLoader.getIdeHelper().invokeAndWait(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            updateName(nodeName, null);
+                                            updateNodeNameAfterLoading();
+                                            expandNodeAfterLoading();
+                                        }
+                                    });
                                 }
 
                                 @Override
                                 public void onFailure(Throwable throwable) {
-                                    updateName(nodeName, throwable);
-                                    updateNodeNameAfterLoading();
-                                    expandNodeAfterLoading();
+                                    DefaultLoader.getIdeHelper().invokeAndWait(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            updateName(nodeName, throwable);
+                                            updateNodeNameAfterLoading();
+                                            expandNodeAfterLoading();
+                                        }
+                                    });
                                 }
                             });
                             node.refreshItems(future, forceRefresh);
@@ -153,21 +158,16 @@ public abstract class RefreshableNode extends Node {
                     }
 
                     private void updateName(String name, final Throwable throwable) {
-                        DefaultLoader.getIdeHelper().invokeAndWait(new Runnable() {
-                            @Override
-                            public void run() {
-                                node.setName(name);
+                        node.setName(name);
 
-                                if (throwable != null) {
-                                    DefaultLoader.getUIHelper().showException("An error occurred while attempting " +
-                                                    "to load " + node.getName() + ".",
-                                            throwable,
-                                            "MS Azure Explorer - Error Loading " + node.getName(),
-                                            false,
-                                            true);
-                                }
-                            }
-                        });
+                        if (throwable != null) {
+                            DefaultLoader.getUIHelper().showException("An error occurred while attempting " +
+                                            "to load " + node.getName() + ".",
+                                    throwable,
+                                    "MS Azure Explorer - Error Loading " + node.getName(),
+                                    false,
+                                    true);
+                        }
                     }
                 }
         );

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/AzureModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/AzureModule.java
@@ -64,8 +64,6 @@ public class AzureModule extends AzureRefreshableNode {
     @Nullable
     private HDInsightRootModule sparkServerlessClusterRootModule;
     @NotNull
-    private HDInsightRootModule sqlBigDataClusterModule;
-    @NotNull
     private DockerHostModule dockerHostModule;
     @NotNull
     private ContainerRegistryModule containerRegistryModule;
@@ -129,10 +127,6 @@ public class AzureModule extends AzureRefreshableNode {
         this.sparkServerlessClusterRootModule = rootModule;
     }
 
-    public void setSQLBigDataClusterModule(@NotNull HDInsightRootModule rootModule) {
-        this.sqlBigDataClusterModule = rootModule;
-    }
-
     @Override
     protected void refreshItems() throws AzureCmdException {
         // add the module; we check if the node has
@@ -159,10 +153,6 @@ public class AzureModule extends AzureRefreshableNode {
                 sparkServerlessClusterRootModule.isFeatureEnabled() &&
                 !isDirectChild(sparkServerlessClusterRootModule)) {
             addChildNode(sparkServerlessClusterRootModule);
-        }
-
-        if (sqlBigDataClusterModule != null && !isDirectChild(sqlBigDataClusterModule)) {
-            addChildNode(sqlBigDataClusterModule);
         }
 
         if (!isDirectChild(dockerHostModule)) {
@@ -193,10 +183,6 @@ public class AzureModule extends AzureRefreshableNode {
 
                 if (sparkServerlessClusterRootModule != null) {
                     sparkServerlessClusterRootModule.load(true);
-                }
-
-                if (sqlBigDataClusterModule != null) {
-                    sqlBigDataClusterModule.load(true);
                 }
 
                 dockerHostModule.load(true);

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
@@ -33,7 +33,6 @@ import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import rx.Observable;
 
 public class CosmosSparkADLAccountNode extends AzureRefreshableNode implements ILogger {
-    // TODO: Update icon path
     private static final String ICON_PATH = CommonConst.AZURE_SERVERLESS_SPARK_ACCOUNT_ICON_PATH;
     @NotNull
     private final AzureSparkServerlessAccount adlAccount;
@@ -93,5 +92,4 @@ public class CosmosSparkADLAccountNode extends AzureRefreshableNode implements I
         return adlAccount;
     }
 
-    // TODO: implement refreshWithoutAsync()
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkClusterRootModuleImpl.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkClusterRootModuleImpl.java
@@ -37,9 +37,7 @@ import java.net.URI;
 
 public class CosmosSparkClusterRootModuleImpl extends HDInsightRootModule {
     private static final String SERVICE_MODULE_ID = CosmosSparkClusterRootModuleImpl.class.getName();
-    // TODO: Update icon path
     private static final String ICON_PATH = CommonConst.AZURE_SERVERLESS_SPARK_ROOT_ICON_PATH;
-    // TODO: determine root node name
     private static final String BASE_MODULE_NAME = "Azure Data Lake Spark Pool";
 
     private static final String SPARK_NOTEBOOK_LINK = "https://aka.ms/spkadlnb";
@@ -72,11 +70,6 @@ public class CosmosSparkClusterRootModuleImpl extends HDInsightRootModule {
     }
 
     @Override
-    public void refreshWithoutAsync() {
-
-    }
-
-    @Override
     protected void loadActions() {
         super.loadActions();
 
@@ -90,6 +83,4 @@ public class CosmosSparkClusterRootModuleImpl extends HDInsightRootModule {
             }
         });
     }
-    // TODO: refreshWithoutAsync() is called when unlink an HDInsight cluster. Maybe we also need to implement this method here?
-    // public void refreshWithoutAsync()
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/HDInsightRootModuleImpl.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/HDInsightRootModuleImpl.java
@@ -53,27 +53,7 @@ public class HDInsightRootModuleImpl extends HDInsightRootModule {
 
     @Override
     protected void refreshItems() throws AzureCmdException {
-        synchronized (this) { //todo???
-//            TelemetryManager.postEvent(TelemetryCommon.HDInsightExplorerHDInsightNodeExpand, null, null);
-
-            clusterDetailList = ClusterManagerEx.getInstance().getClusterDetails().stream()
-                    .filter(ClusterManagerEx.getInstance().getHDInsightClusterFilterPredicate())
-                    .collect(Collectors.toList());
-
-            if (clusterDetailList != null) {
-                for (IClusterDetail clusterDetail : clusterDetailList) {
-                    addChildNode(new ClusterNode(this, clusterDetail));
-                }
-            }
-        }
-    }
-
-    @Override
-    public void refreshWithoutAsync() {
         synchronized (this) {
-            removeAllChildNodes();
-
-            // refresh the cluster list with invalidating the cache
             clusterDetailList = ClusterManagerEx.getInstance().getClusterDetails().stream()
                     .filter(ClusterManagerEx.getInstance().getHDInsightClusterFilterPredicate())
                     .collect(Collectors.toList());
@@ -83,14 +63,6 @@ public class HDInsightRootModuleImpl extends HDInsightRootModule {
                     addChildNode(new ClusterNode(this, clusterDetail));
                 }
             }
-        }
-
-    }
-
-    @Override
-    protected void onNodeClick(NodeActionEvent e) {
-        if (!initialized) {
-            this.load(false);
         }
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/ClusterNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/ClusterNode.java
@@ -126,19 +126,7 @@ public class ClusterNode extends RefreshableNode implements TelemetryProperties 
                             "Unlink HDInsight Cluster", new String[]{"Yes", "No"}, null);
                     if (choice) {
                         ClusterManagerEx.getInstance().removeAdditionalCluster(clusterDetail);
-                        ((HDInsightRootModule) getParent()).refreshWithoutAsync();
-                    }
-                }
-            });
-        } else if (clusterDetail instanceof SqlBigDataLivyLinkClusterDetail) {
-            addAction("Unlink", new NodeActionListener() {
-                @Override
-                protected void actionPerformed(NodeActionEvent e) {
-                    boolean choice = DefaultLoader.getUIHelper().showConfirmation("Do you really want to unlink the SQL big data cluster?",
-                            "Unlink SQL Big Data Cluster", new String[]{"Yes", "No"}, null);
-                    if (choice) {
-                        ClusterManagerEx.getInstance().removeAdditionalCluster(clusterDetail);
-                        ((SqlBigDataClusterModule) getParent()).refreshWithoutAsync();
+                        ((RefreshableNode) getParent()).load(false);
                     }
                 }
             });
@@ -150,7 +138,7 @@ public class ClusterNode extends RefreshableNode implements TelemetryProperties 
                             "Unlink Emulator Cluster", new String[]{"Yes", "No"}, null);
                     if (choice) {
                         ClusterManagerEx.getInstance().removeEmulatorCluster((EmulatorClusterDetail) clusterDetail);
-                        ((HDInsightRootModule) getParent()).refreshWithoutAsync();
+                        ((RefreshableNode) getParent()).load(false);
                     }
                 }
             });

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/sdk/cluster/SqlBigDataLivyLinkClusterDetail.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/sdk/cluster/SqlBigDataLivyLinkClusterDetail.java
@@ -66,16 +66,13 @@ public class SqlBigDataLivyLinkClusterDetail implements IClusterDetail, LivyClus
     @Override
     @NotNull
     public String getTitle() {
-        return Optional.ofNullable(getSparkVersion())
-                .filter(ver -> !ver.trim().isEmpty())
-                .map(ver -> getName() + " (Spark: " + ver + " Linked)")
-                .orElse(getName() + " [Linked]");
+        return getName();
     }
 
     @Override
-    @NotNull
+    @Nullable
     public SubscriptionDetail getSubscription() {
-        return new SubscriptionDetail("[LinkedCluster]", "[NoSubscription]", "", false);
+        return null;
     }
 
     @Override

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterModule.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterModule.java
@@ -27,28 +27,26 @@ import com.microsoft.azure.hdinsight.common.CommonConst;
 import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
 import com.microsoft.azure.hdinsight.serverexplore.hdinsightnode.ClusterNode;
-import com.microsoft.azure.hdinsight.serverexplore.hdinsightnode.HDInsightRootModule;
 import com.microsoft.azure.sqlbigdata.sdk.cluster.SqlBigDataLivyLinkClusterDetail;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
-import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
+import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class SqlBigDataClusterModule extends HDInsightRootModule implements ILogger {
+public class SqlBigDataClusterModule extends RefreshableNode implements ILogger {
     private static final String ARIS_SERVICE_MODULE_ID = SqlBigDataClusterModule.class.getName();
     private static final String BASE_MODULE_NAME = "SQL Big Data Cluster";
     private static final String ICON_PATH = CommonConst.SQL_BIG_DATA_CLUSTER_MODULE_ICON_PATH;
+    @Nullable
+    private Object project;
 
-    public SqlBigDataClusterModule(@NotNull Node parent) {
-        super(ARIS_SERVICE_MODULE_ID, BASE_MODULE_NAME, parent, ICON_PATH);
-    }
-
-    @Override
-    public HDInsightRootModule getNewNode(Node parent) {
-        return new SqlBigDataClusterModule(parent);
+    public SqlBigDataClusterModule(@Nullable Object project) {
+        super(ARIS_SERVICE_MODULE_ID, BASE_MODULE_NAME, null, ICON_PATH);
+        this.project = project;
     }
 
     @Override
@@ -88,5 +86,11 @@ public class SqlBigDataClusterModule extends HDInsightRootModule implements ILog
         if (!initialized) {
             this.load(false);
         }
+    }
+
+    @Nullable
+    @Override
+    public Object getProject() {
+        return project;
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterNode.java
@@ -44,7 +44,6 @@ public class SqlBigDataClusterNode extends RefreshableNode {
         super(SQL_BIG_DATA_CLUSTER_ID, clusterDetail.getTitle(), parent, ICON_PATH, true);
         this.clusterDetail = clusterDetail;
         this.loadActions();
-        this.load(false);
     }
 
     @Override
@@ -68,6 +67,5 @@ public class SqlBigDataClusterNode extends RefreshableNode {
 
     @Override
     protected void refreshItems() throws AzureCmdException {
-        this.load(false);
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterNode.java
@@ -24,48 +24,50 @@ package com.microsoft.azure.sqlbigdata.serverexplore;
 
 import com.microsoft.azure.hdinsight.common.ClusterManagerEx;
 import com.microsoft.azure.hdinsight.common.CommonConst;
-import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
-import com.microsoft.azure.sqlbigdata.sdk.cluster.SqlBigDataLivyLinkClusterDetail;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
-import com.microsoft.azuretools.azurecommons.helpers.Nullable;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
 
-import java.util.List;
-import java.util.stream.Collectors;
+public class SqlBigDataClusterNode extends RefreshableNode {
+    private static final String SQL_BIG_DATA_CLUSTER_ID = SqlBigDataClusterNode.class.getName();
+    private static final String ICON_PATH = CommonConst.ClusterIConPath;
 
-public class SqlBigDataClusterModule extends RefreshableNode implements ILogger {
-    private static final String ARIS_SERVICE_MODULE_ID = SqlBigDataClusterModule.class.getName();
-    private static final String BASE_MODULE_NAME = "SQL Big Data Cluster";
-    private static final String ICON_PATH = CommonConst.SQL_BIG_DATA_CLUSTER_MODULE_ICON_PATH;
-    @Nullable
-    private Object project;
+    @NotNull
+    private IClusterDetail clusterDetail;
 
-    public SqlBigDataClusterModule(@Nullable Object project) {
-        super(ARIS_SERVICE_MODULE_ID, BASE_MODULE_NAME, null, ICON_PATH);
-        this.project = project;
+    public SqlBigDataClusterNode(Node parent, @NotNull IClusterDetail clusterDetail) {
+        super(SQL_BIG_DATA_CLUSTER_ID, clusterDetail.getTitle(), parent, ICON_PATH, true);
+        this.clusterDetail = clusterDetail;
+        this.loadActions();
+        this.load(false);
+    }
+
+    @Override
+    protected void loadActions() {
+        super.loadActions();
+
+        // TODO: Add Master UI link and Yarn UI link
+
+        addAction("Unlink", new NodeActionListener() {
+            @Override
+            protected void actionPerformed(NodeActionEvent e) {
+                boolean choice = DefaultLoader.getUIHelper().showConfirmation("Do you really want to unlink the SQL big data cluster?",
+                        "Unlink SQL Big Data Cluster", new String[]{"Yes", "No"}, null);
+                if (choice) {
+                    ClusterManagerEx.getInstance().removeAdditionalCluster(clusterDetail);
+                    ((RefreshableNode) getParent()).load(false);
+                }
+            }
+        });
     }
 
     @Override
     protected void refreshItems() throws AzureCmdException {
-        synchronized (this) {
-            List<IClusterDetail> clusterDetailList = ClusterManagerEx.getInstance().getClusterDetails().stream()
-                    .filter(clusterDetail -> clusterDetail instanceof SqlBigDataLivyLinkClusterDetail)
-                    .collect(Collectors.toList());
-
-            if (clusterDetailList != null) {
-                for (IClusterDetail clusterDetail : clusterDetailList) {
-                    addChildNode(new SqlBigDataClusterNode(this, clusterDetail));
-                }
-            }
-        }
-    }
-
-    @Nullable
-    @Override
-    public Object getProject() {
-        return project;
+        this.load(false);
     }
 }


### PR DESCRIPTION
 - preview as below
![image](https://user-images.githubusercontent.com/32627233/50220105-52455d00-03cc-11e9-85eb-5015e2ce35d1.png)

Code changes:
1. Make aris node paralleled as azure node
2. Remove legacy `refreshWithoutAsync()` method for HDInsightRootModule
3. Remove `[Linked]` suffix from aris cluster node title
4. Remove sub-nodes for aris cluster node, including `jobs` node and `Storage Accounts` node 