### PR TITLE
Modify default run config parameters for cosmos serverless spark

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkSubmitModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkSubmitModel.kt
@@ -29,11 +29,11 @@ class CosmosServerlessSparkSubmitModel : CosmosSparkSubmitModel {
 
     override fun getDefaultParameters(): Stream<Pair<String, out Any>> {
         return listOf(
-                Pair(SparkSubmissionParameter.DriverMemory, SparkSubmissionParameter.DriverMemoryDefaultValue),
-                Pair(SparkSubmissionParameter.DriverCores, SparkSubmissionParameter.DriverCoresDefaultValue),
-                Pair(SparkSubmissionParameter.ExecutorMemory, SparkSubmissionParameter.ExecutorMemoryDefaultValue),
-                Pair(SparkSubmissionParameter.ExecutorCores, SparkSubmissionParameter.ExecutorCoresDefaultValue),
-                Pair(SparkSubmissionParameter.NumExecutors, SparkSubmissionParameter.NumExecutorsDefaultValue)
+                Pair(CreateSparkBatchJobParameters.DriverMemory, CreateSparkBatchJobParameters.DriverMemoryDefaultValue),
+                Pair(CreateSparkBatchJobParameters.DriverCores, CreateSparkBatchJobParameters.DriverCoresDefaultValue),
+                Pair(CreateSparkBatchJobParameters.ExecutorMemory, CreateSparkBatchJobParameters.ExecutorMemoryDefaultValue),
+                Pair(CreateSparkBatchJobParameters.ExecutorCores, CreateSparkBatchJobParameters.ExecutorCoresDefaultValue),
+                Pair(CreateSparkBatchJobParameters.NumExecutors, CreateSparkBatchJobParameters.NumExecutorsDefaultValue)
         ).stream()
     }
 

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/serverless/spark/models/CreateSparkBatchJobParameters.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/serverless/spark/models/CreateSparkBatchJobParameters.java
@@ -37,11 +37,11 @@ import com.microsoft.azure.hdinsight.spark.common.SparkSubmissionParameter;
 public class CreateSparkBatchJobParameters extends SparkSubmissionParameter {
     public static final String DriverMemoryDefaultValue = "12G";
 
-    public static final Integer DriverCoresDefaultValue = 4;
+    public static final int DriverCoresDefaultValue = 4;
 
     public static final String ExecutorMemoryDefaultValue = "12G";
 
-    public static final Integer ExecutorCoresDefaultValue = 4;
+    public static final int ExecutorCoresDefaultValue = 4;
 
     @JsonIgnoreProperties
     private String adlAccountName;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/serverless/spark/models/CreateSparkBatchJobParameters.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/serverless/spark/models/CreateSparkBatchJobParameters.java
@@ -35,6 +35,14 @@ import com.microsoft.azure.hdinsight.spark.common.SparkSubmissionParameter;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateSparkBatchJobParameters extends SparkSubmissionParameter {
+    public static final String DriverMemoryDefaultValue = "12G";
+
+    public static final Integer DriverCoresDefaultValue = 4;
+
+    public static final String ExecutorMemoryDefaultValue = "12G";
+
+    public static final Integer ExecutorCoresDefaultValue = 4;
+
     @JsonIgnoreProperties
     private String adlAccountName;
 

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkSubmissionParameter.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkSubmissionParameter.java
@@ -72,16 +72,16 @@ public class SparkSubmissionParameter implements IConvertible {
     public static final String DriverMemoryDefaultValue = "4G";
 
     public static final String DriverCores = "driverCores";
-    public static final Integer DriverCoresDefaultValue = 1;
+    public static final int DriverCoresDefaultValue = 1;
 
     public static final String ExecutorMemory = "executorMemory";
     public static final String ExecutorMemoryDefaultValue = "4G";
 
     public static final String NumExecutors = "numExecutors";
-    public static final Integer NumExecutorsDefaultValue = 5;
+    public static final int NumExecutorsDefaultValue = 5;
 
     public static final String ExecutorCores = "executorCores";
-    public static final Integer ExecutorCoresDefaultValue = 1;
+    public static final int ExecutorCoresDefaultValue = 1;
 
     public static final String Conf = "conf";   // 	Spark configuration properties
 


### PR DESCRIPTION
According to \private\cosmos\santorini\KiwiFrontEnd\JobPlugin.Spark\Microsoft.Cosmos.Kiwi.FrontEnd.JobPlugin.Spark.dll.config, the minimal cores is 4 and the minimal memory is 12GB. So this PR changes the default config for cosmos serverless spark.