### PR TITLE
Add switch in setting file to enable/disable cosmos serverless

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SelectSparkApplicationTypeAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SelectSparkApplicationTypeAction.kt
@@ -84,7 +84,7 @@ class SelectCosmosServerlessSparkTypeAction : SelectSparkApplicationTypeAction()
 
     override fun update(e: AnActionEvent) {
         super.update(e)
-        if (!CommonSettings.ENABLE_COSMOS_SERVERLESS) {
+        if (!CommonSettings.isCosmosServerlessEnabled) {
             e.presentation.isEnabled = false
         }
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SelectSparkApplicationTypeAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SelectSparkApplicationTypeAction.kt
@@ -24,6 +24,7 @@ package com.microsoft.azure.hdinsight.spark.run.action
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Toggleable
+import com.microsoft.azuretools.authmanage.CommonSettings
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
 import com.microsoft.intellij.common.CommonConst
 import com.microsoft.tooling.msservices.components.DefaultLoader
@@ -79,6 +80,13 @@ class SelectCosmosSparkTypeAction : SelectSparkApplicationTypeAction() {
 class SelectCosmosServerlessSparkTypeAction : SelectSparkApplicationTypeAction() {
     override fun getSparkApplicationType() : SparkApplicationType {
         return SparkApplicationType.CosmosServerlessSpark
+    }
+
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        if (!CommonSettings.ENABLE_COSMOS_SERVERLESS) {
+            e.presentation.isEnabled = false
+        }
     }
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkSubmitJobActionGroups.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkSubmitJobActionGroups.kt
@@ -34,7 +34,7 @@ class SparkSubmitJobActionGroups : QuickSwitchSchemeAction() {
     override fun fillActions(project: Project?, group: DefaultActionGroup, dataContext: DataContext) {
         group.add(ActionManager.getInstance().getAction("Actions.SubmitLivySparkApplicationAction"))
         group.add(ActionManager.getInstance().getAction("Actions.SubmitCosmosSparkApplicationAction"))
-        if(CommonSettings.ENABLE_COSMOS_SERVERLESS) {
+        if (CommonSettings.isCosmosServerlessEnabled) {
             group.add(ActionManager.getInstance().getAction("Actions.SubmitCosmosServerlessSparkApplicationAction"))
         }
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkSubmitJobActionGroups.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkSubmitJobActionGroups.kt
@@ -27,12 +27,15 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.project.Project
+import com.microsoft.azuretools.authmanage.CommonSettings
 
 
 class SparkSubmitJobActionGroups : QuickSwitchSchemeAction() {
     override fun fillActions(project: Project?, group: DefaultActionGroup, dataContext: DataContext) {
         group.add(ActionManager.getInstance().getAction("Actions.SubmitLivySparkApplicationAction"))
         group.add(ActionManager.getInstance().getAction("Actions.SubmitCosmosSparkApplicationAction"))
-        group.add(ActionManager.getInstance().getAction("Actions.SubmitCosmosServerlessSparkApplicationAction"))
+        if(CommonSettings.ENABLE_COSMOS_SERVERLESS) {
+            group.add(ActionManager.getInstance().getAction("Actions.SubmitCosmosServerlessSparkApplicationAction"))
+        }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkConfigurationType.kt
@@ -4,6 +4,7 @@ import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.ConfigurationType
 import com.intellij.execution.configurations.ConfigurationTypeUtil
 import com.microsoft.azure.hdinsight.common.CommonConst
+import com.microsoft.azuretools.authmanage.CommonSettings
 import com.microsoft.intellij.util.PluginUtil
 import javax.swing.Icon
 
@@ -26,6 +27,9 @@ object CosmosServerlessSparkConfigurationType : ConfigurationType {
     }
 
     override fun getConfigurationFactories(): Array<ConfigurationFactory> {
-        return arrayOf(CosmosServerlessSparkConfigurationFactory(this))
+        return when {
+            CommonSettings.ENABLE_COSMOS_SERVERLESS -> arrayOf(CosmosServerlessSparkConfigurationFactory(this))
+            else -> arrayOf()
+        }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkConfigurationType.kt
@@ -28,7 +28,7 @@ object CosmosServerlessSparkConfigurationType : ConfigurationType {
 
     override fun getConfigurationFactories(): Array<ConfigurationFactory> {
         return when {
-            CommonSettings.ENABLE_COSMOS_SERVERLESS -> arrayOf(CosmosServerlessSparkConfigurationFactory(this))
+            CommonSettings.isCosmosServerlessEnabled -> arrayOf(CosmosServerlessSparkConfigurationFactory(this))
             else -> arrayOf()
         }
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/CommonSettings.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/CommonSettings.java
@@ -42,8 +42,10 @@ public class CommonSettings {
     private static String settingsBaseDir = null;
     private static final String AAD_PROVIDER_FILENAME = "AadProvider.json";
     private static final String ENV_NAME_KEY = "EnvironmentName";
+    private static final String COSMOS_SERVERLESS_KEY = "EnableCosmosSeverlessSpark";
     private static IUIFactory uiFactory;
     private static Environment ENV = Environment.GLOBAL;
+    public static boolean ENABLE_COSMOS_SERVERLESS = false;
 
     public static String getSettingsBaseDir() {
         return settingsBaseDir;
@@ -93,6 +95,11 @@ public class CommonSettings {
                     } else {
                         ENV = providedEnv;
                     }
+                }
+
+                JsonElement serverlessElement = jsonObject.get(COSMOS_SERVERLESS_KEY);
+                if(serverlessElement != null) {
+                    ENABLE_COSMOS_SERVERLESS = serverlessElement.getAsBoolean();
                 }
             }
         } catch (Exception e) {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/CommonSettings.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/CommonSettings.java
@@ -45,7 +45,7 @@ public class CommonSettings {
     private static final String COSMOS_SERVERLESS_KEY = "EnableCosmosSeverlessSpark";
     private static IUIFactory uiFactory;
     private static Environment ENV = Environment.GLOBAL;
-    public static boolean ENABLE_COSMOS_SERVERLESS = false;
+    public static boolean isCosmosServerlessEnabled = false;
 
     public static String getSettingsBaseDir() {
         return settingsBaseDir;
@@ -99,7 +99,7 @@ public class CommonSettings {
 
                 JsonElement serverlessElement = jsonObject.get(COSMOS_SERVERLESS_KEY);
                 if(serverlessElement != null) {
-                    ENABLE_COSMOS_SERVERLESS = serverlessElement.getAsBoolean();
+                    isCosmosServerlessEnabled = serverlessElement.getAsBoolean();
                 }
             }
         } catch (Exception e) {

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
@@ -77,9 +77,10 @@ public class CosmosSparkADLAccountNode extends AzureRefreshableNode implements I
     protected void loadActions() {
         super.loadActions();
 
-        // TODO: enable after testing with backend ready
-        /*addAction("Submit Serverless Spark Job", new CosmosServerlessSparkSubmitAction(
-                this, adlAccount, CosmosSparkClusterOps.getInstance().getServerlessSubmitAction()));*/
+        if(CommonSettings.ENABLE_COSMOS_SERVERLESS) {
+            addAction("Submit Serverless Spark Job", new CosmosServerlessSparkSubmitAction(
+                    this, adlAccount, CosmosSparkClusterOps.getInstance().getServerlessSubmitAction()));
+        }
 
         addAction("Provision Spark Cluster", new CosmosSparkProvisionAction(
                 this, adlAccount, CosmosSparkClusterOps.getInstance().getProvisionAction()));

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
@@ -26,6 +26,7 @@ import com.microsoft.azure.hdinsight.common.CommonConst;
 import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessAccount;
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessCluster;
+import com.microsoft.azuretools.authmanage.CommonSettings;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureRefreshableNode;
@@ -77,7 +78,7 @@ public class CosmosSparkADLAccountNode extends AzureRefreshableNode implements I
     protected void loadActions() {
         super.loadActions();
 
-        if(CommonSettings.ENABLE_COSMOS_SERVERLESS) {
+        if (CommonSettings.isCosmosServerlessEnabled) {
             addAction("Submit Serverless Spark Job", new CosmosServerlessSparkSubmitAction(
                     this, adlAccount, CosmosSparkClusterOps.getInstance().getServerlessSubmitAction()));
         }


### PR DESCRIPTION
Add the switch { "EnableCosmosSeverlessSpark": "false" } in  AadProvider.json to control the visibility of cosmos serverless features.

