### PR TITLE
Put Cosmos serverless spark job list under the control of config setting 

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosserverlessspark/spark/ui/CosmosServerlessSparkJobsToolWindowFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosserverlessspark/spark/ui/CosmosServerlessSparkJobsToolWindowFactory.java
@@ -24,10 +24,16 @@ package com.microsoft.azure.cosmosserverlessspark.spark.ui;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
+import com.microsoft.azuretools.authmanage.CommonSettings;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 
 public class CosmosServerlessSparkJobsToolWindowFactory implements ToolWindowFactory {
     @Override
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+    }
+
+    @Override
+    public boolean shouldBeAvailable(@org.jetbrains.annotations.NotNull Project project) {
+        return CommonSettings.isCosmosServerlessEnabled;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosserverlessspark/spark/ui/CosmosServerlessSparkJobsToolWindowFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosserverlessspark/spark/ui/CosmosServerlessSparkJobsToolWindowFactory.java
@@ -33,7 +33,7 @@ public class CosmosServerlessSparkJobsToolWindowFactory implements ToolWindowFac
     }
 
     @Override
-    public boolean shouldBeAvailable(@org.jetbrains.annotations.NotNull Project project) {
+    public boolean shouldBeAvailable(@NotNull Project project) {
         return CommonSettings.isCosmosServerlessEnabled;
     }
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/CommonSettings.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/CommonSettings.java
@@ -42,7 +42,7 @@ public class CommonSettings {
     private static String settingsBaseDir = null;
     private static final String AAD_PROVIDER_FILENAME = "AadProvider.json";
     private static final String ENV_NAME_KEY = "EnvironmentName";
-    private static final String COSMOS_SERVERLESS_KEY = "EnableCosmosSeverlessSpark";
+    private static final String COSMOS_SERVERLESS_KEY = "EnableCosmosServerlessSpark";
     private static IUIFactory uiFactory;
     private static Environment ENV = Environment.GLOBAL;
     public static boolean isCosmosServerlessEnabled = false;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
@@ -78,15 +78,14 @@ public class CosmosSparkADLAccountNode extends AzureRefreshableNode implements I
     protected void loadActions() {
         super.loadActions();
 
+        addAction("Provision Spark Cluster", new CosmosSparkProvisionAction(
+                this, adlAccount, CosmosSparkClusterOps.getInstance().getProvisionAction()));
         if (CommonSettings.isCosmosServerlessEnabled) {
             addAction("Submit Serverless Spark Job", new CosmosServerlessSparkSubmitAction(
                     this, adlAccount, CosmosSparkClusterOps.getInstance().getServerlessSubmitAction()));
+            addAction("View Serverless Spark Jobs", new CosmosServerlessSparkViewJobsAction(
+                    this, adlAccount, CosmosSparkClusterOps.getInstance().getViewServerlessJobsAction()));
         }
-
-        addAction("Provision Spark Cluster", new CosmosSparkProvisionAction(
-                this, adlAccount, CosmosSparkClusterOps.getInstance().getProvisionAction()));
-        addAction("View Serverless Spark Jobs", new CosmosServerlessSparkViewJobsAction(
-                this, adlAccount, CosmosSparkClusterOps.getInstance().getViewServerlessJobsAction()));
     }
 
     @NotNull

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/HttpObservable.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/HttpObservable.java
@@ -58,6 +58,7 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.TrustStrategy;
+import org.apache.http.util.EntityUtils;
 import rx.Observable;
 
 import javax.net.ssl.SSLContext;
@@ -285,7 +286,7 @@ public class HttpObservable implements ILogger {
                         if (status.getStatusCode() >= 300) {
                             Header requestIdHeader = streamResp.getFirstHeader("x-ms-request-id");
                             return Observable.error(new SparkAzureDataLakePoolServiceException(status.getStatusCode(),
-                                    status.getReasonPhrase(),
+                                    EntityUtils.toString(streamResp.getEntity()),
                                     requestIdHeader != null ? requestIdHeader.getValue() : ""));
                         }
 


### PR DESCRIPTION
This PR will fix #2559 . It's an addition to #2565 . It will be hidden unless a config  { "EnableCosmosServerlessSpark": "true" }  to enable cosmos serverless.

![image](https://user-images.githubusercontent.com/2101973/50500813-a3b9b000-0a8e-11e9-9e97-9b385c6332f5.png)
