### PR TITLE
Replace internal URL with public yarn url in console view for aris cluster

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/CosmosSparkBatchRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/CosmosSparkBatchRunner.kt
@@ -58,7 +58,7 @@ class CosmosSparkBatchRunner : SparkBatchJobRunner() {
                     .toBlocking()
                     .firstOrDefault(null)
 
-            return ServerlessSparkBatchJob(
+            return CosmosSparkBatchJob(
                     submitModel.submissionParameter,
                     SparkBatchAzureSubmission(tenantId, accountName, clusterId, livyUri),
                     ctrlSubject)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
@@ -29,6 +29,8 @@ import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.filters.BrowserHyperlinkInfo;
+import com.intellij.execution.filters.Filter;
 import com.intellij.execution.runners.DefaultProgramRunner;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
@@ -38,6 +40,7 @@ import com.microsoft.azure.hdinsight.common.ClusterManagerEx;
 import com.microsoft.azure.hdinsight.common.MessageInfoType;
 import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
+import com.microsoft.azure.hdinsight.sdk.cluster.InternalUrlMapping;
 import com.microsoft.azure.hdinsight.sdk.common.AzureSparkClusterManager;
 import com.microsoft.azure.hdinsight.sdk.storage.HDStorageAccount;
 import com.microsoft.azure.hdinsight.sdk.storage.IHDIStorageAccount;
@@ -57,6 +60,10 @@ import rx.subjects.PublishSubject;
 
 import java.io.IOException;
 import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSubmissionRunner, ILogger {
     @NotNull
@@ -136,7 +143,7 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
                 break;
         }
 
-        return new SparkBatchJob(submitModel.getSubmissionParameter(), SparkBatchSubmission.getInstance(), ctrlSubject, storageAccount, accessToken, destinationRootPath);
+        return new SparkBatchJob(clusterDetail, submitModel.getSubmissionParameter(), SparkBatchSubmission.getInstance(), ctrlSubject, storageAccount, accessToken, destinationRootPath);
     }
 
     @Nullable
@@ -170,6 +177,28 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
         ExecutionResult result = new DefaultExecutionResult(jobOutputView, processHandler, Separator.getInstance(), disconnectAction);
         submissionState.setExecutionResult(result);
         submissionState.setConsoleView(jobOutputView.getSecondaryConsoleView());
+
+        SparkBatchJob sparkBatchJob = remoteProcess.getSparkJob() instanceof SparkBatchJob
+                ? (SparkBatchJob) remoteProcess.getSparkJob()
+                : null;
+        if (sparkBatchJob != null) {
+            InternalUrlMapping mapping = sparkBatchJob.getCluster() instanceof InternalUrlMapping
+                    ? (InternalUrlMapping) sparkBatchJob.getCluster()
+                    : null;
+            if (mapping != null) {
+                submissionState.getConsoleView().addMessageFilter((line, entireLength) -> {
+                    String mappedUrl = mapping.mapInternalUrlToPublic();
+                    Matcher matcher = Pattern.compile("http://[^\\s]+").matcher(line);
+                    List<Filter.ResultItem> items = new ArrayList<>();
+                    int textStartOffset = entireLength - line.length();
+                    while (matcher.find()) {
+                        // TODO: we can extract application ID from internal URL and put it to hyper link
+                        items.add(new Filter.ResultItem(textStartOffset + matcher.start(), textStartOffset + matcher.end(), new BrowserHyperlinkInfo(mappedUrl)));
+                    }
+                    return items.size() != 0 ? new Filter.Result(items) : null;
+                });
+            }
+        }
         submissionState.setRemoteProcessCtrlLogHandler(processHandler);
 
         ctrlSubject.subscribe(

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
@@ -187,12 +187,11 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
                     : null;
             if (mapping != null) {
                 submissionState.getConsoleView().addMessageFilter((line, entireLength) -> {
-                    String mappedUrl = mapping.mapInternalUrlToPublic();
-                    Matcher matcher = Pattern.compile("http://[^\\s]+").matcher(line);
+                    Matcher matcher = Pattern.compile("http://[^\\s]+", Pattern.CASE_INSENSITIVE).matcher(line);
                     List<Filter.ResultItem> items = new ArrayList<>();
                     int textStartOffset = entireLength - line.length();
                     while (matcher.find()) {
-                        // TODO: we can extract application ID from internal URL and put it to hyper link
+                        String mappedUrl = mapping.mapInternalUrlToPublic(matcher.group(0));
                         items.add(new Filter.ResultItem(textStartOffset + matcher.start(), textStartOffset + matcher.end(), new BrowserHyperlinkInfo(mappedUrl)));
                     }
                     return items.size() != 0 ? new Filter.Result(items) : null;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkJobLogConsoleView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkJobLogConsoleView.java
@@ -27,6 +27,7 @@ import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.psi.search.GlobalSearchScope;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,7 +44,8 @@ public class SparkJobLogConsoleView extends ConsoleViewImpl {
     public SparkJobLogConsoleView(@NotNull Project project) {
         super(project, true);
 
-        this.secondaryConsoleView = new ConsoleViewImpl(project, true);
+        // set `usePredefinedMessageFilter = false` to disable predefined filter by console view and avoid filter conflict
+        this.secondaryConsoleView = new ConsoleViewImpl(project, GlobalSearchScope.allScope(project), true, false);
     }
 
     @Override

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/InternalUrlMapping.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/InternalUrlMapping.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.hdinsight.sdk.cluster;
+
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+
+public interface InternalUrlMapping {
+    @NotNull
+    String mapInternalUrlToPublic();
+}

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/InternalUrlMapping.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/InternalUrlMapping.java
@@ -26,5 +26,5 @@ import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 
 public interface InternalUrlMapping {
     @NotNull
-    String mapInternalUrlToPublic();
+    String mapInternalUrlToPublic(@NotNull String url);
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/CosmosSparkBatchJob.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/CosmosSparkBatchJob.java
@@ -38,15 +38,15 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
-public class ServerlessSparkBatchJob extends SparkBatchJob {
-    public ServerlessSparkBatchJob(@NotNull SparkSubmissionParameter submissionParameter,
-                                   @NotNull SparkBatchAzureSubmission azureSubmission,
-                                   @NotNull Observer<SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject) {
+public class CosmosSparkBatchJob extends SparkBatchJob {
+    public CosmosSparkBatchJob(@NotNull SparkSubmissionParameter submissionParameter,
+                               @NotNull SparkBatchAzureSubmission azureSubmission,
+                               @NotNull Observer<SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject) {
         super(submissionParameter, azureSubmission, ctrlSubject);
     }
 
     @NotNull
-    private Observable<? extends AzureSparkServerlessCluster> getCluster() {
+    private Observable<? extends AzureSparkServerlessCluster> getCosmosSparkCluster() {
         return AzureSparkServerlessClusterManager.getInstance()
                 .findCluster(getAzureSubmission().getAccountName(), getAzureSubmission().getClusterId())
                 .onErrorResumeNext(err -> Observable.error(err instanceof NoSuchElementException ?
@@ -62,7 +62,7 @@ public class ServerlessSparkBatchJob extends SparkBatchJob {
     @NotNull
     @Override
     public Observable<? extends ISparkBatchJob> deploy(@NotNull String artifactPath) {
-        return getCluster()
+        return getCosmosSparkCluster()
                 .flatMap(cluster -> {
                     try {
                         if (cluster.getStorageAccount() == null) {
@@ -101,7 +101,7 @@ public class ServerlessSparkBatchJob extends SparkBatchJob {
     public Observable<String> awaitStarted() {
         return super.awaitStarted()
                 .flatMap(state -> Observable.zip(
-                        getCluster(), getSparkJobApplicationIdObservable().defaultIfEmpty(null),
+                        getCosmosSparkCluster(), getSparkJobApplicationIdObservable().defaultIfEmpty(null),
                         (cluster, appId) -> Pair.of(
                                 state,
                                 cluster.getSparkHistoryUiUri() == null ?

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/sdk/cluster/SqlBigDataLivyLinkClusterDetail.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/sdk/cluster/SqlBigDataLivyLinkClusterDetail.java
@@ -110,7 +110,8 @@ public class SqlBigDataLivyLinkClusterDetail implements IClusterDetail, LivyClus
     @Override
     @NotNull
     public String mapInternalUrlToPublic(@NotNull String url) {
-        // TODO: we can extract application ID from internal URL and map it to output
+        // FIXME: Hardcode for only output Yarn NM connection URL
+        // We should extract application ID from internal URL and map it to output
         return getYarnNMConnectionUrl();
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/sdk/cluster/SqlBigDataLivyLinkClusterDetail.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/sdk/cluster/SqlBigDataLivyLinkClusterDetail.java
@@ -109,7 +109,8 @@ public class SqlBigDataLivyLinkClusterDetail implements IClusterDetail, LivyClus
 
     @Override
     @NotNull
-    public String mapInternalUrlToPublic() {
+    public String mapInternalUrlToPublic(@NotNull String url) {
+        // TODO: we can extract application ID from internal URL and map it to output
         return getYarnNMConnectionUrl();
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/sdk/cluster/SqlBigDataLivyLinkClusterDetail.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/sdk/cluster/SqlBigDataLivyLinkClusterDetail.java
@@ -1,8 +1,8 @@
 package com.microsoft.azure.sqlbigdata.sdk.cluster;
 
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
+import com.microsoft.azure.hdinsight.sdk.cluster.InternalUrlMapping;
 import com.microsoft.azure.hdinsight.sdk.cluster.LivyCluster;
-import com.microsoft.azure.hdinsight.sdk.cluster.SparkCluster;
 import com.microsoft.azure.hdinsight.sdk.cluster.YarnCluster;
 import com.microsoft.azure.hdinsight.sdk.common.HDIException;
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmitStorageType;
@@ -12,10 +12,7 @@ import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import org.apache.commons.lang3.StringUtils;
 
-import java.net.URI;
-import java.util.Optional;
-
-public class SqlBigDataLivyLinkClusterDetail implements IClusterDetail, LivyCluster, YarnCluster {
+public class SqlBigDataLivyLinkClusterDetail implements IClusterDetail, LivyCluster, YarnCluster, InternalUrlMapping {
     @NotNull
     private String host;
     private int knoxPort;
@@ -108,5 +105,11 @@ public class SqlBigDataLivyLinkClusterDetail implements IClusterDetail, LivyClus
     @Override
     public SparkSubmitStorageTypeOptionsForCluster getStorageOptionsType() {
        return SparkSubmitStorageTypeOptionsForCluster.BigDataClusterWithWebHdfs;
+    }
+
+    @Override
+    @NotNull
+    public String mapInternalUrlToPublic() {
+        return getYarnNMConnectionUrl();
     }
 }


### PR DESCRIPTION
The internal URL remains the same, but when you click the URL it jumps to public YARN UI URL.
 - console view
![image](https://user-images.githubusercontent.com/32627233/50507283-cca26b00-0ab7-11e9-9ecd-10b64ed8c6ad.png)
 - open internal URL in browser
![image](https://user-images.githubusercontent.com/32627233/50507333-02475400-0ab8-11e9-80da-420df1e75607.png)
