### PR TITLE
Fix potential infinity loop issue

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/ClusterNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/ClusterNode.java
@@ -147,8 +147,6 @@ public class ClusterNode extends RefreshableNode implements TelemetryProperties 
 
     @Override
     protected void refreshItems() {
-        this.load(false);
-
         if(!clusterDetail.isEmulator()) {
             JobViewManager.registerJovViewNode(clusterDetail.getName(), clusterDetail);
             JobViewNode jobViewNode = new JobViewNode(this, clusterDetail.getName());


### PR DESCRIPTION
if A() <- B() means method B is refered in method A. We have:
1. In class `RefreshableNode`, `load(boolean forceRefresh)` <- `refreshItems(SettableFuture<List<Node>> future, boolean forceRefresh)` <- `refreshItems()`
2. In class `ClusterNode`, `refreshItems()` <- `load(boolean forceRefresh)`.
Here infinity loop happends.