### PR TITLE
Recover icon path for eclipse build failure

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/CommonConst.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/CommonConst.java
@@ -40,6 +40,7 @@ public class CommonConst {
     public static final String StopIconPath = "/icons/Stop.png";
     public static final String StopDisableIconPath = "/icons/Stop-Disable.png";
     public static final String OpenSparkUIIconName = "OpenSparkUI";
+    public static final String OpenSparkUIIconPath = "/icons/OpenSparkUI.png";
     public static final String OpenSparkUIDisableIconPath = "/icons/OpenSparkUI-Disable.png";
     public static final String SPARK_JOBVIEW_ICONPATH = "/icons/JobViewTitle.png";
     public static final String EmualtorPath = "/emulator/";


### PR DESCRIPTION
```
+ mvn clean install -f /jenkinshome/jenkins/workspace/Azure_Toolkits_for_Java/AzureToolsManager_develop/PluginsAndFeatures/azure-toolkit-for-eclipse/pom.xml -q
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:0.25.0:compile (default-compile) on project com.microsoft.azuretools.hdinsight: Compilation failure: Compilation failure:
[ERROR] /jenkinshome/jenkins/workspace/Azure_Toolkits_for_Java/AzureToolsManager_develop/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.hdinsight/src/com/microsoft/azuretools/hdinsight/SparkSubmissionToolWindowView.java:[109]
[ERROR] openSparkUIButton.setImage(Activator.getImageDescriptor(CommonConst.OpenSparkUIIconPath).createImage());
[ERROR] ^^^^^^^^^^^^^^^^^^^
[ERROR] OpenSparkUIIconPath cannot be resolved or is not a field
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :com.microsoft.azuretools.hdinsight
Build step 'Execute shell' marked build as failure
[Cobertura] Publishing Cobertura coverage report...

```
