### PR TITLE
Fix the regression Spark AdvConf ssh password loading

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkRunConfigurationSettingsEditor.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkRunConfigurationSettingsEditor.kt
@@ -51,6 +51,7 @@ class LivySparkRunConfigurationSettingsEditor(val jobConfigurable: SparkBatchJob
         if (advModel.enableRemoteDebug && advModel.sshAuthType == UsePassword) {
             // Load password for no password input
             try {
+                advModel.clusterName = livySparkBatchJobRunConfiguration.submitModel.clusterName
                 advModel.sshPassword = secureStore?.loadPassword(advModel.credentialStoreAccount, advModel.sshUserName)
             } catch (ignored: Exception) { }
         }


### PR DESCRIPTION
`advModel.credentialStoreAccount` depends on `clusterName` property which has to be set before getting `credentialStoreAccount`