### PR TITLE
classify user error for wrong class name

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/SparkToolException.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/SparkToolException.kt
@@ -23,6 +23,7 @@ package com.microsoft.azure.hdinsight.common.classifiedexception
 
 import com.intellij.openapi.application.ApplicationManager
 import com.microsoft.azure.hdinsight.sdk.common.livy.interactive.exceptions.SessionNotStartException
+import com.microsoft.azure.hdinsight.spark.common.SparkJobException
 import com.microsoft.azure.hdinsight.spark.common.YarnDiagnosticsException
 import com.microsoft.intellij.forms.ErrorMessageForm
 import org.apache.commons.lang.exception.ExceptionUtils
@@ -49,6 +50,7 @@ object SparkToolExceptionFactory : ClassifiedExceptionFactory() {
                 && !(exp is IllegalArgumentException && stackTrace.contains("com.microsoft.azure.storage.CloudStorageAccount"))
                 // Thrown from creating Livy helper session to upload artifacts,refer to Issue #2552
                 && exp !is SessionNotStartException
+                && exp !is SparkJobException
                 && stackTrace.contains(ToolPackageSuffix)) {
             SparkToolException(exp)
         } else null

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/SparkUserException.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/SparkUserException.kt
@@ -21,6 +21,7 @@
  */
 package com.microsoft.azure.hdinsight.common.classifiedexception
 
+import com.microsoft.azure.hdinsight.spark.common.SparkJobException
 import com.microsoft.azure.hdinsight.spark.common.YarnDiagnosticsException
 
 class SparkUserException(exp: Throwable?) : ClassifiedException(exp) {
@@ -32,6 +33,10 @@ class SparkUserException(exp: Throwable?) : ClassifiedException(exp) {
 
 object SparkUserExceptionFactory : ClassifiedExceptionFactory() {
     override fun createClassifiedException(exp: Throwable?): ClassifiedException? {
-        return if (exp is YarnDiagnosticsException) SparkUserException(exp) else null
+        return if (exp is YarnDiagnosticsException
+                // Throw from wrong class name ,refer to issue 1827 and 2466
+                || exp is SparkJobException) {
+            SparkUserException(exp)
+        } else null
     }
 }


### PR DESCRIPTION
When user inputs wrong class name , sparkjobexception can happen
![image](https://user-images.githubusercontent.com/43339305/50813879-b8315e80-1352-11e9-8963-1beb267bf088.png)

This pr classifies this exp as user exp
#1827 
#2466 
Since clusters of different versions have different detail error message , we just treat SparkJobException as user exception at present.