### PR TITLE
Fix livy console bug that session hangs when application gets killed.

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/livy/interactive/Session.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/livy/interactive/Session.java
@@ -227,7 +227,8 @@ public abstract class Session implements AutoCloseable, Closeable {
         return getLastState() == SessionState.SHUTTING_DOWN ||
                 getLastState() == SessionState.NOT_STARTED ||
                 getLastState() == SessionState.DEAD ||
-                getLastState() == SessionState.KILLED;
+                getLastState() == SessionState.KILLED ||
+                getLastState() == SessionState.ERROR;
     }
 
     public boolean isStatementRunnable() {

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/livy/interactive/Session.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/livy/interactive/Session.java
@@ -226,7 +226,8 @@ public abstract class Session implements AutoCloseable, Closeable {
     public boolean isStop() {
         return getLastState() == SessionState.SHUTTING_DOWN ||
                 getLastState() == SessionState.NOT_STARTED ||
-                getLastState() == SessionState.DEAD;
+                getLastState() == SessionState.DEAD ||
+                getLastState() == SessionState.KILLED;
     }
 
     public boolean isStatementRunnable() {


### PR DESCRIPTION
To fix #2629 
According to [livy code](https://github.com/apache/incubator-livy/blob/551dd5c27f05c35c75015c7dae9153e2a7f23089/core/src/main/scala/org/apache/livy/sessions/SessionState.scala#L32), KILLED/ERROR should also be a terminated state.