### PR TITLE
Remove useless error log when use device login

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -73,6 +73,7 @@ repositories {
 
 configurations {
     compile.exclude module:'slf4j-api'
+    compile.exclude module:'log4j'
     cucumberRuntime {
         extendsFrom testRuntime
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/DeviceLoginWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/DeviceLoginWindow.java
@@ -90,8 +90,11 @@ public class DeviceLoginWindow extends AzureDialogWrapper {
                                           final AuthenticationCallback<AuthenticationResult> callback) {
         final long interval = deviceCode.getInterval();
         long remaining = deviceCode.getExpiresIn();
-        // Close logger for adal sdk will write useless error log
-        Logger.getRootLogger().setLevel(Level.OFF);
+        // Close adal logger for it will write useless error log
+        // for issue #2368 https://github.com/Microsoft/azure-tools-for-java/issues/2368
+        Logger authLogger = Logger.getLogger(AuthenticationContext.class);
+        Level authLoggerLevel = authLogger.getLevel();
+        authLogger.setLevel(Level.OFF);
         while (remaining > 0 && authenticationResult == null) {
             try {
                 remaining -= interval;
@@ -107,7 +110,7 @@ public class DeviceLoginWindow extends AzureDialogWrapper {
                 }
             }
         }
-        LogManager.resetConfiguration();
+        authLogger.setLevel(authLoggerLevel);
         closeDialog();
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/DeviceLoginWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/DeviceLoginWindow.java
@@ -31,6 +31,9 @@ import com.microsoft.aad.adal4j.AuthenticationException;
 import com.microsoft.aad.adal4j.AuthenticationResult;
 import com.microsoft.aad.adal4j.DeviceCode;
 import com.microsoft.intellij.ui.components.AzureDialogWrapper;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import java.awt.Desktop;
 import java.awt.Toolkit;
@@ -87,6 +90,8 @@ public class DeviceLoginWindow extends AzureDialogWrapper {
                                           final AuthenticationCallback<AuthenticationResult> callback) {
         final long interval = deviceCode.getInterval();
         long remaining = deviceCode.getExpiresIn();
+        // Close logger for adal sdk will write useless error log
+        Logger.getRootLogger().setLevel(Level.OFF);
         while (remaining > 0 && authenticationResult == null) {
             try {
                 remaining -= interval;
@@ -102,6 +107,7 @@ public class DeviceLoginWindow extends AzureDialogWrapper {
                 }
             }
         }
+        LogManager.resetConfiguration();
         closeDialog();
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/DeviceLoginWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/DeviceLoginWindow.java
@@ -35,6 +35,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
+
 import java.awt.Desktop;
 import java.awt.Toolkit;
 import java.awt.Window;
@@ -95,22 +96,25 @@ public class DeviceLoginWindow extends AzureDialogWrapper {
         Logger authLogger = Logger.getLogger(AuthenticationContext.class);
         Level authLoggerLevel = authLogger.getLevel();
         authLogger.setLevel(Level.OFF);
-        while (remaining > 0 && authenticationResult == null) {
-            try {
-                remaining -= interval;
-                Thread.sleep(interval * 1000);
-                authenticationResult = ctx.acquireTokenByDeviceCode(deviceCode, callback).get();
-            } catch (ExecutionException | InterruptedException e) {
-                if (e.getCause() instanceof AuthenticationException &&
-                    ((AuthenticationException) e.getCause()).getErrorCode() == AdalErrorCode.AUTHORIZATION_PENDING) {
-                    // swallow the pending exception
-                } else {
-                    e.printStackTrace();
-                    break;
+        try {
+            while (remaining > 0 && authenticationResult == null) {
+                try {
+                    remaining -= interval;
+                    Thread.sleep(interval * 1000);
+                    authenticationResult = ctx.acquireTokenByDeviceCode(deviceCode, callback).get();
+                } catch (ExecutionException | InterruptedException e) {
+                    if (e.getCause() instanceof AuthenticationException &&
+                        ((AuthenticationException) e.getCause()).getErrorCode() == AdalErrorCode.AUTHORIZATION_PENDING) {
+                        // swallow the pending exception
+                    } else {
+                        e.printStackTrace();
+                        break;
+                    }
                 }
             }
+        } finally {
+            authLogger.setLevel(authLoggerLevel);
         }
-        authLogger.setLevel(authLoggerLevel);
         closeDialog();
     }
 


### PR DESCRIPTION
Remove waiting response error notification when use device login.
For issue #2368 