### PR TITLE
Pretty print JSON for Spark serverless job detail

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/Test/java/com/microsoft/azure/hdinsight/spark/ui/SparkJobTableTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/Test/java/com/microsoft/azure/hdinsight/spark/ui/SparkJobTableTest.kt
@@ -83,7 +83,13 @@ class MockSparkBatchJobViewerControl(private val view: MockSparkBatchJobViewer) 
         Observable.from(sparkJobDesc)
                 .delay(500, TimeUnit.MILLISECONDS)
                 .subscribe { view.getModel(LivyBatchJobViewer.Model::class.java).apply {
-                    jobDetail = """{"message":"hello ${it.jobStatus.appId}!","error no": 0, "id": ${it.jobStatus.id}}"""
+                    jobDetail = if (it.jobStatus.id == 1) {
+                        // Unclosed JSON string
+                        """{"message":"A broken response for ${it.jobStatus.appId}!","error no": 0, "id": ${it.jobStatus.id}"""
+
+                    } else {
+                        """{"message":"hello ${it.jobStatus.appId}!","error no": 0, "id": ${it.jobStatus.id}}"""
+                    }
 
                     view.setData(this)
                 }}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/livy/batch/LivyBatchJobViewer.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/livy/batch/LivyBatchJobViewer.kt
@@ -29,6 +29,8 @@ import com.intellij.openapi.command.undo.UndoUtil
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.EditorKind
 import com.microsoft.azure.hdinsight.common.mvc.IdeaSettableControlView
+import org.json.JSONException
+import org.json.JSONObject
 import javax.swing.JComponent
 import javax.swing.JSplitPane
 import javax.swing.JSplitPane.HORIZONTAL_SPLIT
@@ -78,7 +80,16 @@ abstract class LivyBatchJobViewer : Disposable, IdeaSettableControlView<LivyBatc
         jobTableViewport.setDataInDispatch(from.tableViewportModel)
 
         runWriteAction {
-            jobDetailDocument.setText(from.jobDetail ?: jobDetailNotSetMessage)
+            // TODO: Leverage IntelliJ's `Reformat Code` action to format JSON text with syntax highlighted
+            val formattedText = from.jobDetail?.let {
+                try {
+                    JSONObject(from.jobDetail).toString(4)
+                } catch (err: JSONException) {
+                    "<broken response>\n${from.jobDetail}"
+                }
+            } ?: jobDetailNotSetMessage
+
+            jobDetailDocument.setText(formattedText)
         }
     }
 }


### PR DESCRIPTION
Just a simple solution, nice to leverage IntelliJ's `Reformat Code`
action later for syntax highlighting.

Signed-off-by: Wei Zhang <wezhang@outlook.com>