### PR TITLE
Hide Livy link resource type field when link aris cluster

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewClusterForm.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewClusterForm.form
@@ -43,7 +43,7 @@
                       </model>
                     </properties>
                   </component>
-                  <component id="cf31d" class="javax.swing.JLabel">
+                  <component id="cf31d" class="javax.swing.JLabel" binding="linkResourceTypeLabel">
                     <constraints>
                       <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewClusterForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewClusterForm.java
@@ -88,6 +88,7 @@ public class AddNewClusterForm extends DialogWrapper implements SettableControl<
     protected JPanel arisLivyServiceCard;
     private JPanel authErrorDetailsPanelHolder;
     private JPanel authErrorDetailsPanel;
+    protected JLabel linkResourceTypeLabel;
     protected HideableDecorator authErrorDetailsDecorator;
     protected ConsoleViewImpl consoleViewPanel;
     @NotNull

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/sqlbigdata/serverexplore/ui/AddNewSqlBigDataClusterForm.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/sqlbigdata/serverexplore/ui/AddNewSqlBigDataClusterForm.kt
@@ -38,6 +38,9 @@ class AddNewSqlBigDataClusterForm(project: Project, module: SqlBigDataClusterMod
     init {
         title = "Link SQL Server Big Data Cluster"
 
+        linkResourceTypeLabel.isVisible = false
+        clusterComboBox.isVisible = false
+
         val livyServiceTitle = "Livy Service"
         clusterComboBox.model = DefaultComboBoxModel(arrayOf(livyServiceTitle))
         clusterComboBox.isEnabled = true


### PR DESCRIPTION
 - Preview as below
![image](https://user-images.githubusercontent.com/32627233/51818422-dbc04700-2309-11e9-9541-5c2f09da7852.png)
