### PR TITLE
Apply same font to Device Login Dialog

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/DeviceLoginWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/DeviceLoginWindow.java
@@ -32,11 +32,17 @@ import com.microsoft.aad.adal4j.AuthenticationResult;
 import com.microsoft.aad.adal4j.DeviceCode;
 import com.microsoft.intellij.ui.components.AzureDialogWrapper;
 import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
+import javax.swing.JComponent;
+import javax.swing.JEditorPane;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.text.html.HTMLDocument;
 import java.awt.Desktop;
+import java.awt.Font;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.datatransfer.Clipboard;
@@ -47,10 +53,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import javax.swing.JComponent;
-import javax.swing.JEditorPane;
-import javax.swing.JPanel;
-import javax.swing.event.HyperlinkEvent;
 
 public class DeviceLoginWindow extends AzureDialogWrapper {
     private static final String TITLE = "Azure Device Login";
@@ -82,6 +84,12 @@ public class DeviceLoginWindow extends AzureDialogWrapper {
                 }
             }
         });
+        // Apply JLabel's font to JEditorPane
+        final Font font = UIManager.getFont("Label.font");
+        final String cssRule = String.format("body { font-family: %s ; font-size: %s pt ;}", font.getFamily(),
+            font.getSize());
+        ((HTMLDocument) editorPanel.getDocument()).getStyleSheet().addRule(cssRule);
+
         authExecutor = ApplicationManager.getApplication()
             .executeOnPooledThread(() -> pullAuthenticationResult(ctx, deviceCode, callBack));
         init();


### PR DESCRIPTION
Use same font for device login dialog, for issue #2719 
After:
![after](https://user-images.githubusercontent.com/12445236/51822153-5d1dd680-2316-11e9-9eee-6ff756ffbabb.png)
Before:
![before](https://user-images.githubusercontent.com/12445236/51822157-6149f400-2316-11e9-9545-12773f23afcf.png)
