### PR TITLE
Fix build break for IntelliJ EAP 2019.1

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version "0.3.12"
+    id "org.jetbrains.intellij" version "0.4.2"
     id "org.jetbrains.kotlin.jvm" version "1.2.50"
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -2,6 +2,6 @@ javaVersion=1.8
 org.gradle.jvmargs='-Duser.language=en'
 sources=false
 intellij_version=IC-LATEST-EAP-SNAPSHOT
-dep_plugins=org.intellij.scala:2018.3.2
+dep_plugins=org.intellij.scala:2019.1.1
 applicationinsights.key=57cc111a-36a8-44b3-b044-25d293b8b77c
 updateVersionRange=true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ApplicationSettings.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ApplicationSettings.java
@@ -10,8 +10,7 @@ import java.util.Map;
 @State(
         name = "HDInsightSettings",
         storages = {
-                @Storage(file = "$APP_CONFIG$/azure.application.settings.xml",
-                        scheme = StorageScheme.DIRECTORY_BASED)
+                @Storage(file = "$APP_CONFIG$/azure.application.settings.xml")
         })
 public class ApplicationSettings implements PersistentStateComponent<ApplicationSettings.State> {
     private State myState = new State();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureSettings.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureSettings.java
@@ -38,7 +38,7 @@ import static com.microsoft.intellij.ui.messages.AzureBundle.message;
         name = "AzureSettings",
         storages = {
                 @Storage(file = "$PROJECT_FILE$"),
-                @Storage(file = "$PROJECT_CONFIG_DIR$/azureSettings.xml", scheme = StorageScheme.DIRECTORY_BASED)
+                @Storage(file = "$PROJECT_CONFIG_DIR$/azureSettings.xml")
         }
 )
 public class AzureSettings implements PersistentStateComponent<AzureSettings.State> {


### PR DESCRIPTION
 - Remove scheme for @Storage since it's `not required and not used anymore`. Refer to [intelliJ-community repo](https://github.com/JetBrains/intellij-community/commit/356e2eb3f6da799986b844e825bd94a8afb019fb?diff=split)
 - The latest version of gradle-intellij-plugin is `0.4.3` but we only upgrade it to `0.4.2` due to [Cannot download JetBrains Java Runtime issue](https://github.com/JetBrains/gradle-intellij-plugin/issues/367)