### PR TITLE
- Do not show "refresh" button in webapp node

### DIFF
--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBaseNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBaseNode.java
@@ -22,6 +22,7 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +77,16 @@ public abstract class WebAppBaseNode extends RefreshableNode implements Telemetr
         getNodeActionByName(ACTION_STOP).setEnabled(running);
         getNodeActionByName(ACTION_RESTART).setEnabled(running);
 
-        return super.getNodeActions();
+        List<NodeAction> actions = super.getNodeActions();
+        // Dirty fix, should not show "refresh" in webapp node, since we do not support deploy slot
+        // Temp solution, after we support deploy slot, should remove this line.
+        List<NodeAction> webAppActions = new ArrayList<>();
+        for (NodeAction nodeAction : actions) {
+        	if (!nodeAction.getName().equals("Refresh")) {
+        		webAppActions.add(nodeAction);
+        	}
+        }
+        return webAppActions;
     }
 
     protected NodeActionListener createBackgroundActionListener(final String actionName, final Runnable runnable) {


### PR DESCRIPTION
We should not show "refresh" button in web app node, since we do not support deploy slot and have nothing to refresh.

<img width="477" alt="wechat image_20190305091916" src="https://user-images.githubusercontent.com/7624690/53774061-e634b880-3f27-11e9-8c49-3ff1582a38a6.png">
