### PR TITLE
Enable to build plugins for Eclipse/IntelliJ separately

### DIFF
--- a/BuildProduct.sh
+++ b/BuildProduct.sh
@@ -6,8 +6,16 @@ SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 cd "$SCRIPTPATH"
 
+# Utils
 VERSION="3.18.0"
 MAVEN_QUIET=""
+
+# Eclipse
+BUILD_ECLIPSE=true
+
+# IntelliJ
+BUILD_INTELLIJ=true
+
 INJECT_INTELLIJ_VERSION=false
 
 IJ_VERSION_LATEST=2018.3
@@ -18,11 +26,17 @@ IJ_VERSION_FALLBACK=2018.2
 IJ_DISPLAY_VERSION_FALLBACK=2018.2
 IJ_SCALA_VERSION_FALLBACK=2018.2.11
 
-while getopts ":hqv" option; do
+while getopts "hqve:" option; do
     case $option in
-        h) echo "usage: $0 [-h] [-q] [-v]"; exit ;;
+        h) echo "usage: $0 [-h] [-q] [-v] [-e eclipse/intellij]"; exit ;;
         q) MAVEN_QUIET="-q" ;;
         v) INJECT_INTELLIJ_VERSION=true ;;
+        e)
+          shopt -s nocasematch
+          case $OPTARG in 
+            eclipse) BUILD_ECLIPSE=false ;;
+            intellij) BUILD_INTELLIJ=false ;;
+          esac ;;
         ?) echo "error: option -$OPTARG is not implemented"; exit ;;
     esac
 done
@@ -46,6 +60,7 @@ fi
 set -x
 
 # Build Utils
+echo "Building Utils ..."
 mvn install -f ./Utils/pom.xml -Dmaven.repo.local=./.repository $MAVEN_QUIET
 rm -rf ${TOSIGNPATH}/*
 cp ./Utils/azuretools-core/target/azuretools-core-${VERSION}.jar ${TOSIGNPATH}/
@@ -71,34 +86,40 @@ mvn install:install-file -Dfile=./Utils/hdinsight-node-common/target/hdinsight-n
 
 mvn install -f ./PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml -Dmaven.repo.local=./.repository $MAVEN_QUIET
 
-# Build eclipse plugin
-mvn clean install -f ./PluginsAndFeatures/azure-toolkit-for-eclipse/pom.xml -Dinstrkey=${ECLIPSE_KEY}  $MAVEN_QUIET
-cp ./PluginsAndFeatures/azure-toolkit-for-eclipse/WindowsAzurePlugin4EJ/target/WindowsAzurePlugin4EJ*.zip ./$ARTIFACTS_DIR/WindowsAzurePlugin4EJ.zip
+# Build Eclipse plugin
+if $BUILD_ECLIPSE; then
+  echo "Building Eclipse plugin ..."
+  mvn clean install -f ./PluginsAndFeatures/azure-toolkit-for-eclipse/pom.xml -Dinstrkey=${ECLIPSE_KEY}  $MAVEN_QUIET
+  cp ./PluginsAndFeatures/azure-toolkit-for-eclipse/WindowsAzurePlugin4EJ/target/WindowsAzurePlugin4EJ*.zip ./$ARTIFACTS_DIR/WindowsAzurePlugin4EJ.zip
 
-chmod +x ./tools/IntellijVersionHelper
-
-# Build intellij plugin for latest version
-if [ $INJECT_INTELLIJ_VERSION == "true" ] ; then
-    ./tools/IntellijVersionHelper $IJ_DISPLAY_VERSION_LATEST
+   # Extract jars to sign
+  rm -rf ${ECLIPSE_TOSIGN}/*
+  unzip -j artifacts/WindowsAzurePlugin4EJ.zip "**/*.jar" "*.jar" -d ${ECLIPSE_TOSIGN}
 fi
-(cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s -Papplicationinsights.key=${INTELLIJ_KEY} -Pintellij_version=IC-$IJ_VERSION_LATEST -Pdep_plugins=org.intellij.scala:$IJ_SCALA_VERSION_LATEST)
-cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-$IJ_DISPLAY_VERSION_LATEST.zip
 
-# Build intellij plugin for fallback version
-if [ $INJECT_INTELLIJ_VERSION == "true" ] ; then
-    ./tools/IntellijVersionHelper $IJ_DISPLAY_VERSION_FALLBACK
+# Build IntelliJ plugin
+if $BUILD_INTELLIJ; then
+  echo "Building IntelliJ plugin ..."
+  chmod +x ./tools/IntellijVersionHelper
+
+  # Build intellij plugin for latest version
+  if [ $INJECT_INTELLIJ_VERSION == "true" ] ; then
+      ./tools/IntellijVersionHelper $IJ_DISPLAY_VERSION_LATEST
+  fi
+  (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s -Papplicationinsights.key=${INTELLIJ_KEY} -Pintellij_version=IC-$IJ_VERSION_LATEST -Pdep_plugins=org.intellij.scala:$IJ_SCALA_VERSION_LATEST)
+  cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-$IJ_DISPLAY_VERSION_LATEST.zip
+
+  # Build intellij plugin for fallback version
+  if [ $INJECT_INTELLIJ_VERSION == "true" ] ; then
+      ./tools/IntellijVersionHelper $IJ_DISPLAY_VERSION_FALLBACK
+  fi
+  (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s -Papplicationinsights.key=${INTELLIJ_KEY} -Pintellij_version=IC-$IJ_VERSION_FALLBACK -Pdep_plugins=org.intellij.scala:$IJ_SCALA_VERSION_FALLBACK)
+  cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-$IJ_DISPLAY_VERSION_FALLBACK.zip
+
+  # Extract jars to sign
+  rm -rf ${INTELLIJ_TOSIGN}/*
+  unzip -p ./artifacts/azure-toolkit-for-intellij-$IJ_DISPLAY_VERSION_LATEST.zip azure-toolkit-for-intellij/lib/azure-toolkit-for-intellij.jar > ${INTELLIJ_TOSIGN}/azure-toolkit-for-intellij_$IJ_DISPLAY_VERSION_LATEST.jar
+  unzip -p ./artifacts/azure-toolkit-for-intellij-$IJ_DISPLAY_VERSION_FALLBACK.zip azure-toolkit-for-intellij/lib/azure-toolkit-for-intellij.jar > ${INTELLIJ_TOSIGN}/azure-toolkit-for-intellij_$IJ_DISPLAY_VERSION_FALLBACK.jar
 fi
-(cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew clean buildPlugin -s -Papplicationinsights.key=${INTELLIJ_KEY} -Pintellij_version=IC-$IJ_VERSION_FALLBACK -Pdep_plugins=org.intellij.scala:$IJ_SCALA_VERSION_FALLBACK)
-cp ./PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions/azure-toolkit-for-intellij.zip ./$ARTIFACTS_DIR/azure-toolkit-for-intellij-$IJ_DISPLAY_VERSION_FALLBACK.zip
-
-# Extract jars to sign
-# intelliJ
-rm -rf ${INTELLIJ_TOSIGN}/*
-unzip -p ./artifacts/azure-toolkit-for-intellij-$IJ_DISPLAY_VERSION_LATEST.zip azure-toolkit-for-intellij/lib/azure-toolkit-for-intellij.jar > ${INTELLIJ_TOSIGN}/azure-toolkit-for-intellij_$IJ_DISPLAY_VERSION_LATEST.jar
-unzip -p ./artifacts/azure-toolkit-for-intellij-$IJ_DISPLAY_VERSION_FALLBACK.zip azure-toolkit-for-intellij/lib/azure-toolkit-for-intellij.jar > ${INTELLIJ_TOSIGN}/azure-toolkit-for-intellij_$IJ_DISPLAY_VERSION_FALLBACK.jar
-
-# Eclipse
-rm -rf ${ECLIPSE_TOSIGN}/*
-unzip -j artifacts/WindowsAzurePlugin4EJ.zip "**/*.jar" "*.jar" -d ${ECLIPSE_TOSIGN}
 
 echo "ALL BUILD SUCCESSFUL"


### PR DESCRIPTION
Same as `BuildDevint`, it uses `-e eclipse/intellij` to separate the plugin building for the two platforms.

It's prerequisite for releasing them separately.  