### PR TITLE
Add ':' to deployment labels

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/slimui/WebAppSlimSettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/slimui/WebAppSlimSettingPanel.form
@@ -237,7 +237,7 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Artifact"/>
+          <text value="Artifact:"/>
           <visible value="false"/>
         </properties>
       </component>
@@ -254,7 +254,7 @@
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Artifact"/>
+          <text value="Artifact:"/>
           <visible value="false"/>
         </properties>
       </component>
@@ -263,7 +263,7 @@
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="WebApp"/>
+          <text value="WebApp:"/>
         </properties>
       </component>
       <grid id="e0127" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">


### PR DESCRIPTION
Add ':' to labels of deployment dialog to keep consistent with IntelliJ component.

Before:
![image](https://user-images.githubusercontent.com/12445236/54176824-4056f000-44cb-11e9-83ae-3b0c548640dc.png)

After:
![image](https://user-images.githubusercontent.com/12445236/54176855-58c70a80-44cb-11e9-88eb-5d5ce5a5483e.png)
