### PR TITLE
Webapp in intellij support the new telemetry schema

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/ui/WebAppDeployDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/ui/WebAppDeployDialog.java
@@ -596,14 +596,14 @@ public class WebAppDeployDialog extends AzureTitleAreaDialogWrapper {
                 String successMessage = "";
                 String errorMessage = "Error";
                 Map<String, String> postEventProperties = new HashMap<>();
-                postEventProperties.put("runtime",
+                postEventProperties.put(TelemetryConstants.RUNTIME,
                     webApp.operatingSystem() == OperatingSystem.LINUX ? "linux-" + webApp.linuxFxVersion()
                         : "windows-" + webApp.javaContainer());
-                postEventProperties.put("Java App Name", project.getName());
+                postEventProperties.put(TelemetryConstants.JAVA_APPNAME, project.getName());
                 try {
                     boolean isJar = MavenUtils.isMavenProject(project) && MavenUtils.getPackaging(project)
                         .equals(WebAppUtils.TYPE_JAR);
-                    postEventProperties.put("FileType", isJar ? "jar" : "war");
+                    postEventProperties.put(TelemetryConstants.FILETYPE, isJar ? "jar" : "war");
                 } catch (Exception e) {
                 }
 
@@ -638,7 +638,7 @@ public class WebAppDeployDialog extends AzureTitleAreaDialogWrapper {
                         uploadingTryCount = WebAppUtils.deployArtifact(artifactName, artifactPath, pp, isDeployToRoot,
                             new UpdateProgressIndicator(monitor));
                     }
-                    postEventProperties.put("uploadingTryCount", String.valueOf(uploadingTryCount));
+                    postEventProperties.put(TelemetryConstants.ARTIFACT_UPLOAD_COUNT, String.valueOf(uploadingTryCount));
                     webApp.start();
                     if (monitor.isCanceled()) {
                         AzureDeploymentProgressNotification.notifyProgress(this, deploymentName, null, -1,

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/ui/WebAppDeployDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/ui/WebAppDeployDialog.java
@@ -638,7 +638,8 @@ public class WebAppDeployDialog extends AzureTitleAreaDialogWrapper {
                         uploadingTryCount = WebAppUtils.deployArtifact(artifactName, artifactPath, pp, isDeployToRoot,
                             new UpdateProgressIndicator(monitor));
                     }
-                    postEventProperties.put(TelemetryConstants.ARTIFACT_UPLOAD_COUNT, String.valueOf(uploadingTryCount));
+                    postEventProperties
+                        .put(TelemetryConstants.ARTIFACT_UPLOAD_COUNT, String.valueOf(uploadingTryCount));
                     webApp.start();
                     if (monitor.isCanceled()) {
                         AzureDeploymentProgressNotification.notifyProgress(this, deploymentName, null, -1,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
@@ -158,7 +158,7 @@ public class WebAppRunState extends AzureRunProfileState<WebAppBase> {
 
     @Override
     protected void sendOperInfo(Map<String, String> properties) {
-        TelemetryUtil.sendTelemetryInfo(TelemetryUtil.buildProperties(properties, webAppSettingModel));
+        TelemetryUtil.sendTelemetryInfo(TelemetryUtil.buildWebappProperties(properties, webAppSettingModel));
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/WebAppRunState.java
@@ -32,6 +32,7 @@ import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azuretools.azurecommons.util.FileUtil;
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.utils.AzureUIRefreshCore;
 import com.microsoft.azuretools.utils.AzureUIRefreshEvent;
 import com.microsoft.azuretools.utils.WebAppUtils;
@@ -39,6 +40,7 @@ import com.microsoft.intellij.runner.AzureRunProfileState;
 import com.microsoft.intellij.runner.RunProcessHandler;
 import com.microsoft.intellij.runner.webapp.Constants;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
+import com.microsoft.intellij.util.TelemetryUtil;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPReply;
 import org.jetbrains.annotations.NotNull;
@@ -147,6 +149,16 @@ public class WebAppRunState extends AzureRunProfileState<WebAppBase> {
         } catch (Exception e) {
             processHandler.println(e.getMessage(), ProcessOutputTypes.STDERR);
         }
+    }
+
+    @Override
+    protected void sendOperStart() {
+        TelemetryUtil.sendTelemetryOpStart(TelemetryConstants.WEBAPP, TelemetryConstants.DEPLOY_WEBAPP);
+    }
+
+    @Override
+    protected void sendOperInfo(Map<String, String> properties) {
+        TelemetryUtil.sendTelemetryInfo(TelemetryUtil.buildProperties(properties, webAppSettingModel));
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/slimui/creation/WebAppCreationDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/slimui/creation/WebAppCreationDialog.java
@@ -430,7 +430,8 @@ public class WebAppCreationDialog extends JDialog implements WebAppCreationMvpVi
         ProgressManager.getInstance().run(new Task.Modal(null, "Creating New WebApp...", true) {
             @Override
             public void run(ProgressIndicator progressIndicator) {
-                Map<String, String> properties = TelemetryUtil.buildProperties(null, webAppConfiguration.getModel());
+                Map<String, String> properties = TelemetryUtil
+                    .buildWebappProperties(null, webAppConfiguration.getModel());
                 try {
                     progressIndicator.setIndeterminate(true);
                     TelemetryUtil.sendTelemetryOpStart(TelemetryConstants.WEBAPP, TelemetryConstants.CREATE_WEBAPP);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/TelemetryUtil.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/TelemetryUtil.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.intellij.util;
+
+import com.microsoft.azure.management.appservice.OperatingSystem;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
+import com.microsoft.azuretools.telemetrywrapper.ErrorType;
+import com.microsoft.azuretools.telemetrywrapper.TelemetryManager;
+import com.microsoft.intellij.runner.webapp.webappconfig.IntelliJWebAppSettingModel;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TelemetryUtil {
+    public static void sendTelemetryOpStart(String productionName, String operationName) {
+        TelemetryManager.getInstance().getProducer().startTransaction(productionName, operationName);
+    }
+
+    public static void sendTelemetryOpEnd() {
+        TelemetryManager.getInstance().getProducer().endTransaction();
+    }
+
+    public static void sendTelemetryOpError(ErrorType errorType, String errMsg, Map<String, String> properties) {
+        TelemetryManager.getInstance().getProducer().sendError(errorType, errMsg, properties, null);
+    }
+
+    public static void sendTelemetryInfo(Map<String, String> properties) {
+        TelemetryManager.getInstance().getProducer().sendInfo(properties, null);
+    }
+
+    public static Map<String, String> buildProperties(Map<String, String> properties,
+        IntelliJWebAppSettingModel webAppSettingModel) {
+        Map<String, String> result = new HashMap<>();
+        try {
+            if (properties != null) {
+                result.putAll(properties);
+            }
+            result.put(TelemetryConstants.RUNTIME,
+                webAppSettingModel.getOS() == OperatingSystem.LINUX ? "linux-" + webAppSettingModel.getLinuxRuntime()
+                    .toString() : "windows-" + webAppSettingModel.getWebContainer());
+            result.put(TelemetryConstants.WEBAPP_DEPLOY_TO_SLOT, String.valueOf(webAppSettingModel.isDeployToSlot()));
+            result.put(TelemetryConstants.SUBSCRIPTIONID, webAppSettingModel.getSubscriptionId());
+            result.put(TelemetryConstants.CREATE_NEWWEBAPP, String.valueOf(webAppSettingModel.isCreatingNew()));
+            result.put(TelemetryConstants.CREATE_NEWASP, String.valueOf(webAppSettingModel.isCreatingAppServicePlan()));
+            result.put(TelemetryConstants.CREATE_NEWRG, String.valueOf(webAppSettingModel.isCreatingResGrp()));
+            result.put(TelemetryConstants.FILETYPE, MavenRunTaskUtil.getFileType(webAppSettingModel.getTargetName()));
+        } catch (Exception ignore) {
+        }
+        return result;
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/TelemetryUtil.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/TelemetryUtil.java
@@ -47,7 +47,7 @@ public class TelemetryUtil {
         TelemetryManager.getInstance().getProducer().sendInfo(properties, null);
     }
 
-    public static Map<String, String> buildProperties(Map<String, String> properties,
+    public static Map<String, String> buildWebappProperties(Map<String, String> properties,
         IntelliJWebAppSettingModel webAppSettingModel) {
         Map<String, String> result = new HashMap<>();
         try {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/TelemetryConstants.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/TelemetryConstants.java
@@ -28,7 +28,7 @@ public class TelemetryConstants {
     public static final String ACR = "acr";
     public static final String DOCKER = "docker";
 
-    // operation name
+    // operation value
     public static final String CREATE_WEBAPP = "create-webapp";
     public static final String DELETE_WEBAPP = "delete-webapp";
     public static final String DEPLOY_WEBAPP = "deploy-webapp";
@@ -36,4 +36,15 @@ public class TelemetryConstants {
     public static final String CREATE_WEBAPP_SLOT = "create-webapp-slot";
     public static final String OPEN_CREATEWEBAPP_DIALOG = "open-create-webapp-dialog";
     public static final String REFRESH_METADATA = "refresh";
+
+    // property name
+    public static final String WEBAPP_DEPLOY_TO_SLOT = "webappDeployToSlot";
+    public static final String RUNTIME = "runtime";
+    public static final String CREATE_NEWASP = "createNewAsp";
+    public static final String CREATE_NEWWEBAPP = "createNewWebapp";
+    public static final String CREATE_NEWRG = "createNewRg";
+    public static final String SUBSCRIPTIONID = "subscriptionId";
+    public static final String FILETYPE = "fileType";
+    public static final String ARTIFACT_UPLOAD_COUNT = "artifactUploadCount";
+    public static final String JAVA_APPNAME = "javaAppName";
 }


### PR DESCRIPTION
Send the telemetry use the new telemetry wrapper, the old telemetry still needs for one or two release.
This commit mainly covers the webapp telemetry in intellij.