### PR TITLE
Rules change when probe HDI new API

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/HDInsightHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/HDInsightHelperImpl.java
@@ -189,7 +189,7 @@ public class HDInsightHelperImpl implements HDInsightHelper {
             public void run() {
                 Project project = (Project)module.getProject();
                 String title = "Cluster Job Access Denied";
-                String warningText = "<html><pre>You have Read-only permission for this cluster.<br>Please ‘Link this cluster’ through Ambari credentials to view the corresponding jobs.</pre></html>";
+                String warningText = "<html><pre>You have Read-only permission for this cluster.<br>Please ask the administrator to upgrade your role to Cluster Operator,  or<br>‘Link this cluster’ through Ambari credentials to view the corresponding jobs.</pre></html>";
                 String okButtonText = "Link this cluster";
                 WarningMessageForm form = new WarningMessageForm(project, title, warningText, okButtonText) {
                     @Override
@@ -212,7 +212,7 @@ public class HDInsightHelperImpl implements HDInsightHelper {
             public void run() {
                 Project project = (Project)node.getProject();
                 String title = "Storage Access Denied";
-                String warningText = "<html><pre>You have Read-only permission for this cluster.<br>Please use ‘Open Azure Storage Explorer’ to access the storage associated with this cluster.</pre></html>";
+                String warningText = "<html><pre>You have Read-only permission for this cluster.<br>Please ask the administrator to upgrade your role to Cluster Operator,  or <br>use ‘Open Azure Storage Explorer’ to access the storages associated with this cluster.</pre></html>";
                 String okButtonText = "Open Azure Storage Explorer";
                 WarningMessageForm form = new WarningMessageForm(project, title, warningText, okButtonText) {
                     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkSubmissionContentPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkSubmissionContentPanel.kt
@@ -129,7 +129,7 @@ open class SparkSubmissionContentPanel(private val myProject: Project, val type:
     }}
 
     private val hdiReaderErrorLabel: JLabel =
-        JLabel("No Ambari permission to submit job to the selected cluster.").apply {
+        JLabel("No Ambari permission to submit job to the selected cluster. Please ask the administrator to upgrade your role to Cluster Operator, or link to the selected cluster.").apply {
             foreground = currentErrorColor
             isVisible = false
         }


### PR DESCRIPTION
For probe new HDI API, if the response:
 - Status code 403, we will take it as a HDI Reader cluster
 - Status code 200 with cluster credential provided, we take it as a HDI Owner cluster
 - Status code 200 without cluster credential provided, **telemetry will be sent**. Legacy API will be used. 
 - For network error, we will log the error, no telemtry will be sent. Legacy API will be used.
 - All the other errors will be shown as `HDInsightNewApiUnavailableException` and **telemetry will be sent**. Legacy API will be used.