### PR TITLE
Fix intellij no telemetry problem

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -91,14 +91,17 @@ dependencies {
     compile 'com.microsoft.azuretools:azuretools-core:3.20.0', {
         exclude group: "com.microsoft.azure", module: "azure-client-authentication"
         exclude group: "com.microsoft.azure", module: "azure-client-runtime"
+        exclude group: "javax.xml.bind", module: "jaxb-api"
     }
     compile 'com.microsoft.azuretools:azure-explorer-common:3.20.0', {
         exclude group: "com.microsoft.azure", module: "azure-client-authentication"
         exclude group: "com.microsoft.azure", module: "azure-client-runtime"
+        exclude group: "javax.xml.bind", module: "jaxb-api"
     }
     compile 'com.microsoft.azuretools:hdinsight-node-common:3.20.0', {
         exclude group: "com.microsoft.azure", module: "azure-client-authentication"
         exclude group: "com.microsoft.azure", module: "azure-client-runtime"
+        exclude group: "javax.xml.bind", module: "jaxb-api"
     }
     compile 'com.spotify:docker-client:8.11.7'
 

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -316,6 +316,12 @@
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure</artifactId>
                 <version>1.21.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>


### PR DESCRIPTION
After we upgrade azure sdk to 1.21.0, the intellij cannot send telemetry.
The new azure sdk import jaxb jar, it will conflict with our jaxb file, so just remove it.