### PR TITLE
Fix telemetry issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in t
 
 - [Change Log](#change-log)
 
+  - [3.21.1](#3211)
   - [3.21.0](#3210)
   - [3.20.0](#3200)
   - [3.19.0](#3190)
@@ -32,6 +33,12 @@ All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in t
   - [3.0.8](#308)
   - [3.0.7](#307)
   - [3.0.6](#306)
+
+## 3.21.1
+
+### Fixed
+
+- Fix telemetry shares same installation id
 
 ## 3.21.0
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -140,6 +140,8 @@ task cucumberPackJar(type: Jar) {
     }
 }
 
+buildSearchableOptions.onlyIf {false}
+
 task cucumber() {
     dependsOn compileTestJava, cucumberPackJar
     doLast {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin url="https://github.com/Microsoft/azure-tools-for-java">
   <id>com.microsoft.tooling.msservices.intellij.azure</id>
   <name>Azure Toolkit for IntelliJ</name>
-  <version>3.21.0</version>
+  <version>3.21.1</version>
   <vendor email="java@microsoft.com" url="http://www.microsoft.com">Microsoft</vendor>
 
   <description><![CDATA[
@@ -20,29 +20,10 @@
   <change-notes>
     <![CDATA[
     <html>
-    <h3>3.21.0</h3>
-    <h4>Added</h4>
-    <ul>
-        <li>Support Java 11 App Service</li>
-        <li>Add failure task debug feature for HDInsight cluster with Spark 2.3.2</li>
-        <li>Support linking cluster with ADLS GEN2 storage account</li>
-        <li>Add default storage type for cluster with ADLS GEN2 account</li>
-    </ul>
-    <h4>Changed</h4>
-    <ul>
-        <li><span style="color: red;font-weight: bold;">Breaking Change: </span>Users with cluster ‘<span style="font-weight: bold;">Reader</span>’ only role can no longer submit job to the HDInsight cluster nor access to the cluster storage. Please request the cluster owner or user access administrator to upgrade your role to <span style="font-weight: bold;">HDInsight Cluster Operator</span> or <span style="font-weight: bold;">Contributor</span> in the <a href="https://ms.portal.azure.com">Azure Portal</a>. Click <a href="https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor">here</a> for more information</li>
-        <li>AadProvider.json file is no longer needed for Spark on Cosmos Serverless feature</li>
-    </ul>
+    <h3>3.21.1</h3>
     <h4>Fixed</h4>
     <ul>
-        <li><a href="https://github.com/Microsoft/azure-tools-for-java/issues/2866">#2866</a> Fix uncaught exception when
-            remote debug in HDI 4.0</li>
-        <li><a href="https://github.com/Microsoft/azure-tools-for-java/issues/2958">#2958</a> Fix deleted cluster
-            re-appeared issue for Spark on Cosmos cluster</li>
-        <li><a href="https://github.com/Microsoft/azure-tools-for-java/issues/2988">#2988</a> Fix toolkit installation
-            failure with version incompatibility issue</li>
-        <li><a href="https://github.com/Microsoft/azure-tools-for-java/issues/2977">#2977</a> Fix "Report to Microsoft"
-            button been disabled issue</li>
+        <li>Fix telemetry shares same installation id</li>
     </ul>
     <p>You may get the full change log <a
             href="https://github.com/Microsoft/azure-tools-for-java/blob/develop/CHANGELOG.md">here</a></p>


### PR DESCRIPTION
Fix telemetry shares same installation id.

IntelliJ Gradle plugin introduces a new step called '[buildSearchableOptions](https://github.com/JetBrains/gradle-intellij-plugin#tasks)', it will build an index of UI components (a.k.a. searchable options) for the plugin by running a headless IDE instance. However, this will trigger initialize methods and generate data file contains installation id. This will be executed during Jenkins publish job, which means data file of the Jenkins machine will be packaged into the release plugin, and all users will share the same installation id in telemetry. So skip this step in build script.