### PR TITLE
Enable streaming log in Azure Toolkits

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -96,6 +96,12 @@
         id="Cosmos Serverless Spark Jobs"
         canCloseContents="true"/>
 
+    <toolWindow
+            anchor="bottom"
+            factoryClass="com.microsoft.azure.webapp.ui.WebAppStreamingLogToolWindowFactory"
+            id="Azure Streaming Log"
+            canCloseContents="true"/>
+
     <executor implementation="com.microsoft.azure.hdinsight.spark.run.SparkBatchJobRunExecutor" id="SparkJobRun" />
     <executor implementation="com.microsoft.azure.hdinsight.spark.run.SparkBatchJobDebugExecutor" id="SparkJobDebug" />
     <configurationType implementation="com.microsoft.intellij.runner.webapp.WebAppConfigurationType"/>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/webapp/ui/WebAppStreamingLogToolWindowFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/webapp/ui/WebAppStreamingLogToolWindowFactory.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.webapp.ui;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowFactory;
+import com.microsoft.azure.hdinsight.common.CommonConst;
+import com.microsoft.azure.hdinsight.common.IconPathBuilder;
+import com.microsoft.intellij.util.PluginUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class WebAppStreamingLogToolWindowFactory implements ToolWindowFactory {
+    @Override
+    public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+        toolWindow.setIcon(
+                PluginUtil.getIcon(IconPathBuilder
+                        .custom(CommonConst.CosmosServerlessToolWindowIconName)
+                        .build()));
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppStreamingLogConsoleView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppStreamingLogConsoleView.java
@@ -23,7 +23,6 @@ package com.microsoft.intellij.helpers.webapp;
 
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
-import com.intellij.openapi.application.ApplicationManager;
 import rx.Observable;
 import rx.Subscription;
 import rx.schedulers.Schedulers;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppStreamingLogConsoleView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppStreamingLogConsoleView.java
@@ -24,19 +24,31 @@ package com.microsoft.intellij.helpers.webapp;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
 import rx.Observable;
 import rx.Subscription;
 import rx.schedulers.Schedulers;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 public class WebAppStreamingLogConsoleView {
 
     private static final String SEPARATOR = System.getProperty("line.separator");
-
+    private static final Map<String, ConsoleViewContentType> LOG_LEVEL = new HashMap<>();
 
     private Observable<String> logStreaming;
     private Subscription subscription;
     private ConsoleView logConsole;
     private boolean enable = false;
+
+    static {
+        LOG_LEVEL.put("INFO", ConsoleViewContentType.LOG_INFO_OUTPUT);
+        LOG_LEVEL.put("WARNING", ConsoleViewContentType.LOG_WARNING_OUTPUT);
+        LOG_LEVEL.put("ERROR", ConsoleViewContentType.LOG_ERROR_OUTPUT);
+        LOG_LEVEL.put("DEBUG", ConsoleViewContentType.LOG_DEBUG_OUTPUT);
+    }
 
     public WebAppStreamingLogConsoleView(Observable<String> logStreaming, ConsoleView logConsole) {
         this.logStreaming = logStreaming;
@@ -44,11 +56,14 @@ public class WebAppStreamingLogConsoleView {
     }
 
     public void startStreamingLog() {
-        if(!enable){
-            subscription = logStreaming.subscribeOn(Schedulers.io()).subscribe((log)->{
-                ApplicationManager.getApplication().invokeLater(() ->
-                        logConsole.print(log+SEPARATOR,ConsoleViewContentType.NORMAL_OUTPUT));
-            });
+        if (!enable) {
+            subscription = logStreaming.subscribeOn(Schedulers.io())
+                    .doAfterTerminate(() -> logConsole.print("Disconnected from log-streaming service." + SEPARATOR, ConsoleViewContentType.SYSTEM_OUTPUT))
+                    .subscribe((log) -> {
+                        String logLevel = LOG_LEVEL.keySet().stream().filter(level -> log.contains(level)).findAny().orElse(null);
+                        ConsoleViewContentType type = logLevel == null ? ConsoleViewContentType.NORMAL_OUTPUT : LOG_LEVEL.get(logLevel);
+                        ApplicationManager.getApplication().invokeLater(() -> logConsole.print(log + SEPARATOR, type));
+                    });
             enable = true;
         }
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppStreamingLogConsoleView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppStreamingLogConsoleView.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.intellij.helpers.webapp;
+
+import com.intellij.execution.ui.ConsoleView;
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.application.ApplicationManager;
+import rx.Observable;
+import rx.Subscription;
+import rx.schedulers.Schedulers;
+
+public class WebAppStreamingLogConsoleView {
+
+    private static final String SEPARATOR = System.getProperty("line.separator");
+
+
+    private Observable<String> logStreaming;
+    private Subscription subscription;
+    private ConsoleView logConsole;
+    private boolean enable = false;
+
+    public WebAppStreamingLogConsoleView(Observable<String> logStreaming, ConsoleView logConsole) {
+        this.logStreaming = logStreaming;
+        this.logConsole = logConsole;
+    }
+
+    public void startStreamingLog() {
+        if(!enable){
+            subscription = logStreaming.subscribeOn(Schedulers.io()).subscribe((log)->{
+                ApplicationManager.getApplication().invokeLater(() ->
+                        logConsole.print(log+SEPARATOR,ConsoleViewContentType.NORMAL_OUTPUT));
+            });
+            enable = true;
+        }
+    }
+
+    public void closeStreamingLog() {
+        subscription.unsubscribe();
+        logConsole.print("Disconnected from log-streaming service." + SEPARATOR, ConsoleViewContentType.SYSTEM_OUTPUT);
+        enable = false;
+    }
+
+    public boolean isEnable() {
+        return enable;
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppStreamingLogConsoleViewProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppStreamingLogConsoleViewProvider.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.intellij.helpers.webapp;
+
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
+import com.intellij.execution.ui.ConsoleView;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.MessageType;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentManagerAdapter;
+import com.intellij.ui.content.ContentManagerEvent;
+import com.microsoft.azuretools.core.mvp.model.AzureMvpModel;
+import com.microsoft.intellij.ui.util.UIUtils;
+import org.jetbrains.annotations.NotNull;
+import rx.Observable;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum WebAppStreamingLogConsoleViewProvider {
+    INSTANCE;
+
+    public static final String LOG_TOOL_WINDOW = "Azure Streaming Log";
+    public static final String STREAMING_LOG_NOT_STARTED = "Streaming log is not started.";
+
+    private Map<String, WebAppStreamingLogConsoleView> consoleViewMap = new HashMap<>();
+    private Map<Project, ToolWindow> toolWindowMap = new HashMap<>();
+
+    public void startStreamingLogs(Project project, String subscriptionId, String webAppId, String webAppName) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            try {
+                ToolWindow toolWindow = getToolWindow(project);
+                WebAppStreamingLogConsoleView consoleView = consoleViewMap.containsKey(webAppId) ?
+                        consoleViewMap.get(webAppId) :
+                        createConsoleView(toolWindow, project, subscriptionId, webAppId, webAppName);
+                consoleView.startStreamingLog();
+                showConsoleView(toolWindow, webAppId);
+            } catch (Exception e) {
+                UIUtils.showNotification(project, e.getMessage(), MessageType.ERROR);
+            }
+        });
+    }
+
+    public void stopStreamingLogs(String webAppId) {
+        if (consoleViewMap.containsKey(webAppId)) {
+            consoleViewMap.get(webAppId).closeStreamingLog();
+        } else {
+            throw new RuntimeException(STREAMING_LOG_NOT_STARTED);
+        }
+    }
+
+    private WebAppStreamingLogConsoleView createConsoleView(ToolWindow toolWindow, Project project,
+                                                            String subscriptionId, String webAppId,
+                                                            String webAppName) throws IOException {
+        ConsoleView consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(project).getConsole();
+        Content content = toolWindow.getContentManager().getFactory()
+                .createContent(consoleView.getComponent(), webAppName, false);
+        content.setDescription(webAppId);
+        toolWindow.getContentManager().addContent(content);
+
+        Observable<String> streamingLogs = AzureMvpModel.getInstance()
+                .getAppServiceStreamingLogs(subscriptionId, webAppId);
+        WebAppStreamingLogConsoleView logConsoleView = new WebAppStreamingLogConsoleView(streamingLogs, consoleView);
+        consoleViewMap.put(webAppId, logConsoleView);
+        return logConsoleView;
+    }
+
+    private void showConsoleView(ToolWindow toolWindow, String webAppId) {
+        toolWindow.show(() -> {
+        });
+        Content consoleViewContent = Arrays.stream(toolWindow.getContentManager().getContents())
+                .filter(content -> content.getDescription().equals(webAppId))
+                .findAny().orElse(null);
+        ApplicationManager.getApplication().invokeLater(
+                () -> toolWindow.getContentManager().setSelectedContent(consoleViewContent));
+    }
+
+    private ToolWindow getToolWindow(Project project) {
+        if (toolWindowMap.containsKey(project)) {
+            return toolWindowMap.get(project);
+        }
+        // Add content manager listener when get tool window at the first time
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(LOG_TOOL_WINDOW);
+        toolWindow.getContentManager().addContentManagerListener(new ContentManagerAdapter() {
+            @Override
+            public void contentRemoved(@NotNull ContentManagerEvent contentManagerEvent) {
+                Content content = contentManagerEvent.getContent();
+                if (consoleViewMap.containsKey(content.getDescription())) {
+                    consoleViewMap.get(content.getDescription()).closeStreamingLog();
+                    consoleViewMap.remove(content.getDescription());
+                }
+            }
+        });
+        return toolWindow;
+    }
+
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppStreamingLogConsoleViewProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppStreamingLogConsoleViewProvider.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.microsoft.azuretools.core.mvp.model.AzureMvpModel.APPLICATION_LOG_NOT_ENABLED;
+//import static com.microsoft.azuretools.core.mvp.model.AzureMvpModel.APPLICATION_LOG_NOT_ENABLED;
 
 public enum WebAppStreamingLogConsoleViewProvider {
     INSTANCE;
@@ -50,7 +50,7 @@ public enum WebAppStreamingLogConsoleViewProvider {
     public static final String LOG_TOOL_WINDOW = "Azure Streaming Log";
     public static final String STREAMING_LOG_NOT_STARTED = "Streaming log is not started.";
 
-    private Map<String, WebAppStreamingLogConsoleView> consoleViewMap = new  HashMap<>();
+    private Map<String, WebAppStreamingLogConsoleView> consoleViewMap = new HashMap<>();
     private Map<Project, ToolWindow> toolWindowMap = new HashMap<>();
 
     public void startStreamingLogs(Project project, String subscriptionId, String webAppId, String webAppName, String slotName) {
@@ -63,32 +63,32 @@ public enum WebAppStreamingLogConsoleViewProvider {
             consoleView.startStreamingLog();
             showConsoleView(toolWindow, consoleView.getLogConsole());
         } catch (IOException e) {
-            if (e instanceof IOException && e.getMessage().equals(APPLICATION_LOG_NOT_ENABLED)) {
-                enableStreamingLog(project, subscriptionId, webAppId, webAppName, slotName);
-            } else {
-                UIUtils.showNotification(project, e.getMessage(), MessageType.ERROR);
-            }
+//            if (e instanceof IOException && e.getMessage().equals(APPLICATION_LOG_NOT_ENABLED)) {
+//                enableStreamingLog(project, subscriptionId, webAppId, webAppName, slotName);
+//            } else {
+            UIUtils.showNotification(project, e.getMessage(), MessageType.ERROR);
+//            }
         }
     }
 
-    private void enableStreamingLog(Project project, String subscriptionId, String webAppId, String webAppName, String slotName) {
-        int res = JOptionPane.showConfirmDialog(null,
-                String.format("Do you want to enable file logging for %s", getConsoleName(webAppName, slotName)),
-                "Enable logging",
-                JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
-        if (res == JOptionPane.OK_OPTION) {
-            try {
-                if (StringUtils.isEmpty(slotName)) {
-                    AzureMvpModel.getInstance().enableAppServiceContainerLogging(subscriptionId, webAppId);
-                } else {
-                    AzureMvpModel.getInstance().enableDeploymentSlotLogging(subscriptionId, webAppId, slotName);
-                }
-                startStreamingLogs(project, subscriptionId, webAppId, webAppName, slotName);
-            } catch (Exception e) {
-                UIUtils.showNotification(project, e.getMessage(), MessageType.ERROR);
-            }
-        }
-    }
+//    private void enableStreamingLog(Project project, String subscriptionId, String webAppId, String webAppName, String slotName) {
+//        int res = JOptionPane.showConfirmDialog(null,
+//                String.format("Do you want to enable file logging for %s", getConsoleName(webAppName, slotName)),
+//                "Enable logging",
+//                JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+//        if (res == JOptionPane.OK_OPTION) {
+//            try {
+//                if (StringUtils.isEmpty(slotName)) {
+//                    AzureMvpModel.getInstance().enableAppServiceContainerLogging(subscriptionId, webAppId);
+//                } else {
+//                    AzureMvpModel.getInstance().enableDeploymentSlotLogging(subscriptionId, webAppId, slotName);
+//                }
+//                startStreamingLogs(project, subscriptionId, webAppId, webAppName, slotName);
+//            } catch (Exception e) {
+//                UIUtils.showNotification(project, e.getMessage(), MessageType.ERROR);
+//            }
+//        }
+//    }
 
     public void stopStreamingLogs(String webAppId, String slotName) {
         String id = getConsoleViewId(webAppId, slotName);
@@ -123,7 +123,7 @@ public enum WebAppStreamingLogConsoleViewProvider {
     }
 
     private void showConsoleView(ToolWindow toolWindow, ConsoleView consoleView) {
-        ApplicationManager.getApplication().invokeLater(()->{
+        ApplicationManager.getApplication().invokeLater(() -> {
             toolWindow.show(() -> {
             });
             Content consoleViewContent = toolWindow.getContentManager().getContent((JComponent) consoleView);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/NodeActionsMap.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/NodeActionsMap.java
@@ -44,6 +44,8 @@ import com.microsoft.intellij.serviceexplorer.azure.storage.CreateTableAction;
 import com.microsoft.intellij.serviceexplorer.azure.storage.ModifyExternalStorageAccountAction;
 import com.microsoft.intellij.serviceexplorer.azure.storagearm.CreateStorageAccountAction;
 import com.microsoft.intellij.serviceexplorer.azure.vmarm.CreateVMAction;
+import com.microsoft.intellij.serviceexplorer.azure.webapp.StartStreamingLogsAction;
+import com.microsoft.intellij.serviceexplorer.azure.webapp.StopStreamingLogsAction;
 import com.microsoft.sqlbigdata.serverexplore.action.LinkSqlServerBigDataClusterAction;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
@@ -61,6 +63,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.StorageMod
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.StorageNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.TableModule;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.vmarm.VMArmModule;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppNode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -122,5 +125,8 @@ public class NodeActionsMap {
 
         node2Actions.put(ResourceManagementNode.class, new ImmutableList.Builder<Class<? extends NodeActionListener>>()
             .add(CreateDeploymentAction.class).build());
+
+        node2Actions.put(WebAppNode.class, new ImmutableList.Builder<Class<? extends NodeActionListener>>()
+                .add(StartStreamingLogsAction.class).add(StopStreamingLogsAction.class).build());
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/NodeActionsMap.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/NodeActionsMap.java
@@ -64,6 +64,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.StorageNod
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.TableModule;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.vmarm.VMArmModule;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppNode;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotNode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -127,6 +128,9 @@ public class NodeActionsMap {
             .add(CreateDeploymentAction.class).build());
 
         node2Actions.put(WebAppNode.class, new ImmutableList.Builder<Class<? extends NodeActionListener>>()
+                .add(StartStreamingLogsAction.class).add(StopStreamingLogsAction.class).build());
+
+        node2Actions.put(DeploymentSlotNode.class, new ImmutableList.Builder<Class<? extends NodeActionListener>>()
                 .add(StartStreamingLogsAction.class).add(StopStreamingLogsAction.class).build());
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StartStreamingLogsAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StartStreamingLogsAction.java
@@ -21,40 +21,54 @@
  */
 package com.microsoft.intellij.serviceexplorer.azure.webapp;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.MessageType;
-import com.intellij.openapi.wm.StatusBar;
-import com.intellij.openapi.wm.WindowManager;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.telemetrywrapper.EventUtil;
 import com.microsoft.intellij.helpers.webapp.WebAppStreamingLogConsoleViewProvider;
-import com.microsoft.intellij.ui.util.UIUtils;
 import com.microsoft.tooling.msservices.helpers.Name;
+import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppNode;
-
-import java.io.IOException;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotNode;
 
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP;
 
 @Name("Start Streaming Logs")
 public class StartStreamingLogsAction extends NodeActionListener {
 
-    private final WebAppNode webAppNode;
+    private Node node;
+    private Project project;
+    private String subscriptionId;
+    private String webAppId;
+    private String webAppName;
+    private String deploymentSlotName;
+
 
     public StartStreamingLogsAction(WebAppNode webAppNode) {
         super(webAppNode);
-        this.webAppNode = webAppNode;
+        this.node = webAppNode;
+        this.project = (Project) webAppNode.getProject();
+        this.subscriptionId = webAppNode.getSubscriptionId();
+        this.webAppId = webAppNode.getWebAppId();
+        this.webAppName = webAppNode.getWebAppName();
+    }
+
+    public StartStreamingLogsAction(DeploymentSlotNode deploymentSlotNode) {
+        super(deploymentSlotNode);
+        this.node = deploymentSlotNode;
+        this.project = (Project) deploymentSlotNode.getProject();
+        this.subscriptionId = deploymentSlotNode.getSubscriptionId();
+        this.webAppId = deploymentSlotNode.getWebAppId();
+        this.webAppName = deploymentSlotNode.getWebAppName();
+        this.deploymentSlotName = deploymentSlotNode.getName();
     }
 
     @Override
     protected void actionPerformed(NodeActionEvent nodeActionEvent) throws AzureCmdException {
-        EventUtil.executeWithLog(WEBAPP, "Test", operation -> {
+        EventUtil.executeWithLog(WEBAPP, "StartStreamingLog", operation -> {
             new Thread(() -> WebAppStreamingLogConsoleViewProvider.INSTANCE
-                    .startStreamingLogs((Project) webAppNode.getProject(), webAppNode.getSubscriptionId(),
-                            webAppNode.getWebAppId(), webAppNode.getWebAppName())).start();
+                    .startStreamingLogs(project,subscriptionId,webAppId,webAppName,deploymentSlotName)).start();
         });
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StartStreamingLogsAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StartStreamingLogsAction.java
@@ -21,6 +21,9 @@
  */
 package com.microsoft.intellij.serviceexplorer.azure.webapp;
 
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.telemetrywrapper.EventUtil;
@@ -31,6 +34,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotNode;
+import org.jetbrains.annotations.NotNull;
 
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP;
 
@@ -67,8 +71,13 @@ public class StartStreamingLogsAction extends NodeActionListener {
     @Override
     protected void actionPerformed(NodeActionEvent nodeActionEvent) throws AzureCmdException {
         EventUtil.executeWithLog(WEBAPP, "StartStreamingLog", operation -> {
-            new Thread(() -> WebAppStreamingLogConsoleViewProvider.INSTANCE
-                    .startStreamingLogs(project,subscriptionId,webAppId,webAppName,deploymentSlotName)).start();
+            ProgressManager.getInstance().run(new Task.Backgroundable(project, "Start Streaming Logs", true) {
+                @Override
+                public void run(@NotNull ProgressIndicator progressIndicator) {
+                    WebAppStreamingLogConsoleViewProvider.INSTANCE
+                            .startStreamingLogs(project, subscriptionId, webAppId, webAppName, deploymentSlotName);
+                }
+            });
         });
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StartStreamingLogsAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StartStreamingLogsAction.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.intellij.serviceexplorer.azure.webapp;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.MessageType;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.WindowManager;
+import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
+import com.microsoft.azuretools.telemetrywrapper.EventUtil;
+import com.microsoft.intellij.helpers.webapp.WebAppStreamingLogConsoleViewProvider;
+import com.microsoft.intellij.ui.util.UIUtils;
+import com.microsoft.tooling.msservices.helpers.Name;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppNode;
+
+import java.io.IOException;
+
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP;
+
+@Name("Start Streaming Logs")
+public class StartStreamingLogsAction extends NodeActionListener {
+
+    private final WebAppNode webAppNode;
+
+    public StartStreamingLogsAction(WebAppNode webAppNode) {
+        super(webAppNode);
+        this.webAppNode = webAppNode;
+    }
+
+    @Override
+    protected void actionPerformed(NodeActionEvent nodeActionEvent) throws AzureCmdException {
+        EventUtil.executeWithLog(WEBAPP, "Test", operation -> {
+            new Thread(() -> WebAppStreamingLogConsoleViewProvider.INSTANCE
+                    .startStreamingLogs((Project) webAppNode.getProject(), webAppNode.getSubscriptionId(),
+                            webAppNode.getWebAppId(), webAppNode.getWebAppName())).start();
+        });
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StopStreamingLogsAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StopStreamingLogsAction.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.intellij.serviceexplorer.azure.webapp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.MessageType;
+import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
+import com.microsoft.azuretools.telemetrywrapper.EventUtil;
+import com.microsoft.intellij.helpers.webapp.WebAppStreamingLogConsoleViewProvider;
+import com.microsoft.intellij.ui.util.UIUtils;
+import com.microsoft.tooling.msservices.helpers.Name;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppNode;
+
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP;
+
+@Name("Stop Streaming Logs")
+public class StopStreamingLogsAction extends NodeActionListener {
+
+    private final WebAppNode webAppNode;
+
+    public StopStreamingLogsAction(WebAppNode webAppNode) {
+        super(webAppNode);
+        this.webAppNode = webAppNode;
+    }
+
+    @Override
+    protected void actionPerformed(NodeActionEvent nodeActionEvent) throws AzureCmdException {
+        EventUtil.executeWithLog(WEBAPP, "Test",
+                (operation) -> {
+                    WebAppStreamingLogConsoleViewProvider.INSTANCE.stopStreamingLogs(webAppNode.getWebAppId());
+                },
+                (exception)->{
+                    UIUtils.showNotification((Project) webAppNode.getProject(),exception.getMessage(), MessageType.ERROR);
+                });
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StopStreamingLogsAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StopStreamingLogsAction.java
@@ -28,30 +28,42 @@ import com.microsoft.azuretools.telemetrywrapper.EventUtil;
 import com.microsoft.intellij.helpers.webapp.WebAppStreamingLogConsoleViewProvider;
 import com.microsoft.intellij.ui.util.UIUtils;
 import com.microsoft.tooling.msservices.helpers.Name;
+import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppNode;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotNode;
 
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP;
 
 @Name("Stop Streaming Logs")
 public class StopStreamingLogsAction extends NodeActionListener {
 
-    private final WebAppNode webAppNode;
+    private final Node node;
+    private String webAppId;
+    private String deploymentSlotName;
 
     public StopStreamingLogsAction(WebAppNode webAppNode) {
         super(webAppNode);
-        this.webAppNode = webAppNode;
+        this.node = webAppNode;
+        this.webAppId = webAppNode.getWebAppId();
+    }
+
+    public StopStreamingLogsAction(DeploymentSlotNode deploymentSlotNode) {
+        super(deploymentSlotNode);
+        this.node = deploymentSlotNode;
+        this.webAppId = deploymentSlotNode.getWebAppId();
+        this.deploymentSlotName = deploymentSlotNode.getName();
     }
 
     @Override
     protected void actionPerformed(NodeActionEvent nodeActionEvent) throws AzureCmdException {
-        EventUtil.executeWithLog(WEBAPP, "Test",
+        EventUtil.executeWithLog(WEBAPP, "StopStreamingLog",
                 (operation) -> {
-                    WebAppStreamingLogConsoleViewProvider.INSTANCE.stopStreamingLogs(webAppNode.getWebAppId());
+                    WebAppStreamingLogConsoleViewProvider.INSTANCE.stopStreamingLogs(webAppId, deploymentSlotName);
                 },
                 (exception)->{
-                    UIUtils.showNotification((Project) webAppNode.getProject(),exception.getMessage(), MessageType.ERROR);
+                    UIUtils.showNotification((Project) node.getProject(),exception.getMessage(), MessageType.ERROR);
                 });
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/util/UIUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/util/UIUtils.java
@@ -32,6 +32,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.WindowManager;
 import com.intellij.util.Consumer;
 
 import org.jetbrains.annotations.NotNull;
@@ -151,5 +152,10 @@ public class UIUtils {
                 .setFadeoutTime(10 * 1000) // fade out after 10 seconds
                 .createBalloon()
                 .showInCenterOf(statusBar.getComponent());
+    }
+
+    public static void showNotification(@NotNull Project project, String message, MessageType type) {
+        StatusBar statusBar = WindowManager.getInstance().getStatusBar(project);
+        showNotification(statusBar, message, type);
     }
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/AzureMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/AzureMvpModel.java
@@ -37,6 +37,8 @@ import com.microsoft.azuretools.utils.AzureModel;
 import com.microsoft.azuretools.utils.AzureModelController;
 import com.microsoft.azuretools.utils.CanceledByUserException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -211,6 +213,18 @@ public class AzureMvpModel {
         return res;
     }
 
+    /**
+     * Get Log Streaming by Subscription and AppServiceId
+     *
+     * @param sid subscription
+     * @param appServiceId appServiceId
+     * @return Log Streaming
+     * @throws IOException
+     */
+    public Observable<String> getAppServiceStreamingLogs(String sid, String appServiceId) throws IOException{
+        Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
+        return azure.webApps().getById(appServiceId).streamAllLogsAsync();
+    }
 
     /**
      * List Location by Subscription ID.


### PR DESCRIPTION
Enable streaming log in Azure Toolkits

todo:
1. Allow users to enable streaming log when streaming log is disabled, for now, mgmt sdk didn't work, https://github.com/Azure/azure-libraries-for-java/issues/759
2. Render server log according to log pattern, the pattern in the [document](https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs#understandlogs) is out of date. https://github.com/MicrosoftDocs/azure-docs/issues/33421
3. Add an icon for streaming log tool window.