### PR TITLE
Add telemetry for run remote spark job feature

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/Test/java/com/microsoft/azure/hdinsight/spark/ui/SparkJobTableTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/Test/java/com/microsoft/azure/hdinsight/spark/ui/SparkJobTableTest.kt
@@ -26,9 +26,13 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmitResponse
 import com.microsoft.azure.hdinsight.spark.common.SparkUITest
-import com.microsoft.azure.hdinsight.spark.ui.livy.batch.*
+import com.microsoft.azure.hdinsight.spark.ui.livy.batch.LivyBatchJobTableModel
 import com.microsoft.azure.hdinsight.spark.ui.livy.batch.LivyBatchJobTableModel.JobPage
+import com.microsoft.azure.hdinsight.spark.ui.livy.batch.LivyBatchJobTableViewport
+import com.microsoft.azure.hdinsight.spark.ui.livy.batch.LivyBatchJobViewer
+import com.microsoft.azure.hdinsight.spark.ui.livy.batch.UniqueColumnNameTableSchema
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import org.junit.Ignore
 import org.junit.Test
 import rx.Observable
@@ -37,14 +41,16 @@ import java.awt.event.WindowEvent
 import java.util.concurrent.TimeUnit
 
 class KillLivyJobAction : AzureAnAction(AllIcons.Actions.Cancel) {
-    override fun onActionPerformed(anActionEvent: AnActionEvent?) {
+    override fun onActionPerformed(anActionEvent: AnActionEvent?, operation: Operation?): Boolean {
         System.out.println("Clicked ${anActionEvent?.place} kill job button")
+        return true
     }
 }
 
 class RestartLivyJobAction : AzureAnAction(AllIcons.Actions.Restart) {
-    override fun onActionPerformed(anActionEvent: AnActionEvent?) {
+    override fun onActionPerformed(anActionEvent: AnActionEvent?, operation: Operation?): Boolean {
         System.out.println("Clicked ${anActionEvent?.place} restart job button")
+        return true
     }
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosserverlessspark/spark/ui/livy/batch/KillCosmosServerlessSparkBatchJobAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosserverlessspark/spark/ui/livy/batch/KillCosmosServerlessSparkBatchJobAction.kt
@@ -29,30 +29,41 @@ import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServe
 import com.microsoft.azure.hdinsight.sdk.rest.azure.serverless.spark.models.SchedulerState
 import com.microsoft.azure.hdinsight.sdk.rest.azure.serverless.spark.models.SparkBatchJob
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
+import com.microsoft.azuretools.telemetrywrapper.ErrorType
+import com.microsoft.azuretools.telemetrywrapper.EventType
+import com.microsoft.azuretools.telemetrywrapper.EventUtil
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import com.microsoft.intellij.util.PluginUtil
 import org.apache.commons.lang3.exception.ExceptionUtils
 import rx.Observable
+import java.io.IOException
 
 class KillCosmosServerlessSparkBatchJobAction(private val account: AzureSparkServerlessAccount,
                                               private val job: SparkBatchJob) : AzureAnAction(AllIcons.Actions.Cancel), ILogger {
-    override fun onActionPerformed(anActionEvent: AnActionEvent?) {
+    override fun onActionPerformed(anActionEvent: AnActionEvent, operation: Operation?): Boolean {
         if (job.id() == null) {
             val errorMsg = "Failed to kill spark job ${job.name()}. Batch job id is empty"
             log().warn(errorMsg)
             PluginUtil.displayErrorDialog("Kill Serverless Spark Job", errorMsg)
+            EventUtil.logErrorWithComplete(operation, ErrorType.systemError, IOException(errorMsg), null, null)
         } else {
             account.getSparkBatchJobRequest(job.id().toString())
                 .flatMap { respBatchJob ->
                     if (respBatchJob.state() == SchedulerState.ENDED || respBatchJob.state() == SchedulerState.FINALIZING) {
-                        PluginUtil.displayInfoDialog("Kill Serverless Spark Job", "Can't kill spark job ${respBatchJob.name()}. It's in '${respBatchJob.schedulerState()}' state!")
+                        val errMsg = "Can't kill spark job ${respBatchJob.name()}. It's in '${respBatchJob.schedulerState()}' state!"
+                        PluginUtil.displayInfoDialog("Kill Serverless Spark Job", errMsg)
+                        EventUtil.logErrorWithComplete(operation, ErrorType.userError, IOException(errMsg), null, null)
                         return@flatMap Observable.just(respBatchJob)
                     } else {
                         return@flatMap account.killSparkBatchJobRequest(job.id().toString())
                             .doOnNext { resp ->
                                 if (resp.code >= 300) {
-                                    PluginUtil.displayErrorDialog("Kill Serverless Spark Job", "Failed to kill spark job ${respBatchJob.name()}. ${resp.message}")
+                                    val errMsg = "Failed to kill spark job ${respBatchJob.name()}. ${resp.message}"
+                                    PluginUtil.displayErrorDialog("Kill Serverless Spark Job", errMsg)
+                                    EventUtil.logErrorWithComplete(operation, ErrorType.serviceError, IOException(errMsg), null, null)
                                 } else {
                                     PluginUtil.displayInfoDialog("Kill Serverless Spark Job", "Successfully killed Spark Job ${respBatchJob.name()}!")
+                                    EventUtil.logEventWithComplete(EventType.info, operation, null, null)
                                 }
                             }
                             .map { respBatchJob }
@@ -61,10 +72,13 @@ class KillCosmosServerlessSparkBatchJobAction(private val account: AzureSparkSer
                 .subscribe(
                     {},
                     { err ->
-                        PluginUtil.displayErrorDialog("Kill Serverless Spark Job", "Failed to kill spark job ${job.name()}. ${err.message}")
+                        val errMsg = "Failed to kill spark job ${job.name()}. ${err.message}"
+                        PluginUtil.displayErrorDialog("Kill Serverless Spark Job", errMsg)
                         log().warn("Failed to kill serverless spark job. " + ExceptionUtils.getStackTrace(err))
+                        EventUtil.logErrorWithComplete(operation, ErrorType.serviceError, IOException(errMsg), null, null)
                     }
                 )
         }
+        return false
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/ClassifiedException.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/ClassifiedException.kt
@@ -22,12 +22,14 @@
 package com.microsoft.azure.hdinsight.common.classifiedexception
 
 import com.microsoft.azure.hdinsight.common.logger.ILogger
+import com.microsoft.azuretools.telemetrywrapper.ErrorType
 import org.apache.commons.lang.exception.ExceptionUtils
 
 abstract class ClassifiedException(exp: Throwable?) : Throwable(exp), ILogger {
     abstract val title: String
     override val message: String
         get() = cause?.message ?: EmptyLog
+    abstract val errorType: ErrorType
 
     fun getStackTrace(): String {
         return if (cause != null) ExceptionUtils.getStackTrace(cause) else message

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/SparkServiceException.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/SparkServiceException.kt
@@ -22,11 +22,13 @@
 package com.microsoft.azure.hdinsight.common.classifiedexception
 
 import com.microsoft.azure.datalake.store.ADLException
+import com.microsoft.azuretools.telemetrywrapper.ErrorType
 import java.io.FileNotFoundException
 import java.io.IOException
 
 class SparkServiceException(exp: Throwable?) : ClassifiedException(exp) {
     override val title: String = "Spark Service Error"
+    override val errorType = ErrorType.serviceError
 }
 
 object SparkServiceExceptionFactory : ClassifiedExceptionFactory() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/SparkToolException.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/SparkToolException.kt
@@ -26,6 +26,7 @@ import com.microsoft.azure.datalake.store.ADLException
 import com.microsoft.azure.hdinsight.sdk.common.livy.interactive.exceptions.SessionNotStartException
 import com.microsoft.azure.hdinsight.spark.common.SparkJobException
 import com.microsoft.azure.hdinsight.spark.common.YarnDiagnosticsException
+import com.microsoft.azuretools.telemetrywrapper.ErrorType
 import com.microsoft.intellij.forms.ErrorMessageForm
 import org.apache.commons.lang.exception.ExceptionUtils
 import java.io.FileNotFoundException
@@ -34,6 +35,7 @@ const val ToolPackageSuffix: String = "com.microsoft.azure"
 
 class SparkToolException(exp: Throwable?) : ClassifiedException(exp) {
     override val title: String = "Azure Plugin for IntelliJ Error"
+    override val errorType = ErrorType.toolError
 
     override fun handleByUser(){
         ApplicationManager.getApplication().invokeLater {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/SparkUserException.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/SparkUserException.kt
@@ -24,10 +24,12 @@ package com.microsoft.azure.hdinsight.common.classifiedexception
 import com.microsoft.azure.datalake.store.ADLException
 import com.microsoft.azure.hdinsight.spark.common.SparkJobException
 import com.microsoft.azure.hdinsight.spark.common.YarnDiagnosticsException
+import com.microsoft.azuretools.telemetrywrapper.ErrorType
 import java.io.FileNotFoundException
 
 class SparkUserException(exp: Throwable?) : ClassifiedException(exp) {
     override val title: String = "Spark User Error"
+    override val errorType = ErrorType.userError
 
     override fun handleByUser() {
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/UnclassifiedException.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/classifiedexception/UnclassifiedException.kt
@@ -21,6 +21,9 @@
  */
 package com.microsoft.azure.hdinsight.common.classifiedexception
 
+import com.microsoft.azuretools.telemetrywrapper.ErrorType
+
 class UnclassifiedException(exp: Throwable?) : ClassifiedException(exp) {
     override val title: String = "Unclassified Error"
+    override val errorType = ErrorType.unclassifiedError
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/actions/SparkSubmitJobAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/actions/SparkSubmitJobAction.kt
@@ -39,7 +39,6 @@ import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRu
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
 import com.microsoft.azuretools.telemetry.TelemetryConstants
 import com.microsoft.azuretools.telemetrywrapper.Operation
-import com.microsoft.azuretools.telemetrywrapper.TelemetryManager
 
 
 open class SparkSubmitJobAction : AzureAnAction() {
@@ -52,23 +51,22 @@ open class SparkSubmitJobAction : AzureAnAction() {
             false
         }
     }
-    override fun onActionPerformed(anActionEvent: AnActionEvent?) {
+
+    override fun onActionPerformed(anActionEvent: AnActionEvent, operation: Operation?): Boolean {
         if (anActionEvent == null) {
-            return
+            return true
         }
         if (submitWithPopupMenu(anActionEvent)) {
-            return
+            return true
         }
 
-        val operation = TelemetryManager.createOperation(getServiceName(anActionEvent), getOperationName(anActionEvent))
-        operation.start()
-
         val runConfigurationSetting = anActionEvent.dataContext.getData(RUN_CONFIGURATION_SETTING) ?:
-                getRunConfigurationFromDataContext(anActionEvent.dataContext) ?: return
+                getRunConfigurationFromDataContext(anActionEvent.dataContext) ?: return true
         val clusterName = anActionEvent.dataContext.getData(CLUSTER)?.name
         val mainClassName = anActionEvent.dataContext.getData(MAIN_CLASS_NAME)
 
         submit(runConfigurationSetting, clusterName, mainClassName, operation)
+        return false
     }
 
     override fun update(event: AnActionEvent) {
@@ -87,7 +85,7 @@ open class SparkSubmitJobAction : AzureAnAction() {
     private fun submit(runConfigurationSetting: RunnerAndConfigurationSettings,
                        clusterName: String?,
                        mainClassName: String?,
-                       operation: Operation) {
+                       operation: Operation?) {
         val executor = ExecutorRegistry.getInstance().getExecutorById(SparkBatchJobRunExecutor.EXECUTOR_ID)
 
         runConfigurationSetting.isEditBeforeRun = true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/actions/SparkSubmitJobAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/actions/SparkSubmitJobAction.kt
@@ -39,6 +39,7 @@ import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRu
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
 import com.microsoft.azuretools.telemetry.TelemetryConstants
 import com.microsoft.azuretools.telemetrywrapper.Operation
+import com.microsoft.intellij.telemetry.TelemetryKeys
 
 
 open class SparkSubmitJobAction : AzureAnAction() {
@@ -53,9 +54,6 @@ open class SparkSubmitJobAction : AzureAnAction() {
     }
 
     override fun onActionPerformed(anActionEvent: AnActionEvent, operation: Operation?): Boolean {
-        if (anActionEvent == null) {
-            return true
-        }
         if (submitWithPopupMenu(anActionEvent)) {
             return true
         }
@@ -108,7 +106,9 @@ open class SparkSubmitJobAction : AzureAnAction() {
         model.isLocalRunConfigEnabled = false   // Disable local run configuration tab
 
         val environment = ExecutionEnvironmentBuilder.create(executor, runConfigurationSetting).build()
-        RunConfigurationActionUtils.runEnvironmentProfileWithCheckSettings(environment, operation)
+        environment.putUserData(TelemetryKeys.OPERATION, operation)
+
+        RunConfigurationActionUtils.runEnvironmentProfileWithCheckSettings(environment)
 
         // Restore for common run configuration editor
         runConfigurationSetting.isEditBeforeRun = false

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/RunSparkConsoleActionDelegate.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/RunSparkConsoleActionDelegate.kt
@@ -25,6 +25,7 @@ package com.microsoft.azure.hdinsight.spark.console
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.microsoft.azure.hdinsight.common.logger.ILogger
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import java.lang.reflect.Method
 
 // The Action is a bridge to connect Scala related actions with dependent Scala Plugin actions by reflection
@@ -52,8 +53,10 @@ open class RunSparkConsoleActionDelegate(sparkScalaActionClassName: String) : Az
         }
     }
 
-    override fun onActionPerformed(actionEvent: AnActionEvent) {
+    override fun onActionPerformed(actionEvent: AnActionEvent, operation: Operation?): Boolean {
         actionPerformedMethod?.invoke(delegate.sparkScalaObj, actionEvent)
+        // FIXME: We should pass the operation object to the real method and send telemtry in the method
+        return true
     }
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/RunSparkScalaConsoleAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/RunSparkScalaConsoleAction.kt
@@ -41,6 +41,7 @@ import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRu
 import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRunConfigurationType
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
 import com.microsoft.azuretools.telemetrywrapper.Operation
+import com.microsoft.intellij.telemetry.TelemetryKeys
 import com.microsoft.intellij.util.runInReadAction
 import org.jetbrains.plugins.scala.console.RunConsoleAction
 import org.jetbrains.plugins.scala.console.ScalaConsoleRunConfigurationFactory
@@ -146,8 +147,9 @@ abstract class RunSparkScalaConsoleAction
         val environment = ExecutionEnvironmentBuilder.create(runExecutor, setting)
                 .runProfile(consoleRunConfigurationFactory.createConfiguration(configuration.name, configuration))
                 .build()
+        environment.putUserData(TelemetryKeys.OPERATION, operation)
 
-        RunConfigurationActionUtils.runEnvironmentProfileWithCheckSettings(environment, operation)
+        RunConfigurationActionUtils.runEnvironmentProfileWithCheckSettings(environment)
 
         if (configuration is LivySparkBatchJobRunConfiguration) {
             configuration.model.isLocalRunConfigEnabled = true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkConsoleExecuteAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkConsoleExecuteAction.kt
@@ -24,12 +24,13 @@ package com.microsoft.azure.hdinsight.spark.console
 
 import com.intellij.execution.console.LanguageConsoleImpl
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys.*
+import com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.util.TextRange
 import com.microsoft.azure.hdinsight.common.logger.ILogger
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import com.microsoft.intellij.util.runInWriteAction
 import java.io.IOException
 import java.nio.charset.StandardCharsets.UTF_8
@@ -56,11 +57,11 @@ class SparkConsoleExecuteAction() : AzureAnAction(), DumbAware, ILogger {
         e.presentation.isEnabled = isEnabled
     }
 
-    override fun onActionPerformed(actionEvent: AnActionEvent?) {
-        val editor = actionEvent?.getData(EDITOR) ?: return
+    override fun onActionPerformed(actionEvent: AnActionEvent, operation: Operation?): Boolean {
+        val editor = actionEvent?.getData(EDITOR) ?: return true
 
-        val consoleDetail = SparkConsoleManager.get(editor) ?: return
-        val outputStream = consoleDetail.processHandler?.processInput ?: return
+        val consoleDetail = SparkConsoleManager.get(editor) ?: return true
+        val outputStream = consoleDetail.processHandler?.processInput ?: return true
 
         val document = consoleDetail.console.editorDocument
         val text = document.text
@@ -87,5 +88,6 @@ class SparkConsoleExecuteAction() : AzureAnAction(), DumbAware, ILogger {
         }
 
         consoleDetail.console.indexCodes(normalizedCodes)
+        return true
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleRunConfiguration.kt
@@ -76,7 +76,7 @@ class SparkScalaLocalConsoleRunConfiguration(
             isMockFs = true
         }
 
-        val localRunParams = SparkBatchLocalRunState(project, batchRunConfiguration.model.localRunConfigurableModel)
+        val localRunParams = SparkBatchLocalRunState(project, batchRunConfiguration.model.localRunConfigurableModel, null)
                 .createParams(hasJmockit = isMockFs, hasMainClass = false, hasClassPath = false)
         val params = super.createParams()
         params.classPath.clear()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/CosmosServerlessSparkBatchRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/CosmosServerlessSparkBatchRunner.kt
@@ -58,7 +58,6 @@ class CosmosServerlessSparkBatchRunner : SparkBatchJobRunner() {
         }
         val storageRootPath = account.storageRootPath ?: throw ExecutionException("Error getting ADLS storage root path for account ${account.name}")
 
-        this.sparkBatchJob = CosmosServerlessSparkBatchJob(account, AdlsDeploy(storageRootPath, accessToken),submissionParameter, SparkBatchSubmission.getInstance(), ctrlSubject)
-        return this.sparkBatchJob as CosmosServerlessSparkBatchJob
+        return CosmosServerlessSparkBatchJob(account, AdlsDeploy(storageRootPath, accessToken),submissionParameter, SparkBatchSubmission.getInstance(), ctrlSubject)
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/CosmosServerlessSparkBatchRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/CosmosServerlessSparkBatchRunner.kt
@@ -58,6 +58,7 @@ class CosmosServerlessSparkBatchRunner : SparkBatchJobRunner() {
         }
         val storageRootPath = account.storageRootPath ?: throw ExecutionException("Error getting ADLS storage root path for account ${account.name}")
 
-        return CosmosServerlessSparkBatchJob(account, AdlsDeploy(storageRootPath, accessToken),submissionParameter, SparkBatchSubmission.getInstance(), ctrlSubject)
+        this.sparkBatchJob = CosmosServerlessSparkBatchJob(account, AdlsDeploy(storageRootPath, accessToken),submissionParameter, SparkBatchSubmission.getInstance(), ctrlSubject)
+        return this.sparkBatchJob as CosmosServerlessSparkBatchJob
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/CosmosSparkBatchRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/CosmosSparkBatchRunner.kt
@@ -53,7 +53,7 @@ class CosmosSparkBatchRunner : SparkBatchJobRunner() {
         val clusterId = submitModel.clusterId
         try {
             val clusterDetail = AzureSparkCosmosClusterManager.getInstance().findCluster(accountName, clusterId)
-                .toBlocking().singleOrDefault(null) ?: throw Exception("Can't get Spark on Cosmos cluster")
+                .toBlocking().singleOrDefault(null) ?: throw ExecutionException("Can't get Spark on Cosmos cluster")
 
             val livyUri = submitModel.livyUri?.let { URI.create(it) }
                 ?: clusterDetail.get().toBlocking().singleOrDefault(clusterDetail).livyUri

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/CosmosSparkBatchRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/CosmosSparkBatchRunner.kt
@@ -58,11 +58,10 @@ class CosmosSparkBatchRunner : SparkBatchJobRunner() {
             val livyUri = submitModel.livyUri?.let { URI.create(it) }
                 ?: clusterDetail.get().toBlocking().singleOrDefault(clusterDetail).livyUri
 
-             this.sparkBatchJob = CosmosSparkBatchJob(
-                    submitModel.submissionParameter,
-                    SparkBatchAzureSubmission(tenantId, accountName, clusterId, livyUri),
-                    ctrlSubject)
-            return this.sparkBatchJob as CosmosSparkBatchJob
+            return CosmosSparkBatchJob(
+                submitModel.submissionParameter,
+                SparkBatchAzureSubmission(tenantId, accountName, clusterId, livyUri),
+                ctrlSubject)
         } catch (e: Exception) {
             throw ExecutionException("Can't get Spark on Cosmos cluster, please sign in and refresh.", e)
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/RunProfileStateWithAppInsightsEvent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/RunProfileStateWithAppInsightsEvent.kt
@@ -31,10 +31,14 @@ interface RunProfileStateWithAppInsightsEvent : RunProfileState {
 
     val appInsightsMessage: String
 
+    fun getPostEventProperties(executor: Executor, addedEventProps: Map<String, String>?): Map<String, String> {
+        return mapOf(
+            "Executor" to executor.id,
+            "ActionUuid" to uuid).plus(addedEventProps ?: emptyMap())
+    }
+
     fun createAppInsightEvent(executor: Executor, addedEventProps: Map<String, String>?): RunProfileState {
-        val postEventProps = mapOf(
-                "Executor" to executor.id,
-                "ActionUuid" to uuid).plus(addedEventProps ?: emptyMap())
+        val postEventProps = getPostEventProperties(executor, addedEventProps)
 
         AppInsightsClient.create(appInsightsMessage, null, postEventProps)
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobDebuggerRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobDebuggerRunner.java
@@ -117,9 +117,6 @@ public class SparkBatchJobDebuggerRunner extends GenericDebuggerRunner implement
         final AsyncPromise<ExecutionEnvironment> jobDriverEnvReady = new AsyncPromise<> ();
         final SparkBatchRemoteDebugState submissionState = (SparkBatchRemoteDebugState) state;
 
-        // Check parameters before starting
-        submissionState.checkSubmissionParameter();
-
         final SparkSubmitModel submitModel = submissionState.getSubmitModel();
         // Create SSH debug session firstly
         SparkBatchDebugSession session;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
@@ -39,40 +39,32 @@ import com.intellij.openapi.project.Project;
 import com.microsoft.azure.hdinsight.common.ClusterManagerEx;
 import com.microsoft.azure.hdinsight.common.MessageInfoType;
 import com.microsoft.azure.hdinsight.common.logger.ILogger;
-import com.microsoft.azure.hdinsight.sdk.cluster.ClusterDetail;
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
 import com.microsoft.azure.hdinsight.sdk.cluster.InternalUrlMapping;
-import com.microsoft.azure.hdinsight.sdk.common.*;
-import com.microsoft.azure.hdinsight.sdk.rest.azure.serverless.spark.models.ApiVersion;
-import com.microsoft.azure.hdinsight.sdk.storage.ADLSGen2StorageAccount;
-import com.microsoft.azure.hdinsight.sdk.storage.HDStorageAccount;
-import com.microsoft.azure.hdinsight.sdk.storage.IHDIStorageAccount;
-import com.microsoft.azure.hdinsight.sdk.storage.StorageAccountType;
 import com.microsoft.azure.hdinsight.spark.common.*;
 import com.microsoft.azure.hdinsight.spark.run.action.SparkBatchJobDisconnectAction;
 import com.microsoft.azure.hdinsight.spark.run.configuration.ArisSparkConfiguration;
 import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRunConfiguration;
 import com.microsoft.azure.hdinsight.spark.ui.SparkJobLogConsoleView;
-import com.microsoft.azure.sqlbigdata.sdk.cluster.SqlBigDataLivyLinkClusterDetail;
-import com.microsoft.azuretools.authmanage.AuthMethodManager;
-import com.microsoft.azuretools.authmanage.models.SubscriptionDetail;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.rxjava.IdeaSchedulers;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import rx.Observer;
 import rx.subjects.PublishSubject;
 
-import java.io.IOException;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSubmissionRunner, ILogger {
+    @Nullable
+    protected ISparkBatchJob sparkBatchJob = null;
+    @Nullable
+    protected Operation operation = null;
+
     @NotNull
     @Override
     public String getRunnerId() {
@@ -95,7 +87,8 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
                 .orElseThrow(() -> new ExecutionException("Can't find cluster named " + clusterName));
 
         Deployable jobDeploy = SparkBatchJobDeployFactory.getInstance().buildSparkBatchJobDeploy(submitModel, ctrlSubject);
-        return new SparkBatchJob(clusterDetail, submitModel.getSubmissionParameter(), SparkBatchSubmission.getInstance(), ctrlSubject, jobDeploy);
+        this.sparkBatchJob = new SparkBatchJob(clusterDetail, submitModel.getSubmissionParameter(), SparkBatchSubmission.getInstance(), ctrlSubject, jobDeploy);
+        return this.sparkBatchJob;
     }
 
     @Nullable
@@ -103,19 +96,23 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
     protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment environment) throws ExecutionException {
         SparkBatchRemoteRunProfileState submissionState = (SparkBatchRemoteRunProfileState) state;
 
-        // Check parameters before starting
-        submissionState.checkSubmissionParameter();
+        submissionState.setOperation(getOperation());
 
         SparkSubmitModel submitModel = submissionState.getSubmitModel();
         Project project = submitModel.getProject();
 
         // Prepare the run table console view UI
         SparkJobLogConsoleView jobOutputView = new SparkJobLogConsoleView(project);
-        PublishSubject<SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject = PublishSubject.create();
+
+        String artifactPath = submitModel.getArtifactPath().orElse(null);
+        assert artifactPath != null : "artifactPath should be checked in LivySparkBatchJobRunConfiguration::checkSubmissionConfigurationBeforeRun";
+        assert this.sparkBatchJob != null : "sparkBatchJob should be initialized in buildSparkBatchJob()";
+
+        PublishSubject<SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject = (PublishSubject) this.sparkBatchJob.getCtrlSubject();
         SparkBatchJobRemoteProcess remoteProcess = new SparkBatchJobRemoteProcess(
                 new IdeaSchedulers(project),
-                buildSparkBatchJob(submitModel, ctrlSubject),
-                submitModel.getArtifactPath().orElseThrow(() -> new ExecutionException("No artifact selected")),
+                this.sparkBatchJob,
+                artifactPath,
                 submitModel.getSubmissionParameter().getMainClassName(),
                 ctrlSubject);
         SparkBatchJobRunProcessHandler processHandler = new SparkBatchJobRunProcessHandler(remoteProcess, "Package and deploy the job to Spark cluster", null);
@@ -167,5 +164,15 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
             LivySparkBatchJobRunConfiguration livyRunConfig = (LivySparkBatchJobRunConfiguration) runConfiguration;
             livyRunConfig.getModel().setFocusedTabIndex(1);
         }
+    }
+
+    @NotNull
+    public Operation getOperation() {
+        assert operation != null : "setOperation should be called first before calling getOperation";
+        return operation;
+    }
+
+    public void setOperation(@NotNull Operation operation) {
+        this.operation = operation;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
@@ -48,7 +48,6 @@ import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRu
 import com.microsoft.azure.hdinsight.spark.ui.SparkJobLogConsoleView;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
-import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.rxjava.IdeaSchedulers;
 import rx.Observer;
 import rx.subjects.PublishSubject;
@@ -60,9 +59,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSubmissionRunner, ILogger {
-    @Nullable
-    protected Operation operation = null;
-
     @NotNull
     @Override
     public String getRunnerId() {
@@ -92,8 +88,6 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
     @Override
     protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment environment) throws ExecutionException {
         SparkBatchRemoteRunProfileState submissionState = (SparkBatchRemoteRunProfileState) state;
-
-        submissionState.setOperation(getOperation());
 
         SparkSubmitModel submitModel = submissionState.getSubmitModel();
         Project project = submitModel.getProject();
@@ -160,14 +154,5 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
             LivySparkBatchJobRunConfiguration livyRunConfig = (LivySparkBatchJobRunConfiguration) runConfiguration;
             livyRunConfig.getModel().setFocusedTabIndex(1);
         }
-    }
-
-    @Nullable
-    public Operation getOperation() {
-        return operation;
-    }
-
-    public void setOperation(@NotNull Operation operation) {
-        this.operation = operation;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
@@ -166,9 +166,8 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
         }
     }
 
-    @NotNull
+    @Nullable
     public Operation getOperation() {
-        assert operation != null : "setOperation should be called first before calling getOperation";
         return operation;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
@@ -61,8 +61,6 @@ import java.util.regex.Pattern;
 
 public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSubmissionRunner, ILogger {
     @Nullable
-    protected ISparkBatchJob sparkBatchJob = null;
-    @Nullable
     protected Operation operation = null;
 
     @NotNull
@@ -87,8 +85,7 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
                 .orElseThrow(() -> new ExecutionException("Can't find cluster named " + clusterName));
 
         Deployable jobDeploy = SparkBatchJobDeployFactory.getInstance().buildSparkBatchJobDeploy(submitModel, ctrlSubject);
-        this.sparkBatchJob = new SparkBatchJob(clusterDetail, submitModel.getSubmissionParameter(), SparkBatchSubmission.getInstance(), ctrlSubject, jobDeploy);
-        return this.sparkBatchJob;
+        return new SparkBatchJob(clusterDetail, submitModel.getSubmissionParameter(), SparkBatchSubmission.getInstance(), ctrlSubject, jobDeploy);
     }
 
     @Nullable
@@ -106,12 +103,11 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
 
         String artifactPath = submitModel.getArtifactPath().orElse(null);
         assert artifactPath != null : "artifactPath should be checked in LivySparkBatchJobRunConfiguration::checkSubmissionConfigurationBeforeRun";
-        assert this.sparkBatchJob != null : "sparkBatchJob should be initialized in buildSparkBatchJob()";
 
-        PublishSubject<SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject = (PublishSubject) this.sparkBatchJob.getCtrlSubject();
+        PublishSubject<SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject = PublishSubject.create();
         SparkBatchJobRemoteProcess remoteProcess = new SparkBatchJobRemoteProcess(
                 new IdeaSchedulers(project),
-                this.sparkBatchJob,
+                buildSparkBatchJob(submitModel, ctrlSubject),
                 artifactPath,
                 submitModel.getSubmissionParameter().getMainClassName(),
                 ctrlSubject);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchLocalDebugState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchLocalDebugState.kt
@@ -27,13 +27,17 @@ import com.intellij.execution.configurations.RemoteConnection
 import com.intellij.execution.configurations.RemoteState
 import com.intellij.openapi.project.Project
 import com.microsoft.azure.hdinsight.spark.common.SparkLocalRunConfigurableModel
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import com.microsoft.intellij.hdinsight.messages.HDInsightBundle
 
-class SparkBatchLocalDebugState(myProject: Project, model: SparkLocalRunConfigurableModel)
-    : SparkBatchLocalRunState(myProject, model), RemoteState {
+class SparkBatchLocalDebugState(myProject: Project, model: SparkLocalRunConfigurableModel, operation: Operation?) :
+    SparkBatchLocalRunState(
+        myProject,
+        model,
+        operation,
+        HDInsightBundle.message("SparkRunConfigLocalDebugButtonClick")!!
+    ), RemoteState {
     private val remoteConnection = RemoteConnection(true, "127.0.0.1", "0", true)
-
-    override val appInsightsMessage = HDInsightBundle.message("SparkRunConfigLocalDebugButtonClick")!!
 
     override fun getRemoteConnection(): RemoteConnection = remoteConnection
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchLocalRunState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchLocalRunState.kt
@@ -40,16 +40,21 @@ import com.microsoft.azure.hdinsight.spark.common.SparkLocalRunConfigurableModel
 import com.microsoft.azure.hdinsight.spark.mock.SparkLocalRunner
 import com.microsoft.azure.hdinsight.spark.ui.SparkJobLogConsoleView
 import com.microsoft.azure.hdinsight.spark.ui.SparkLocalRunParamsPanel
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import com.microsoft.intellij.hdinsight.messages.HDInsightBundle
 import org.apache.commons.lang3.SystemUtils
 import java.io.File
 import java.nio.file.Paths
 import java.util.*
 
-open class SparkBatchLocalRunState(val myProject: Project, val model: SparkLocalRunConfigurableModel)
-    : RunProfileStateWithAppInsightsEvent {
-    override val uuid = UUID.randomUUID().toString()
-    override val appInsightsMessage = HDInsightBundle.message("SparkRunConfigLocalRunButtonClick")!!
+open class SparkBatchLocalRunState(val myProject: Project,
+                                   val model: SparkLocalRunConfigurableModel,
+                                   operation: Operation?,
+                                   appInsightsMessage: String) :
+    RunProfileStateWithAppInsightsEvent(UUID.randomUUID().toString(), appInsightsMessage, operation) {
+
+    constructor(myProject: Project, model: SparkLocalRunConfigurableModel, operation: Operation?) :
+            this(myProject, model, operation, HDInsightBundle.message("SparkRunConfigLocalRunButtonClick")!!)
 
     @Throws(ExecutionException::class)
     override fun execute(executor: Executor?, runner: ProgramRunner<*>): ExecutionResult? {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteDebugExecutorState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteDebugExecutorState.kt
@@ -24,9 +24,10 @@ package com.microsoft.azure.hdinsight.spark.run
 
 import com.intellij.execution.Executor
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel
+import com.microsoft.azuretools.telemetrywrapper.Operation
 
-class SparkBatchRemoteDebugExecutorState(serverlessSparkSubmitModel: SparkSubmitModel)
-    : SparkBatchRemoteDebugState(serverlessSparkSubmitModel) {
+class SparkBatchRemoteDebugExecutorState(serverlessSparkSubmitModel: SparkSubmitModel, operation: Operation?)
+    : SparkBatchRemoteDebugState(serverlessSparkSubmitModel, operation) {
 
     override fun onSuccess(executor: Executor) {
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteDebugState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteDebugState.kt
@@ -25,9 +25,10 @@ package com.microsoft.azure.hdinsight.spark.run
 import com.intellij.execution.configurations.RemoteConnection
 import com.intellij.execution.configurations.RemoteState
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel
+import com.microsoft.azuretools.telemetrywrapper.Operation
 
-open class SparkBatchRemoteDebugState(serverlessSparkSubmitModel: SparkSubmitModel)
-    : SparkBatchRemoteRunState(serverlessSparkSubmitModel), RemoteState {
+open class SparkBatchRemoteDebugState(serverlessSparkSubmitModel: SparkSubmitModel, operation: Operation?)
+    : SparkBatchRemoteRunState(serverlessSparkSubmitModel, operation), RemoteState {
 
     private var remoteConnection = RemoteConnection(true, "127.0.0.1", "0", true)
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteRunProfileState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteRunProfileState.kt
@@ -31,7 +31,6 @@ interface SparkBatchRemoteRunProfileState {
     var executionResult: ExecutionResult?
     var consoleView: ConsoleView?
     var remoteProcessCtrlLogHandler: SparkBatchJobProcessCtrlLogOut?
-    var operation: Operation?
 
     fun getSubmitModel(): SparkSubmitModel
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteRunProfileState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteRunProfileState.kt
@@ -22,18 +22,16 @@
 
 package com.microsoft.azure.hdinsight.spark.run
 
-import com.intellij.execution.ExecutionException
 import com.intellij.execution.ExecutionResult
 import com.intellij.execution.ui.ConsoleView
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel
+import com.microsoft.azuretools.telemetrywrapper.Operation
 
 interface SparkBatchRemoteRunProfileState {
     var executionResult: ExecutionResult?
     var consoleView: ConsoleView?
     var remoteProcessCtrlLogHandler: SparkBatchJobProcessCtrlLogOut?
-
-    @Throws(ExecutionException::class)
-    fun checkSubmissionParameter()
+    var operation: Operation?
 
     fun getSubmitModel(): SparkSubmitModel
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteRunState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteRunState.kt
@@ -86,13 +86,12 @@ open class SparkBatchRemoteRunState(private val sparkSubmitModel: SparkSubmitMod
                             "IsSubmitSucceed" to "false",
                             "SubmitFailedReason" to HDInsightUtil.normalizeTelemetryMessage(errMessage))
                         createAppInsightEvent(it, additionalProperties)
-                        EventUtil.logError(
+                        EventUtil.logErrorWithComplete(
                             operation,
                             classifiedEx.errorType,
                             classifiedEx,
                             getPostEventProperties(it, additionalProperties),
                             null)
-                        operation?.complete()
 
                         consoleView!!.print("ERROR: $errMessage", ConsoleViewContentType.ERROR_OUTPUT)
                         classifiedEx.handleByUser()
@@ -112,7 +111,6 @@ open class SparkBatchRemoteRunState(private val sparkSubmitModel: SparkSubmitMod
     open fun onSuccess(executor: Executor) {
         val additionalProperties = mapOf("IsSubmitSucceed" to "true")
         createAppInsightEvent(executor, additionalProperties)
-        EventUtil.logEvent(EventType.info, operation, getPostEventProperties(executor, additionalProperties))
-        operation?.complete()
+        EventUtil.logEventWithComplete(EventType.info, operation, getPostEventProperties(executor, additionalProperties), null)
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteRunState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteRunState.kt
@@ -41,14 +41,15 @@ import com.microsoft.intellij.hdinsight.messages.HDInsightBundle
 import java.net.URI
 import java.util.*
 
-open class SparkBatchRemoteRunState(private val sparkSubmitModel: SparkSubmitModel)
-    : RunProfileStateWithAppInsightsEvent, SparkBatchRemoteRunProfileState  {
+open class SparkBatchRemoteRunState(private val sparkSubmitModel: SparkSubmitModel, operation: Operation?) :
+    RunProfileStateWithAppInsightsEvent(
+        UUID.randomUUID().toString(),
+        HDInsightBundle.message("SparkRunConfigRunButtonClick")!!,
+        operation
+    ), SparkBatchRemoteRunProfileState {
     override var remoteProcessCtrlLogHandler: SparkBatchJobProcessCtrlLogOut? = null
     override var executionResult: ExecutionResult? = null
     override var consoleView: ConsoleView? = null
-    override val uuid = UUID.randomUUID().toString()
-    override val appInsightsMessage = HDInsightBundle.message("SparkRunConfigRunButtonClick")!!
-    override var operation: Operation? = null
 
     override fun execute(executor: Executor?, programRunner: ProgramRunner<*>): ExecutionResult? {
         if (remoteProcessCtrlLogHandler == null || executionResult == null || consoleView == null) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteRunState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchRemoteRunState.kt
@@ -31,12 +31,12 @@ import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.ide.BrowserUtil
 import com.microsoft.azure.hdinsight.common.HDInsightUtil
 import com.microsoft.azure.hdinsight.common.MessageInfoType
-import com.microsoft.azure.hdinsight.common.classifiedexception.*
-import com.microsoft.azure.hdinsight.spark.common.CosmosSparkSubmitModel
+import com.microsoft.azure.hdinsight.common.classifiedexception.ClassifiedExceptionFactory
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel
 import com.microsoft.azure.hdinsight.spark.common.YarnDiagnosticsException
-import com.microsoft.azure.hdinsight.spark.run.configuration.ArisSparkSubmitModel
-import com.microsoft.azure.hdinsight.spark.run.configuration.CosmosServerlessSparkSubmitModel
+import com.microsoft.azuretools.telemetrywrapper.EventType
+import com.microsoft.azuretools.telemetrywrapper.EventUtil
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import com.microsoft.intellij.hdinsight.messages.HDInsightBundle
 import java.net.URI
 import java.util.*
@@ -48,6 +48,7 @@ open class SparkBatchRemoteRunState(private val sparkSubmitModel: SparkSubmitMod
     override var consoleView: ConsoleView? = null
     override val uuid = UUID.randomUUID().toString()
     override val appInsightsMessage = HDInsightBundle.message("SparkRunConfigRunButtonClick")!!
+    override var operation: Operation? = null
 
     override fun execute(executor: Executor?, programRunner: ProgramRunner<*>): ExecutionResult? {
         if (remoteProcessCtrlLogHandler == null || executionResult == null || consoleView == null) {
@@ -81,9 +82,17 @@ open class SparkBatchRemoteRunState(private val sparkSubmitModel: SparkSubmitMod
                         classifiedEx.logStackTrace()
 
                         val errMessage = classifiedEx.message
-                        createAppInsightEvent(it, mapOf(
-                                "IsSubmitSucceed" to "false",
-                                "SubmitFailedReason" to HDInsightUtil.normalizeTelemetryMessage(errMessage)))
+                        val additionalProperties = mapOf(
+                            "IsSubmitSucceed" to "false",
+                            "SubmitFailedReason" to HDInsightUtil.normalizeTelemetryMessage(errMessage))
+                        createAppInsightEvent(it, additionalProperties)
+                        EventUtil.logError(
+                            operation,
+                            classifiedEx.errorType,
+                            classifiedEx,
+                            getPostEventProperties(it, additionalProperties),
+                            null)
+                        operation?.complete()
 
                         consoleView!!.print("ERROR: $errMessage", ConsoleViewContentType.ERROR_OUTPUT)
                         classifiedEx.handleByUser()
@@ -96,28 +105,14 @@ open class SparkBatchRemoteRunState(private val sparkSubmitModel: SparkSubmitMod
         }
     }
 
-    @Throws(ExecutionException::class)
-    override fun checkSubmissionParameter() {
-        val parameter = getSubmitModel().submissionParameter
-
-        if (parameter.clusterName.isNullOrBlank()) {
-            throw ExecutionException("The ${getSubmitModel().sparkClusterTypeDisplayName} to submit job is not selected, please config it at 'Run/Debug configuration -> Remotely Run in Cluster'.")
-        }
-
-        if (parameter.artifactName.isNullOrBlank() && parameter.localArtifactPath.isNullOrBlank()) {
-            throw ExecutionException("The artifact to submit is not selected, please config it at 'Run/Debug configuration -> Remotely Run in Cluster'.")
-        }
-
-        if (parameter.mainClassName.isNullOrBlank()) {
-            throw ExecutionException("The main class name is empty, please config it at 'Run/Debug configuration -> Remotely Run in Cluster'.")
-        }
-    }
-
     override fun getSubmitModel(): SparkSubmitModel {
         return sparkSubmitModel
     }
 
     open fun onSuccess(executor: Executor) {
-        createAppInsightEvent(executor, mapOf("IsSubmitSucceed" to "true"))
+        val additionalProperties = mapOf("IsSubmitSucceed" to "true")
+        createAppInsightEvent(executor, additionalProperties)
+        EventUtil.logEvent(EventType.info, operation, getPostEventProperties(executor, additionalProperties))
+        operation?.complete()
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/RunConfigurationActionUtils.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/RunConfigurationActionUtils.kt
@@ -34,15 +34,15 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
 import com.intellij.openapi.ui.Messages
 import com.microsoft.azure.hdinsight.common.logger.ILogger
-import com.microsoft.azure.hdinsight.spark.run.SparkBatchJobRunner
 import com.microsoft.azuretools.telemetrywrapper.ErrorType
 import com.microsoft.azuretools.telemetrywrapper.EventUtil
-import com.microsoft.azuretools.telemetrywrapper.Operation
+import com.microsoft.intellij.telemetry.TelemetryKeys
 
 object RunConfigurationActionUtils: ILogger {
-    fun runEnvironmentProfileWithCheckSettings(environment: ExecutionEnvironment, asyncOperation: Operation?) {
+    fun runEnvironmentProfileWithCheckSettings(environment: ExecutionEnvironment) {
         val runner = ProgramRunner.getRunner(environment.executor.id, environment.runProfile) ?: return
         val setting = environment.runnerAndConfigurationSettings ?: return
+        val asyncOperation = environment.getUserData(TelemetryKeys.OPERATION)
 
         try {
             if (setting.isEditBeforeRun && !RunDialog.editConfiguration(environment, "Edit configuration")) {
@@ -73,10 +73,6 @@ object RunConfigurationActionUtils: ILogger {
             }
 
             environment.assignNewExecutionId()
-
-            if (runner is SparkBatchJobRunner) {
-                runner.operation = asyncOperation
-            }
 
             // asyncOperation is completed at class SparkBatchRemoteRunState
             runner.execute(environment)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SelectSparkApplicationTypeAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SelectSparkApplicationTypeAction.kt
@@ -30,6 +30,7 @@ import com.microsoft.azure.hdinsight.spark.run.configuration.CosmosServerlessSpa
 import com.microsoft.azure.hdinsight.spark.run.configuration.CosmosSparkConfigurationType
 import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRunConfigurationType
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
+import com.microsoft.azuretools.telemetry.TelemetryConstants
 import com.microsoft.intellij.common.CommonConst
 import com.microsoft.tooling.msservices.components.DefaultLoader
 
@@ -71,6 +72,14 @@ abstract class SelectSparkApplicationTypeAction
             presentation.icon = null
         }
     }
+
+    override fun getOperationName(event: AnActionEvent?): String {
+        return TelemetryConstants.SELECT_DEFAULT_SPARK_APPLICATION_TYPE
+    }
+
+    override fun getServiceName(event: AnActionEvent?): String {
+        return getSparkApplicationType().value
+    }
 }
 
 class SelectNoneSparkTypeAction : SelectSparkApplicationTypeAction() {
@@ -103,10 +112,10 @@ class SelectArisSparkTypeAction : SelectSparkApplicationTypeAction() {
     }
 }
 
-enum class SparkApplicationType {
-    None,
-    HDInsight,
-    CosmosSpark,
-    CosmosServerlessSpark,
-    ArisSpark,
+enum class SparkApplicationType(val value: String) {
+    None("none"),
+    HDInsight(TelemetryConstants.HDINSIGHT),
+    CosmosSpark(TelemetryConstants.SPARK_ON_COSMOS),
+    CosmosServerlessSpark(TelemetryConstants.SPARK_ON_COSMOS_SERVERLESS),
+    ArisSpark(TelemetryConstants.SPARK_ON_SQL_SERVER),
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SelectSparkApplicationTypeAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SelectSparkApplicationTypeAction.kt
@@ -31,14 +31,16 @@ import com.microsoft.azure.hdinsight.spark.run.configuration.CosmosSparkConfigur
 import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRunConfigurationType
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
 import com.microsoft.azuretools.telemetry.TelemetryConstants
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import com.microsoft.intellij.common.CommonConst
 import com.microsoft.tooling.msservices.components.DefaultLoader
 
 
 abstract class SelectSparkApplicationTypeAction
     : AzureAnAction() , Toggleable {
-    override fun onActionPerformed(e: AnActionEvent) {
+    override fun onActionPerformed(anActionEvent: AnActionEvent, operation: Operation?): Boolean {
         DefaultLoader.getIdeHelper().setApplicationProperty(CommonConst.SPARK_APPLICATION_TYPE, this.getSparkApplicationType().toString())
+        return true
     }
 
     companion object {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SeqActions.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SeqActions.kt
@@ -26,15 +26,15 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import com.microsoft.azure.hdinsight.common.logger.ILogger
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
+import com.microsoft.azuretools.telemetrywrapper.Operation
 
 open class SeqActions(private vararg val actionIds: String): AzureAnAction(), ILogger {
-    override fun onActionPerformed(anActionEvent: AnActionEvent?) {
-        if (anActionEvent != null) {
-            for (actiondId: String in actionIds) {
-                val action = ActionManagerEx.getInstance().getAction(actiondId)
-                action?.actionPerformed(anActionEvent)
-                        ?: log().error("Can't perform the action with id $actiondId")
-            }
+    override fun onActionPerformed(anActionEvent: AnActionEvent, operation: Operation?): Boolean {
+        for (actiondId: String in actionIds) {
+            val action = ActionManagerEx.getInstance().getAction(actiondId)
+            action?.actionPerformed(anActionEvent)
+                ?: log().error("Can't perform the action with id $actiondId")
         }
+        return true
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkJobRunAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkJobRunAction.kt
@@ -24,10 +24,14 @@ package com.microsoft.azure.hdinsight.spark.run.action
 
 import com.intellij.execution.Executor
 import com.intellij.execution.ExecutorRegistry
+import com.intellij.execution.RunManagerEx
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.microsoft.azure.hdinsight.common.CommonConst
 import com.microsoft.azure.hdinsight.common.StreamUtil
 import com.microsoft.azure.hdinsight.spark.run.SparkBatchJobRunExecutor.EXECUTOR_ID
+import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRunConfiguration
+import com.microsoft.azuretools.telemetry.TelemetryConstants
 
 class SparkJobRunAction
     : SparkRunConfigurationAction(
@@ -37,4 +41,15 @@ class SparkJobRunAction
 
     override val runExecutor: Executor
         get() = ExecutorRegistry.getInstance().getExecutorById(EXECUTOR_ID)
+
+    override fun getServiceName(event: AnActionEvent): String {
+        val project = event?.project ?: return super.getServiceName(event)
+        val runManagerEx = RunManagerEx.getInstanceEx(project)
+        val selectedConfigSettings = runManagerEx.selectedConfiguration
+        return (selectedConfigSettings?.configuration as LivySparkBatchJobRunConfiguration).sparkApplicationType.value
+    }
+
+    override fun getOperationName(event: AnActionEvent?): String {
+        return TelemetryConstants.RUN_REMOTE_SPARK_JOB
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkRunConfigurationAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkRunConfigurationAction.kt
@@ -39,6 +39,7 @@ import com.microsoft.azuretools.ijidea.utility.AzureAnAction
 import com.microsoft.azuretools.telemetrywrapper.ErrorType
 import com.microsoft.azuretools.telemetrywrapper.EventUtil
 import com.microsoft.azuretools.telemetrywrapper.Operation
+import com.microsoft.intellij.telemetry.TelemetryKeys
 import com.microsoft.intellij.util.runInReadAction
 import javax.swing.Icon
 
@@ -102,7 +103,7 @@ abstract class SparkRunConfigurationAction : AzureAnAction, ILogger {
     }
 
     override fun onActionPerformed(actionEvent: AnActionEvent, operation: Operation?): Boolean {
-        val project = actionEvent?.project ?: return true
+        val project = actionEvent.project ?: return true
         val runManagerEx = RunManagerEx.getInstanceEx(project)
         val selectedConfigSettings = runManagerEx.selectedConfiguration
 
@@ -164,7 +165,8 @@ abstract class SparkRunConfigurationAction : AzureAnAction, ILogger {
 
     private fun runFromSetting(setting: RunnerAndConfigurationSettings, operation: Operation?) {
         val environment = ExecutionEnvironmentBuilder.create(runExecutor, setting).build()
+        environment.putUserData(TelemetryKeys.OPERATION, operation)
 
-        RunConfigurationActionUtils.runEnvironmentProfileWithCheckSettings(environment, operation)
+        RunConfigurationActionUtils.runEnvironmentProfileWithCheckSettings(environment)
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArisSparkConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArisSparkConfiguration.kt
@@ -24,8 +24,13 @@ package com.microsoft.azure.hdinsight.spark.run.configuration
 
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.options.SettingsEditor
+import com.microsoft.azure.hdinsight.spark.run.action.SparkApplicationType
 
 class ArisSparkConfiguration(name: String, val module: ArisSparkConfigurationModule, factory: ArisSparkConfigurationFactory) : LivySparkBatchJobRunConfiguration(module.model, factory, module, name) {
+    override fun getSparkApplicationType(): SparkApplicationType {
+        return SparkApplicationType.ArisSpark
+    }
+
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
         return LivySparkRunConfigurationSettingsEditor(ArisSparkConfigurable(module.project))
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkConfiguration.kt
@@ -5,9 +5,14 @@ import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.execution.configurations.RuntimeConfigurationException
 import com.intellij.openapi.options.SettingsEditor
 import com.microsoft.azure.hdinsight.spark.run.SparkSubmissionRunner
+import com.microsoft.azure.hdinsight.spark.run.action.SparkApplicationType
 
 class CosmosServerlessSparkConfiguration(name: String, override val module: CosmosServerlessSparkConfigurationModule, cosmosServerlessSparkConfigurationFactory: CosmosServerlessSparkConfigurationFactory)
     : CosmosSparkRunConfiguration(name, module, cosmosServerlessSparkConfigurationFactory) {
+    override fun getSparkApplicationType(): SparkApplicationType {
+        return SparkApplicationType.CosmosServerlessSpark
+    }
+
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
         return LivySparkRunConfigurationSettingsEditor(CosmosServerlessSparkConfigurable(module.project))
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosSparkRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosSparkRunConfiguration.kt
@@ -25,12 +25,17 @@ package com.microsoft.azure.hdinsight.spark.run.configuration
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.options.SettingsEditor
+import com.microsoft.azure.hdinsight.spark.run.action.SparkApplicationType
 import com.microsoft.azure.hdinsight.spark.ui.ServerlessSparkConfigurable
 
 open class CosmosSparkRunConfiguration (name: String,
                                         open val module: CosmosSparkConfigurationModule,
                                         factory: ConfigurationFactory)
     : LivySparkBatchJobRunConfiguration(module.model, factory, module, name) {
+    override fun getSparkApplicationType(): SparkApplicationType {
+        return SparkApplicationType.CosmosSpark
+    }
+
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
         return LivySparkRunConfigurationSettingsEditor(ServerlessSparkConfigurable(module.project))
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkBatchJobRunConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkBatchJobRunConfiguration.java
@@ -25,7 +25,6 @@ import com.intellij.compiler.options.CompileStepBeforeRun;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.JavaExecutionUtil;
-import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configuration.AbstractRunConfiguration;
 import com.intellij.execution.configurations.*;
 import com.intellij.execution.executors.DefaultDebugExecutor;
@@ -45,6 +44,7 @@ import com.microsoft.azure.hdinsight.spark.common.SparkBatchJobConfigurableModel
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmissionParameter;
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel;
 import com.microsoft.azure.hdinsight.spark.run.*;
+import com.microsoft.azure.hdinsight.spark.run.action.SparkApplicationType;
 import com.microsoft.azure.hdinsight.spark.ui.SparkBatchJobConfigurable;
 import org.apache.commons.lang3.StringUtils;
 import org.jdom.Element;
@@ -63,6 +63,10 @@ public class LivySparkBatchJobRunConfiguration extends AbstractRunConfiguration
         LOCAL,
         REMOTE,
         REMOTE_DEBUG_EXECUTOR
+    }
+
+    public SparkApplicationType getSparkApplicationType() {
+        return SparkApplicationType.HDInsight;
     }
 
     @NotNull

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/livy/batch/LivyBatchJobTableViewerWithToolBar.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/livy/batch/LivyBatchJobTableViewerWithToolBar.kt
@@ -27,6 +27,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.impl.ActionButton
 import com.intellij.uiDesigner.core.GridConstraints
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import com.microsoft.intellij.forms.dsl.panel
 import java.awt.Dimension
 import javax.swing.JPanel
@@ -34,8 +35,9 @@ import javax.swing.JPanel
 class LivyBatchJobTableViewerWithToolBar(private val jobTableViewport : LivyBatchJobTableViewport,
                                          private val refreshActionPerformed: (anActionEvent: AnActionEvent?) -> Unit) : JPanel() {
     private val refreshAction = object: AzureAnAction(AllIcons.Actions.Refresh) {
-        override fun onActionPerformed(anActionEvent: AnActionEvent?) {
+        override fun onActionPerformed(anActionEvent: AnActionEvent?, operation: Operation?): Boolean {
             refreshActionPerformed(anActionEvent)
+            return true
         }
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/AzureSignInAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/AzureSignInAction.java
@@ -21,9 +21,6 @@
  */
 package com.microsoft.azuretools.ijidea.actions;
 
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.ACCOUNT;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.SIGNOUT;
-
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataKeys;
 import com.intellij.openapi.diagnostic.Logger;
@@ -38,12 +35,16 @@ import com.microsoft.azuretools.ijidea.ui.SignInWindow;
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetrywrapper.EventUtil;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.helpers.UIHelperImpl;
 import com.microsoft.intellij.serviceexplorer.azure.SignInOutAction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.ACCOUNT;
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.SIGNOUT;
 
 public class AzureSignInAction extends AzureAnAction {
     private static final Logger LOGGER = Logger.getInstance(AzureSignInAction.class);
@@ -59,9 +60,10 @@ public class AzureSignInAction extends AzureAnAction {
     }
 
     @Override
-    public void onActionPerformed(AnActionEvent e) {
+    public boolean onActionPerformed(@NotNull AnActionEvent e, @Nullable Operation operation) {
         Project project = DataKeys.PROJECT.getData(e.getDataContext());
         onAzureSignIn(project);
+        return true;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/AzureSignInAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/AzureSignInAction.java
@@ -65,7 +65,7 @@ public class AzureSignInAction extends AzureAnAction {
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return ACCOUNT;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/DisableSslCertificateValidationAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/DisableSslCertificateValidationAction.kt
@@ -27,10 +27,11 @@ import com.intellij.openapi.actionSystem.Toggleable
 import com.microsoft.azure.hdinsight.common.CommonConst
 import com.microsoft.azuretools.ijidea.ui.BypassCertificateVerificationWarningForm
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import com.microsoft.tooling.msservices.components.DefaultLoader
 
 class DisableSslCertificateValidationAction : AzureAnAction(), Toggleable {
-    override fun onActionPerformed(anActionEvent: AnActionEvent?) {
+    override fun onActionPerformed(anActionEvent: AnActionEvent?, operation: Operation?): Boolean {
         if (!isActionEnabled()) {
             val form = object : BypassCertificateVerificationWarningForm(anActionEvent?.project) {
                 override fun doOKAction() {
@@ -44,7 +45,7 @@ class DisableSslCertificateValidationAction : AzureAnAction(), Toggleable {
             anActionEvent!!.presentation.putClientProperty(Toggleable.SELECTED_PROPERTY, !isActionEnabled())
             DefaultLoader.getIdeHelper().setApplicationProperty(CommonConst.DISABLE_SSL_CERTIFICATE_VALIDATION, (!isActionEnabled()).toString())
         }
-
+        return true
     }
 
     companion object {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/GithubSurveyAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/GithubSurveyAction.java
@@ -35,7 +35,7 @@ public class GithubSurveyAction extends NewGithubIssueAction {
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return TelemetryConstants.SYSTEM;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/SelectSubscriptionsAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/SelectSubscriptionsAction.java
@@ -38,8 +38,11 @@ import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetrywrapper.EventUtil;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.helpers.UIHelperImpl;
 import com.microsoft.intellij.serviceexplorer.azure.ManageSubscriptionsAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.List;
@@ -51,9 +54,10 @@ public class SelectSubscriptionsAction extends AzureAnAction {
     }
 
     @Override
-    public void onActionPerformed(AnActionEvent e) {
+    public boolean onActionPerformed(@NotNull AnActionEvent e, @Nullable Operation operation) {
         Project project = DataKeys.PROJECT.getData(e.getDataContext());
         onShowSubscriptions(project);
+        return true;
     }
 
     public static void onShowSubscriptions(Project project) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/utility/AzureAnAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/utility/AzureAnAction.java
@@ -22,7 +22,8 @@
 
 package com.microsoft.azuretools.ijidea.utility;
 
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.microsoft.azuretools.telemetry.AppInsightsClient;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetry.TelemetryProperties;
@@ -57,7 +58,7 @@ public abstract class AzureAnAction extends AnAction {
     @Override
     public final void actionPerformed(AnActionEvent anActionEvent) {
         sendTelemetryOnAction(anActionEvent, "Execute", null);
-        String serviceName = transformHDInsight(getServiceName(), anActionEvent);
+        String serviceName = transformHDInsight(getServiceName(anActionEvent), anActionEvent);
         String operationName = getOperationName(anActionEvent);
         EventUtil.executeWithLog(serviceName, operationName, (operation) -> {
             EventUtil.logEvent(EventType.info, operation, buildProp(anActionEvent, null));
@@ -85,7 +86,7 @@ public abstract class AzureAnAction extends AnAction {
         return properties;
     }
 
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return TelemetryConstants.ACTION;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AddDockerSupportAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AddDockerSupportAction.java
@@ -134,7 +134,7 @@ public class AddDockerSupportAction extends AzureAnAction {
         notifyInfo(notificationContent);
     }
 
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return TelemetryConstants.DOCKER;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AddDockerSupportAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AddDockerSupportAction.java
@@ -22,9 +22,6 @@
 
 package com.microsoft.intellij.actions;
 
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.CREATE_DOCKER_FILE;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP;
-
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
@@ -41,12 +38,12 @@ import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetrywrapper.ErrorType;
 import com.microsoft.azuretools.telemetrywrapper.EventUtil;
 import com.microsoft.azuretools.telemetrywrapper.Operation;
-import com.microsoft.azuretools.telemetrywrapper.TelemetryManager;
 import com.microsoft.intellij.runner.container.utils.Constant;
 import com.microsoft.intellij.runner.container.utils.DockerUtil;
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
-
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.model.MavenConstants;
 import org.jetbrains.idea.maven.project.MavenProject;
 import org.jetbrains.idea.maven.project.MavenProjectsManager;
@@ -63,13 +60,11 @@ public class AddDockerSupportAction extends AzureAnAction {
     String pomXmlBasePath;
 
     @Override
-    public void onActionPerformed(AnActionEvent anActionEvent) {
-        Operation operation = TelemetryManager.createOperation(WEBAPP, CREATE_DOCKER_FILE);
-        operation.start();
+    public boolean onActionPerformed(@NotNull AnActionEvent anActionEvent, @Nullable Operation operation) {
         module = DataKeys.MODULE.getData(anActionEvent.getDataContext());
         if (module == null) {
             notifyError(Constant.ERROR_NO_SELECTED_PROJECT);
-            return;
+            return true;
         }
         pomXmlBasePath = Paths.get(module.getModuleFilePath()).getParent().toString();
         String artifactRelativePath = Constant.DOCKERFILE_ARTIFACT_PLACEHOLDER;
@@ -108,10 +103,9 @@ public class AddDockerSupportAction extends AzureAnAction {
             );
         } catch (IOException e) {
             EventUtil.logError(operation, ErrorType.userError, e, null, null);
-            operation.complete();
             e.printStackTrace();
             notifyError(e.getMessage());
-            return;
+            return true;
         }
         // detect docker daemon
         String defaultDockerHost = null;
@@ -121,8 +115,6 @@ public class AddDockerSupportAction extends AzureAnAction {
             EventUtil.logError(operation, ErrorType.userError, e, null, null);
             e.printStackTrace();
             // leave defaultDockerHost null
-        } finally {
-            operation.complete();
         }
         // print instructions
         String notificationContent = "";
@@ -132,6 +124,7 @@ public class AddDockerSupportAction extends AzureAnAction {
         notificationContent += Constant.MESSAGE_ADD_DOCKER_SUPPORT_OK + "\n";
         notificationContent += Constant.MESSAGE_INSTRUCTION + "\n";
         notifyInfo(notificationContent);
+        return true;
     }
 
     protected String getServiceName(AnActionEvent event) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/ApplicatioInsightsAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/ApplicatioInsightsAction.java
@@ -26,16 +26,20 @@ import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleTypeId;
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.ui.components.DefaultDialogWrapper;
 import com.microsoft.intellij.ui.libraries.ApplicationInsightsPanel;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ApplicatioInsightsAction extends AzureAnAction {
     @Override
-    public void onActionPerformed(AnActionEvent event) {
+    public boolean onActionPerformed(@NotNull AnActionEvent event, @Nullable Operation operation) {
         final Module module = event.getData(LangDataKeys.MODULE);
         DefaultDialogWrapper dialog = new DefaultDialogWrapper(module.getProject(), new ApplicationInsightsPanel(module));
         dialog.show();
+        return true;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AzureCodeSamples.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AzureCodeSamples.java
@@ -3,7 +3,10 @@ package com.microsoft.intellij.actions;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import org.jdesktop.swingx.JXHyperlink;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
 
@@ -12,10 +15,11 @@ import java.net.URI;
  */
 public class AzureCodeSamples extends AzureAnAction {
     @Override
-    public void onActionPerformed(AnActionEvent anActionEvent) {
+    public boolean onActionPerformed(@NotNull AnActionEvent anActionEvent, @Nullable Operation operation) {
         JXHyperlink portalLing = new JXHyperlink();
         portalLing.setURI(URI.create("https://azure.microsoft.com/en-us/documentation/samples/?platform=java"));
         portalLing.doClick();
+        return true;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AzureCodeSamples.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AzureCodeSamples.java
@@ -19,7 +19,7 @@ public class AzureCodeSamples extends AzureAnAction {
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return TelemetryConstants.SYSTEM;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AzureDockerHostDeployAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AzureDockerHostDeployAction.java
@@ -116,7 +116,7 @@ public class AzureDockerHostDeployAction extends AzureAnAction {
   }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return TelemetryConstants.DOCKER;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AzureDockerHostDeployAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AzureDockerHostDeployAction.java
@@ -21,9 +21,7 @@
  */
 package com.microsoft.intellij.actions;
 
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.DataKeys;
 import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
@@ -40,10 +38,13 @@ import com.microsoft.azuretools.ijidea.actions.AzureSignInAction;
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.docker.utils.AzureDockerUIResources;
 import com.microsoft.intellij.docker.wizards.publish.AzureSelectDockerWizardDialog;
 import com.microsoft.intellij.docker.wizards.publish.AzureSelectDockerWizardModel;
 import com.microsoft.intellij.util.PluginUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -55,10 +56,10 @@ import static com.microsoft.intellij.ui.messages.AzureBundle.message;
 public class AzureDockerHostDeployAction extends AzureAnAction {
   private static final Logger LOGGER = Logger.getInstance(AzureDockerHostDeployAction.class);
 
-  public void onActionPerformed(AnActionEvent actionEvent) {
+    public boolean onActionPerformed(@NotNull AnActionEvent anActionEvent, @Nullable Operation operation) {
     try {
         Project project = getCurrentProject();
-        if (!AzureSignInAction.doSignIn( AuthMethodManager.getInstance(), project)) return;
+        if (!AzureSignInAction.doSignIn( AuthMethodManager.getInstance(), project)) return true;
         AzureDockerUIResources.CANCELED = false;
 
         Module module = PluginUtil.getSelectedModule();
@@ -74,7 +75,7 @@ public class AzureDockerHostDeployAction extends AzureAnAction {
         // not signed in
         if (azureAuthManager == null) {
         System.out.println("ERROR! Not signed in!");
-        return;
+        return true;
         }
 
 
@@ -83,13 +84,13 @@ public class AzureDockerHostDeployAction extends AzureAnAction {
         if (!dockerManager.isInitialized()) {
         AzureDockerUIResources.updateAzureResourcesWithProgressDialog(project);
         if (AzureDockerUIResources.CANCELED) {
-          return;
+          return true;
         }
       }
 
       if (dockerManager.getSubscriptionsMap().isEmpty()) {
         PluginUtil.displayErrorDialog("Publish Docker Container", "Please select a subscription first");
-        return;
+        return true;
       }
 
       DockerHost dockerHost = (dockerManager.getDockerPreferredSettings() != null) ? dockerManager.getDockerHostForURL(dockerManager.getDockerPreferredSettings().dockerApiName) : null;
@@ -113,6 +114,7 @@ public class AzureDockerHostDeployAction extends AzureAnAction {
     } catch (Exception e) {
       e.printStackTrace();
     }
+    return true;
   }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AzureExplorerOpenAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/AzureExplorerOpenAction.java
@@ -26,12 +26,16 @@ import com.intellij.openapi.actionSystem.DataKeys;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.components.ServerExplorerToolWindowFactory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class AzureExplorerOpenAction  extends AzureAnAction {
     @Override
-    public void onActionPerformed(AnActionEvent event) {
+    public boolean onActionPerformed(@NotNull AnActionEvent event, @Nullable Operation operation) {
         Project project = DataKeys.PROJECT.getData(event.getDataContext());
         ToolWindowManager.getInstance(project).getToolWindow(ServerExplorerToolWindowFactory.EXPLORER_WINDOW).activate(null);
+        return true;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/LibraryConfigurationAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/LibraryConfigurationAction.java
@@ -28,16 +28,19 @@ import com.intellij.openapi.module.ModuleTypeId;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.ui.libraries.AzureLibrary;
 import com.microsoft.intellij.ui.libraries.LibrariesConfigurationDialog;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class LibraryConfigurationAction extends AzureAnAction {
 
-    public void onActionPerformed(AnActionEvent event) {
+    public boolean onActionPerformed(@NotNull AnActionEvent event, @Nullable Operation operation) {
         final Module module = event.getData(LangDataKeys.MODULE);
         List<AzureLibrary> currentLibs = new ArrayList<AzureLibrary>();
         for (AzureLibrary azureLibrary : AzureLibrary.LIBRARIES) {
@@ -47,6 +50,7 @@ public class LibraryConfigurationAction extends AzureAnAction {
         }
         LibrariesConfigurationDialog configurationDialog = new LibrariesConfigurationDialog(module, currentLibs);
         configurationDialog.show();
+        return true;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/LibraryConfigurationAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/LibraryConfigurationAction.java
@@ -50,7 +50,7 @@ public class LibraryConfigurationAction extends AzureAnAction {
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return TelemetryConstants.SYSTEM;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/PushImageAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/PushImageAction.java
@@ -62,7 +62,7 @@ public class PushImageAction extends AzureAnAction {
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return TelemetryConstants.ACR;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/PushImageAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/PushImageAction.java
@@ -39,8 +39,11 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.runner.container.AzureDockerSupportConfigurationType;
 import com.microsoft.intellij.runner.container.utils.Constant;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,13 +55,15 @@ public class PushImageAction extends AzureAnAction {
 
 
     @Override
-    public void onActionPerformed(AnActionEvent event) {
+    public boolean onActionPerformed(@NotNull AnActionEvent event, @Nullable Operation operation) {
+
         Module module = DataKeys.MODULE.getData(event.getDataContext());
         if (module == null) {
             notifyError(Constant.ERROR_NO_SELECTED_PROJECT);
-            return;
+            return true;
         }
         ApplicationManager.getApplication().invokeLater(() -> runConfiguration(module));
+        return true;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/RunOnDockerHostAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/RunOnDockerHostAction.java
@@ -27,7 +27,6 @@ import com.intellij.execution.ProgramRunnerUtil;
 import com.intellij.execution.RunManagerEx;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.ConfigurationFactory;
-import com.intellij.execution.configurations.ConfigurationType;
 import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.impl.RunDialog;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -37,10 +36,11 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
-import com.microsoft.intellij.runner.container.utils.Constant;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.runner.container.AzureDockerSupportConfigurationType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -56,12 +56,13 @@ public class RunOnDockerHostAction extends AzureAnAction {
 
 
     @Override
-    public void onActionPerformed(AnActionEvent event) {
+    public boolean onActionPerformed(@NotNull AnActionEvent event, @Nullable Operation operation) {
         Module module = DataKeys.MODULE.getData(event.getDataContext());
         if (module == null) {
-            return;
+            return true;
         }
         ApplicationManager.getApplication().invokeLater(() -> runConfiguration(module));
+        return true;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/RunOnDockerHostAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/RunOnDockerHostAction.java
@@ -65,7 +65,7 @@ public class RunOnDockerHostAction extends AzureAnAction {
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return TelemetryConstants.WEBAPP;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/WebAppOnLinuxAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/WebAppOnLinuxAction.java
@@ -72,7 +72,7 @@ public class WebAppOnLinuxAction extends AzureAnAction {
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return TelemetryConstants.WEBAPP;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/WebAppOnLinuxAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/WebAppOnLinuxAction.java
@@ -38,10 +38,11 @@ import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.ijidea.actions.AzureSignInAction;
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.runner.container.AzureDockerSupportConfigurationType;
-import com.microsoft.intellij.runner.container.utils.Constant;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,10 +58,10 @@ public class WebAppOnLinuxAction extends AzureAnAction {
 
 
     @Override
-    public void onActionPerformed(AnActionEvent event) {
+    public boolean onActionPerformed(@NotNull AnActionEvent event, @Nullable Operation operation) {
         Module module = DataKeys.MODULE.getData(event.getDataContext());
         if (module == null) {
-            return;
+            return true;
         }
         try {
             if (AzureSignInAction.doSignIn(AuthMethodManager.getInstance(), module.getProject())) {
@@ -69,6 +70,8 @@ public class WebAppOnLinuxAction extends AzureAnAction {
         } catch (Exception e) {
             e.printStackTrace();
         }
+
+        return true;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/WebDeployAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/WebDeployAction.java
@@ -67,7 +67,7 @@ public class WebDeployAction extends AzureAnAction {
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(AnActionEvent event) {
         return TelemetryConstants.WEBAPP;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/WebDeployAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/WebDeployAction.java
@@ -38,7 +38,10 @@ import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.ijidea.actions.AzureSignInAction;
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
+import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.intellij.runner.webapp.WebAppConfigurationType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,19 +54,21 @@ public class WebDeployAction extends AzureAnAction {
 
 
     @Override
-    public void onActionPerformed(AnActionEvent event) {
+    public boolean onActionPerformed(@NotNull AnActionEvent event, @Nullable Operation operation) {
         Module module = DataKeys.MODULE.getData(event.getDataContext());
         if (module == null) {
-            return;
+            return true;
         }
         try {
             if (!AzureSignInAction.doSignIn(AuthMethodManager.getInstance(), module.getProject())) {
-                return;
+                return true;
             }
             ApplicationManager.getApplication().invokeLater(() -> runConfiguration(module));
         } catch (Exception e) {
             e.printStackTrace();
         }
+
+        return true;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/feedback/NewGithubIssueAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/feedback/NewGithubIssueAction.kt
@@ -24,10 +24,12 @@ package com.microsoft.intellij.feedback
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.microsoft.azuretools.ijidea.utility.AzureAnAction
+import com.microsoft.azuretools.telemetrywrapper.Operation
 
 open class NewGithubIssueAction(private val issue: GithubIssue<out Reportable>, actionTitle: String)
         : AzureAnAction(actionTitle) {
-    override fun onActionPerformed(anActionEvent: AnActionEvent?) {
+    override fun onActionPerformed(anActionEvent: AnActionEvent, operation: Operation?): Boolean {
         issue.report()
+        return true
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/telemetry/TelemetryKeys.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/telemetry/TelemetryKeys.kt
@@ -20,27 +20,13 @@
  * SOFTWARE.
  */
 
-package com.microsoft.azure.hdinsight.spark.run
+package com.microsoft.intellij.telemetry
 
-import com.intellij.execution.Executor
-import com.intellij.execution.configurations.RunProfileState
-import com.microsoft.azuretools.telemetry.AppInsightsClient
+import com.intellij.openapi.util.Key
 import com.microsoft.azuretools.telemetrywrapper.Operation
 
-abstract class RunProfileStateWithAppInsightsEvent(val uuid: String,
-                                                   val appInsightsMessage: String,
-                                                   val operation: Operation?) : RunProfileState {
-    fun getPostEventProperties(executor: Executor, addedEventProps: Map<String, String>?): Map<String, String> {
-        return mapOf(
-            "Executor" to executor.id,
-            "ActionUuid" to uuid).plus(addedEventProps ?: emptyMap())
-    }
-
-    fun createAppInsightEvent(executor: Executor, addedEventProps: Map<String, String>?): RunProfileState {
-        val postEventProps = getPostEventProperties(executor, addedEventProps)
-
-        AppInsightsClient.create(appInsightsMessage, null, postEventProps)
-
-        return this
+class TelemetryKeys {
+    companion object {
+        @JvmField val OPERATION: Key<Operation> = Key.create("operation")
     }
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/TelemetryConstants.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/TelemetryConstants.java
@@ -40,7 +40,10 @@ public class TelemetryConstants {
     public static final String ACTION = "action";
     public static final String DIALOG = "dialog";
     public static final String HDINSIGHT = "hdinsight";
-    public static final String VFS = "vfs";    // virtual file system
+    public static final String SPARK_ON_COSMOS = "sparkOnCosmos";
+    public static final String SPARK_ON_COSMOS_SERVERLESS = "sparkOnCosmosServerless";
+    public static final String SPARK_ON_SQL_SERVER = "sparkOnSqlServer";
+    public static final String VFS = "virtualFileSystem";
 
     // operation value
     public static final String FEEDBACK = "feedback";
@@ -132,6 +135,8 @@ public class TelemetryConstants {
     public static final String UPDATE_DEPLOYMENT_SHORTCUT = "update-deployment-shortcut";
     public static final String BROWSE_TEMPLATE_SAMPLES = "browse-template-samples";
     public static final String ACTIVATE_TEMPLATE_DEITING = "activate-template-editing";
+    public static final String RUN_REMOTE_SPARK_JOB = "run-remote-spark-job";
+    public static final String SELECT_DEFAULT_SPARK_APPLICATION_TYPE = "select-default-spark-application-type";
 
     // property name
     public static final String WEBAPP_DEPLOY_TO_SLOT = "webappDeployToSlot";

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/DefaultOperation.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/DefaultOperation.java
@@ -80,7 +80,7 @@ public class DefaultOperation implements Operation {
         }
     }
 
-    public synchronized void logError(ErrorType errorType, Exception e, Map<String, String> properties,
+    public synchronized void logError(ErrorType errorType, Throwable e, Map<String, String> properties,
         Map<String, Double> metrics) {
         try {
             if (isComplete) {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/ErrorType.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/ErrorType.java
@@ -24,5 +24,8 @@ package com.microsoft.azuretools.telemetrywrapper;
 
 public enum ErrorType {
     userError,
-    systemError
+    systemError,
+    serviceError,
+    toolError,
+    unclassifiedError
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/EventUtil.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/EventUtil.java
@@ -69,16 +69,48 @@ public class EventUtil {
 
     public static void logEvent(EventType eventType, Operation operation, Map<String, String> properties,
         Map<String, Double> metrics) {
+        if (operation == null) {
+            return;
+        }
+
         ((DefaultOperation) operation).logEvent(eventType, properties, metrics);
     }
 
+    public static void logEventWithComplete(EventType eventType, Operation operation, Map<String, String> properties,
+                                Map<String, Double> metrics) {
+        if (operation == null) {
+            return;
+        }
+
+        logEvent(eventType, operation, properties, metrics);
+        operation.complete();
+    }
+
     public static void logEvent(EventType eventType, Operation operation, Map<String, String> properties) {
+        if (operation == null) {
+            return;
+        }
+
         logEvent(eventType, operation, properties, null);
     }
 
     public static void logError(Operation operation, ErrorType errorType, Throwable e,
         Map<String, String> properties, Map<String, Double> metrics) {
+        if (operation == null) {
+            return;
+        }
+
         ((DefaultOperation) operation).logError(errorType, e, properties, metrics);
+    }
+
+    public static void logErrorWithComplete(Operation operation, ErrorType errorType, Throwable e,
+                                Map<String, String> properties, Map<String, Double> metrics) {
+        if (operation == null) {
+            return;
+        }
+
+        logError(operation, errorType, e, properties, metrics);
+        operation.complete();
     }
 
     public static void executeWithLog(String serviceName, String operName, Map<String, String> properties,

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/EventUtil.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/EventUtil.java
@@ -76,7 +76,7 @@ public class EventUtil {
         logEvent(eventType, operation, properties, null);
     }
 
-    public static void logError(Operation operation, ErrorType errorType, Exception e,
+    public static void logError(Operation operation, ErrorType errorType, Throwable e,
         Map<String, String> properties, Map<String, Double> metrics) {
         ((DefaultOperation) operation).logError(errorType, e, properties, metrics);
     }


### PR DESCRIPTION
### Some code refactor
1. Remove `SparkBatchRemoteRunState::CheckSubmissionParamter` since it's duplicate with `LivySparkBatchJobRunConfiguration::checkSubmissionConfigurationBeforeRun`.
2. Add a parameter `AnActionEvent event` for `AzureAnAction::getServiceName` method since we need info in event to generate service name. Just as `protected String getOperationName(AnActionEvent event)`

### Discussion
#### 1. Design of `AzureAnAction`
For class `AzureAnAction`, the implementation for method `actionPerformed` is 
```
    public abstract void onActionPerformed(AnActionEvent anActionEvent);

    @Override
    public final void actionPerformed(AnActionEvent anActionEvent) {
        sendTelemetryOnAction(anActionEvent, "Execute", null);
        String serviceName = transformHDInsight(getServiceName(anActionEvent), anActionEvent);
        String operationName = getOperationName(anActionEvent);
        EventUtil.executeWithLog(serviceName, operationName, (operation) -> {
            EventUtil.logEvent(EventType.info, operation, buildProp(anActionEvent, null));
            onActionPerformed(anActionEvent);
        });
    }
```
Two problems here:
1. we didn't pass the `operation` object to `onActionPerformed` method, leading to different operation id of telemetry in `actionPerformed` method and `onActionPerformed` method. You can find that another `Operation` object is defined in `AddDockerSupportAction::onActionPerformed`, 
2. `EventUtil.executeWithLog` in `actionPerformed` is not friendly to asynchronous method. If we implement an asynchronous action in `onActionPerformed`. The `operation` object might be `complete`  before the real-end of the action. 

Synced With Wei, here is solution:
```
    /**
     * @param anActionEvent action event
     * @param operation operation for sending telemetry
     * @return if the action is a synchronous action, you should return true and let us complete the operation
     * if the action is an asynchronous action, you should return false and control the operation completion by yourself
     */
    public abstract boolean onActionPerformed(@NotNull AnActionEvent anActionEvent, @Nullable Operation operation);

    @Override
    public final void actionPerformed(@NotNull AnActionEvent anActionEvent) {
        sendTelemetryOnAction(anActionEvent, "Execute", null);
        String serviceName = transformHDInsight(getServiceName(anActionEvent), anActionEvent);
        String operationName = getOperationName(anActionEvent);

        Operation operation = TelemetryManager.createOperation(serviceName, operationName);
        operation.start();
        EventUtil.logEvent(EventType.info, operation, buildProp(anActionEvent, null));
        if (onActionPerformed(anActionEvent, operation)) {
            operation.complete();
        }
    }
```
In this way, there will be only one operation object for each action.

#### 2. Where to put user data during IntelliJ Execution
We can put customized user data  in `ExecutionEnvironment` since there shall be only one envirnment instance during the whole execution process.
*Warning: Please don't set your user data by `setDataContext` since dataContext did some restriction. Only given keys are allowed to set to data context.* 
```
  void setDataContext(@NotNull DataContext dataContext) {
    myDataContext = CachingDataContext.cacheIfNeed(dataContext);
  }

  private static class CachingDataContext implements DataContext {
    private static final DataKey[] keys = {PROJECT, PROJECT_FILE_DIRECTORY, EDITOR, VIRTUAL_FILE, MODULE, PSI_FILE};
    private final Map<String, Object> values = new HashMap<>();

    @NotNull
    static CachingDataContext cacheIfNeed(@NotNull DataContext context) {
      if (context instanceof CachingDataContext)
        return (CachingDataContext)context;
      return new CachingDataContext(context);
    }

    private CachingDataContext(DataContext context) {
      for (DataKey key : keys) {
        values.put(key.getName(), key.getData(context));
      }
    }
}
```

Instead please use `putUserData` and `getUserData`, which is much more flexible.
```
  @Override
  public <T> void putUserData(@NotNull Key<T> key, @Nullable T value) {
    while (true) {
      KeyFMap map = getUserMap();
      KeyFMap newMap = value == null ? map.minus(key) : map.plus(key, value);
      if (newMap == map || changeUserMap(map, newMap)) {
        break;
      }
    }
  }

  @Override
  public <T> T getUserData(@NotNull Key<T> key) {
    T t = getUserMap().get(key);
    if (t == null && key instanceof KeyWithDefaultValue) {
      t = putUserDataIfAbsent(key, ((KeyWithDefaultValue<T>)key).getDefaultValue());
    }
    return t;
  }

```