### PR TITLE
Support IDEA 192 EAP

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -44,7 +44,7 @@ intellij {
     pluginName = 'azure-toolkit-for-intellij'
     version = intellij_version
     updateSinceUntilBuild = Boolean.valueOf(updateVersionRange)
-    plugins = ['maven', dep_plugins, "properties"]
+    plugins = ['java', 'maven', dep_plugins, "properties"]
 	downloadSources = Boolean.valueOf(sources)
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/projects/SbtVersionOptionsPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/projects/SbtVersionOptionsPanel.java
@@ -24,7 +24,7 @@ package com.microsoft.azure.hdinsight.projects;
 
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.ui.ComboBox;
-import org.jetbrains.plugins.scala.project.Versions$;
+import org.jetbrains.plugins.scala.project.Versions;
 
 import javax.swing.JPanel;
 import java.awt.*;
@@ -51,7 +51,7 @@ public class SbtVersionOptionsPanel extends JPanel {
     public void updateSbtVersions() {
         final String[][] versions = new String[1][1];
         ProgressManager.getInstance().runProcessWithProgressSynchronously(() -> {
-            versions[0] = Versions$.MODULE$.loadSbtVersions();
+            versions[0] = Versions.SbtKind$.MODULE$.apply().versions();
         }, "Fetch SBT versions", false, null);
 
         for (String version : versions[0]) {


### PR DESCRIPTION
IDEA 192EAP splits Java related APIs from IDEA production into
a standalone plugin - Java.

Refer to:
 - [IDEA-195719](https://youtrack.jetbrains.com/issue/IDEA-195719)
 - JetBrains/intellij-community@b9c5cd00681b0e763d0cf86ce1cffb55c1ca2ac5

It's required to add Java plugin into dependency modules.

There is also Scala plugin API changed related to SBT version getter.

## IMPORTANT ##

**This is a breaking change, the IDEA 191 and older versions builds will
be failed.**