### PR TITLE
 Add telemetry for actions of nodes in Azure Explorer and serverless job view table actions

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/actions/CreateArmVMAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azureexplorer/src/com/microsoft/azuretools/azureexplorer/actions/CreateArmVMAction.java
@@ -33,7 +33,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.vmarm.VMArmModule;
 @Name("Create VM")
 public class CreateArmVMAction extends NodeActionListener {
     public CreateArmVMAction(VMArmModule node) {
-        super(node);
+        super();
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosserverlessspark/spark/ui/livy/batch/CosmosServerlessSparkBatchJobsViewer.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosserverlessspark/spark/ui/livy/batch/CosmosServerlessSparkBatchJobsViewer.kt
@@ -24,7 +24,16 @@ package com.microsoft.azure.cosmosserverlessspark.spark.ui.livy.batch
 
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessAccount
 import com.microsoft.azure.hdinsight.spark.ui.livy.batch.LivyBatchJobViewer
+import com.microsoft.azuretools.telemetry.TelemetryConstants
+import com.microsoft.azuretools.telemetrywrapper.EventType
+import com.microsoft.azuretools.telemetrywrapper.EventUtil
 
 open class CosmosServerlessSparkBatchJobsViewer(val account: AzureSparkServerlessAccount) : LivyBatchJobViewer() {
     override val jobViewerControl: Control by lazy { CosmosServerlessSparkBatchJobsViewerControl(this@CosmosServerlessSparkBatchJobsViewer) }
+
+    override fun dispose() {
+        super.dispose()
+
+        EventUtil.logEvent(EventType.info, TelemetryConstants.SPARK_ON_COSMOS_SERVERLESS, TelemetryConstants.CLOSE_JOB_VIEW_WINDOW, null)
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/HDInsightUtil.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/common/HDInsightUtil.java
@@ -27,25 +27,18 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.microsoft.azure.hdinsight.serverexplore.HDInsightRootModuleImpl;
-import com.microsoft.azuretools.telemetry.AppInsightsClient;
-import com.microsoft.azuretools.telemetry.TelemetryConstants;
-import com.microsoft.azuretools.telemetrywrapper.EventType;
-import com.microsoft.azuretools.telemetrywrapper.EventUtil;
 import com.microsoft.intellij.ToolWindowKey;
-import com.microsoft.intellij.hdinsight.messages.HDInsightBundle;
-import com.microsoft.intellij.util.PluginUtil;
-import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
-import com.microsoft.tooling.msservices.components.DefaultLoader;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
-import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureModule;
 import com.microsoft.intellij.common.CommonConst;
+import com.microsoft.intellij.util.PluginUtil;
+import com.microsoft.tooling.msservices.components.DefaultLoader;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureModule;
 import org.jetbrains.annotations.NotNull;
 import rx.subjects.ReplaySubject;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Optional;
 
+import static com.microsoft.azure.hdinsight.common.MessageInfoType.Error;
 import static com.microsoft.azure.hdinsight.common.MessageInfoType.*;
 
 public class HDInsightUtil {
@@ -66,16 +59,6 @@ public class HDInsightUtil {
         DefaultLoader.getIdeHelper().setApplicationProperty(
                 com.microsoft.azure.hdinsight.common.CommonConst.ENABLE_HDINSIGHT_NEW_SDK, "true");
         HDInsightRootModuleImpl hdInsightRootModule =  new HDInsightRootModuleImpl(azureModule);
-
-        // add telemetry for HDInsight Node
-        hdInsightRootModule.addClickActionListener(new NodeActionListener() {
-            @Override
-            protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
-                AppInsightsClient.create(HDInsightBundle.message("HDInsightExplorerHDInsightNodeExpand"), null);
-                EventUtil.logEvent(EventType.info, TelemetryConstants.HDINSIGHT,
-                    HDInsightBundle.message("HDInsightExplorerHDInsightNodeExpand"), null);
-            }
-        });
 
         azureModule.setHdInsightModule(hdInsightRootModule);
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/utility/AzureAnAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/utility/AzureAnAction.java
@@ -109,7 +109,7 @@ public abstract class AzureAnAction extends AnAction {
 
     protected String getOperationName(AnActionEvent event) {
         try {
-            return event.getPresentation().getText().replace(" ", "");
+            return event.getPresentation().getText().toLowerCase().trim().replace(" ", "-");
         } catch (Exception ignore) {
             return "";
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/container/PushToContainerRegistryAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/container/PushToContainerRegistryAction.java
@@ -62,7 +62,7 @@ public class PushToContainerRegistryAction extends NodeActionListener {
     private final AzureDockerSupportConfigurationType configType = AzureDockerSupportConfigurationType.getInstance();
 
     public PushToContainerRegistryAction(ContainerRegistryNode node) {
-        super(node);
+        super();
         this.currentNode = node;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StartStreamingLogsAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StartStreamingLogsAction.java
@@ -50,7 +50,7 @@ public class StartStreamingLogsAction extends NodeActionListener {
 
 
     public StartStreamingLogsAction(WebAppNode webAppNode) {
-        super(webAppNode);
+        super();
         this.node = webAppNode;
         this.project = (Project) webAppNode.getProject();
         this.subscriptionId = webAppNode.getSubscriptionId();
@@ -59,7 +59,7 @@ public class StartStreamingLogsAction extends NodeActionListener {
     }
 
     public StartStreamingLogsAction(DeploymentSlotNode deploymentSlotNode) {
-        super(deploymentSlotNode);
+        super();
         this.node = deploymentSlotNode;
         this.project = (Project) deploymentSlotNode.getProject();
         this.subscriptionId = deploymentSlotNode.getSubscriptionId();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StopStreamingLogsAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/webapp/StopStreamingLogsAction.java
@@ -44,13 +44,13 @@ public class StopStreamingLogsAction extends NodeActionListener {
     private String deploymentSlotName;
 
     public StopStreamingLogsAction(WebAppNode webAppNode) {
-        super(webAppNode);
+        super();
         this.node = webAppNode;
         this.webAppId = webAppNode.getWebAppId();
     }
 
     public StopStreamingLogsAction(DeploymentSlotNode deploymentSlotNode) {
-        super(deploymentSlotNode);
+        super();
         this.node = deploymentSlotNode;
         this.webAppId = deploymentSlotNode.getWebAppId();
         this.deploymentSlotName = deploymentSlotNode.getName();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/sqlbigdata/serverexplore/action/LinkSqlServerBigDataClusterAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/sqlbigdata/serverexplore/action/LinkSqlServerBigDataClusterAction.kt
@@ -30,7 +30,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener
 
 @Name("Link SQL Server Big Data Cluster")
-class LinkSqlServerBigDataClusterAction(private val sqlBigDataClusterModule: SqlBigDataClusterModule): NodeActionListener(sqlBigDataClusterModule) {
+class LinkSqlServerBigDataClusterAction(private val sqlBigDataClusterModule: SqlBigDataClusterModule): NodeActionListener() {
     override fun actionPerformed(e: NodeActionEvent?) {
         val form = AddNewSqlBigDataClusterForm(sqlBigDataClusterModule.project as Project, sqlBigDataClusterModule)
         form.show()

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/Node.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/Node.java
@@ -24,8 +24,11 @@ package com.microsoft.tooling.msservices.serviceexplorer;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpView;
 import com.microsoft.azuretools.core.mvp.ui.base.NodeContent;
+import com.microsoft.azuretools.telemetry.BasicTelemetryProperty;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.helpers.Name;
 import com.microsoft.tooling.msservices.helpers.collections.ObservableList;
@@ -40,7 +43,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class Node implements MvpView {
+public class Node implements MvpView, BasicTelemetryProperty {
     private static final String CLICK_ACTION = "click";
 
     protected static Map<Class<? extends Node>, ImmutableList<Class<? extends NodeActionListener>>> node2Actions;
@@ -379,5 +382,11 @@ public class Node implements MvpView {
     
     public Node createNode(Node parent, String sid, NodeContent content) {
         return new Node(content.getId(), content.getName());
+    }
+
+    @Override
+    @NotNull
+    public String getServiceName() {
+        return TelemetryConstants.ACTION;
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionListener.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionListener.java
@@ -34,14 +34,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class NodeActionListener implements EventListener {
-    protected static String name;
-
     public NodeActionListener() {
         // need a nullary constructor defined in order for
         // Class.newInstance to work on sub-classes
-    }
-
-    public NodeActionListener(Node node) {
     }
 
     protected void beforeActionPerformed(NodeActionEvent e) {

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionListener.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionListener.java
@@ -27,12 +27,8 @@ import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.telemetry.AppInsightsClient;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetry.TelemetryProperties;
+import com.microsoft.azuretools.telemetrywrapper.*;
 
-import com.microsoft.azuretools.telemetrywrapper.ErrorType;
-import com.microsoft.azuretools.telemetrywrapper.EventType;
-import com.microsoft.azuretools.telemetrywrapper.EventUtil;
-import com.microsoft.azuretools.telemetrywrapper.Operation;
-import com.microsoft.azuretools.telemetrywrapper.TelemetryManager;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.Map;
@@ -78,7 +74,7 @@ public abstract class NodeActionListener implements EventListener {
             throws AzureCmdException;
 
     public ListenableFuture<Void> actionPerformedAsync(NodeActionEvent e) {
-        String serviceName = transformHDInsight(getServiceName(), e.getAction().getNode());
+        String serviceName = transformHDInsight(getServiceName(e), e.getAction().getNode());
         String operationName = getOperationName(e);
         Operation operation = TelemetryManager.createOperation(serviceName, operationName);
         try {
@@ -121,8 +117,12 @@ public abstract class NodeActionListener implements EventListener {
         return serviceName;
     }
 
-    protected String getServiceName() {
-        return TelemetryConstants.ACTION;
+    protected String getServiceName(NodeActionEvent event) {
+        try {
+            return event.getAction().getNode().getServiceName();
+        } catch (Exception ignore) {
+            return TelemetryConstants.ACTION;
+        }
     }
 
     protected String getOperationName(NodeActionEvent event) {

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionListener.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionListener.java
@@ -127,7 +127,7 @@ public abstract class NodeActionListener implements EventListener {
 
     protected String getOperationName(NodeActionEvent event) {
         try {
-            return event.getAction().getName().replace(" ", "");
+            return event.getAction().getName().toLowerCase().trim().replace(" ", "-");
         } catch (Exception ignore) {
             return "";
         }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerContainerNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerContainerNode.java
@@ -256,7 +256,7 @@ public class DockerContainerNode extends AzureRefreshableNode implements Telemet
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(NodeActionEvent event) {
       return DOCKER;
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerHostNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerHostNode.java
@@ -243,7 +243,7 @@ public class DockerHostNode extends AzureRefreshableNode implements TelemetryPro
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(NodeActionEvent event) {
       return DOCKER;
     }
 
@@ -292,7 +292,7 @@ public class DockerHostNode extends AzureRefreshableNode implements TelemetryPro
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(NodeActionEvent event) {
       return DOCKER;
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerImageNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerImageNode.java
@@ -143,7 +143,7 @@ public class DockerImageNode extends AzureRefreshableNode implements TelemetryPr
     }
 
     @Override
-    protected String getServiceName() {
+    protected String getServiceName(NodeActionEvent event) {
       return DOCKER;
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisCacheNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisCacheNode.java
@@ -117,7 +117,7 @@ public class RedisCacheNode extends Node implements TelemetryProperties {
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return REDIS;
         }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/ContainerNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/ContainerNode.java
@@ -21,16 +21,13 @@
  */
 package com.microsoft.tooling.msservices.serviceexplorer.azure.storage;
 
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.DELETE_BLOB_CONTAINER;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.STORAGE;
-
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.management.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.management.storage.StorageAccount;
+import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
 import com.microsoft.azuretools.telemetry.TelemetryProperties;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
-import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.tooling.msservices.helpers.azure.sdk.StorageClientSDKManager;
 import com.microsoft.tooling.msservices.model.storage.BlobContainer;
 import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount;
@@ -42,6 +39,9 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPro
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.DELETE_BLOB_CONTAINER;
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.STORAGE;
 
 public class ContainerNode extends Node implements TelemetryProperties{
     @Override
@@ -93,7 +93,7 @@ public class ContainerNode extends Node implements TelemetryProperties{
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return STORAGE;
         }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/ExternalStorageNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/ExternalStorageNode.java
@@ -58,7 +58,7 @@ public class ExternalStorageNode extends ClientStorageNode {
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return STORAGE;
         }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/StorageNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/StorageNode.java
@@ -21,9 +21,6 @@
  */
 package com.microsoft.tooling.msservices.serviceexplorer.azure.storage;
 
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.DELETE_STORAGE_ACCOUNT;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.STORAGE;
-
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
@@ -43,6 +40,9 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPro
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.DELETE_STORAGE_ACCOUNT;
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.STORAGE;
 
 public class StorageNode extends RefreshableNode implements TelemetryProperties {
     private static final String STORAGE_ACCOUNT_ICON_PATH = "StorageAccount_16.png";
@@ -103,7 +103,7 @@ public class StorageNode extends RefreshableNode implements TelemetryProperties 
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return STORAGE;
         }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/TableNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/TableNode.java
@@ -101,7 +101,7 @@ public class TableNode extends Node implements TelemetryProperties {
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return STORAGE;
         }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/asm/StorageNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/asm/StorageNode.java
@@ -79,7 +79,7 @@ public class StorageNode extends ClientStorageNode implements TelemetryPropertie
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return STORAGE;
         }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/vmarm/VMNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/vmarm/VMNode.java
@@ -92,7 +92,7 @@ public class VMNode extends RefreshableNode implements TelemetryProperties {
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return VM;
         }
 
@@ -121,7 +121,7 @@ public class VMNode extends RefreshableNode implements TelemetryProperties {
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return VM;
         }
 
@@ -150,7 +150,7 @@ public class VMNode extends RefreshableNode implements TelemetryProperties {
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return VM;
         }
 
@@ -180,7 +180,7 @@ public class VMNode extends RefreshableNode implements TelemetryProperties {
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return VM;
         }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppNode.java
@@ -164,7 +164,7 @@ public class WebAppNode extends WebAppBaseNode implements WebAppNodeView {
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return WEBAPP;
         }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNode.java
@@ -181,7 +181,7 @@ public class DeploymentSlotNode extends WebAppBaseNode implements DeploymentSlot
         }
 
         @Override
-        protected String getServiceName() {
+        protected String getServiceName(NodeActionEvent event) {
             return WEBAPP;
         }
 

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/BasicTelemetryProperty.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/BasicTelemetryProperty.java
@@ -1,18 +1,18 @@
-/**
+/*
  * Copyright (c) Microsoft Corporation
- * <p/>
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -20,34 +20,11 @@
  * SOFTWARE.
  */
 
-package com.microsoft.tooling.msservices.serviceexplorer;
+package com.microsoft.azuretools.telemetry;
 
-import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 
-public class WrappedTelemetryNodeActionListener extends NodeActionListener {
-
-    private final NodeActionListener listener;
-    private final String serviceName;
-    private final String operationName;
-
-    public WrappedTelemetryNodeActionListener(String serviceName, String operationName, NodeActionListener listener) {
-        this.serviceName = serviceName;
-        this.operationName = operationName;
-        this.listener = listener;
-    }
-
-    @Override
-    protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
-        listener.actionPerformed(e);
-    }
-
-    @Override
-    protected String getServiceName(NodeActionEvent event) {
-        return this.serviceName;
-    }
-
-    @Override
-    protected String getOperationName(NodeActionEvent e) {
-        return this.operationName;
-    }
+public interface BasicTelemetryProperty {
+    @NotNull
+    String getServiceName();
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/TelemetryConstants.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/TelemetryConstants.java
@@ -141,6 +141,9 @@ public class TelemetryConstants {
     public static final String DEBUG_REMOTE_SPARK_JOB = "debug-remote-spark-job";
     public static final String SELECT_DEFAULT_SPARK_APPLICATION_TYPE = "select-default-spark-application-type";
     public static final String UNLINK_SPARK_CLUSTER = "unlink-spark-cluster";
+    public static final String REFRESH_JOB_VIEW_TABLE = "refresh-job-view-table";
+    public static final String CLOSE_JOB_VIEW_WINDOW = "close-job-view-window";
+    public static final String SELECT_JOB_IN_JOB_VIEW_WINDOW = "select-job-in-job-view-window";
 
     // property name
     public static final String WEBAPP_DEPLOY_TO_SLOT = "webappDeployToSlot";

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/TelemetryConstants.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/TelemetryConstants.java
@@ -140,6 +140,7 @@ public class TelemetryConstants {
     public static final String DEBUG_LOCAL_SPARK_JOB = "debug-local-spark-job";
     public static final String DEBUG_REMOTE_SPARK_JOB = "debug-remote-spark-job";
     public static final String SELECT_DEFAULT_SPARK_APPLICATION_TYPE = "select-default-spark-application-type";
+    public static final String UNLINK_SPARK_CLUSTER = "unlink-spark-cluster";
 
     // property name
     public static final String WEBAPP_DEPLOY_TO_SLOT = "webappDeployToSlot";

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosServerlessSparkSubmitAction.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosServerlessSparkSubmitAction.java
@@ -43,7 +43,7 @@ public class CosmosServerlessSparkSubmitAction extends NodeActionListener {
                                              @NotNull PublishSubject<Pair<
                                                   AzureSparkServerlessAccount,
                                                   CosmosSparkADLAccountNode>> provisionAction) {
-        super(adlAccountNode);
+        super();
         this.adlAccount = adlAccount;
         this.provisionAction = provisionAction;
         this.adlAccountNode = adlAccountNode;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosServerlessSparkViewJobsAction.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosServerlessSparkViewJobsAction.java
@@ -43,7 +43,7 @@ public class CosmosServerlessSparkViewJobsAction extends NodeActionListener {
                                                @NotNull PublishSubject<Pair<
                                                        AzureSparkServerlessAccount,
                                                        CosmosSparkADLAccountNode>> viewJobsAction) {
-        super(adlAccountNode);
+        super();
         this.adlAccount = adlAccount;
         this.viewJobsAction = viewJobsAction;
         this.adlAccountNode = adlAccountNode;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
@@ -28,6 +28,7 @@ import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkCosmo
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessAccount;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureRefreshableNode;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import rx.Observable;
@@ -90,4 +91,8 @@ public class CosmosSparkADLAccountNode extends AzureRefreshableNode implements I
         return adlAccount;
     }
 
+    @Override
+    public String getServiceName() {
+        return TelemetryConstants.SPARK_ON_COSMOS;
+    }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkClusterNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkClusterNode.java
@@ -28,6 +28,7 @@ import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkCosmo
 import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkServerlessAccount;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.tooling.msservices.serviceexplorer.*;
 
 import java.awt.*;
@@ -128,5 +129,10 @@ public class CosmosSparkClusterNode extends AzureRefreshableNode implements ILog
     @NotNull
     public String getClusterName() {
         return cluster.getName();
+    }
+
+    @Override
+    public String getServiceName() {
+        return TelemetryConstants.SPARK_ON_COSMOS;
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkClusterRootModuleImpl.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkClusterRootModuleImpl.java
@@ -27,9 +27,10 @@ import com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkCosmo
 import com.microsoft.azure.hdinsight.serverexplore.hdinsightnode.HDInsightRootModule;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 
 import java.awt.*;
 import java.io.IOException;
@@ -82,5 +83,10 @@ public class CosmosSparkClusterRootModuleImpl extends HDInsightRootModule {
                 }
             }
         });
+    }
+
+    @Override
+    public String getServiceName() {
+        return TelemetryConstants.SPARK_ON_COSMOS;
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkDestroyAction.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkDestroyAction.java
@@ -50,7 +50,7 @@ public class CosmosSparkDestroyAction extends NodeActionListener {
                                                 AzureSparkServerlessAccount,
                                                 DestroyableCluster,
                                                 CosmosSparkClusterNode>> destroyAction) {
-        super(clusterNode);
+        super();
         this.clusterNode = clusterNode;
         this.adlAccount = adlAccount;
         this.cluster = cluster;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkMonitorAction.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkMonitorAction.java
@@ -21,7 +21,7 @@ public class CosmosSparkMonitorAction extends NodeActionListener {
                                     @NotNull PublishSubject<Pair<
                                             AzureSparkCosmosCluster,
                                                 CosmosSparkClusterNode>> monitorAction) {
-        super(clusterNode);
+        super();
         this.cluster = cluster;
         this.clusterNode = clusterNode;
         this.monitorAction = monitorAction;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkProvisionAction.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkProvisionAction.java
@@ -44,7 +44,7 @@ public class CosmosSparkProvisionAction extends NodeActionListener {
                                       @NotNull PublishSubject<Pair<
                                                   AzureSparkServerlessAccount,
                                                   CosmosSparkADLAccountNode>> provisionAction) {
-        super(adlAccountNode);
+        super();
         this.adlAccount = adlAccount;
         this.provisionAction = provisionAction;
         this.adlAccountNode = adlAccountNode;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkSubmitAction.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkSubmitAction.java
@@ -41,7 +41,7 @@ public class CosmosSparkSubmitAction extends NodeActionListener {
     public CosmosSparkSubmitAction(@NotNull CosmosSparkClusterNode clusterNode,
                                    @NotNull AzureSparkCosmosCluster cluster,
                                    @NotNull PublishSubject<Pair<AzureSparkCosmosCluster, CosmosSparkClusterNode>> submitAction) {
-        super(clusterNode);
+        super();
         this.cluster = cluster;
         this.clusterNode = clusterNode;
         this.submitAction = submitAction;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkUpdateAction.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkUpdateAction.java
@@ -19,7 +19,7 @@ public class CosmosSparkUpdateAction extends NodeActionListener {
                                    @NotNull AzureSparkCosmosCluster cluster,
                                    @NotNull PublishSubject<Pair<AzureSparkCosmosCluster,
                                                CosmosSparkClusterNode>> updateAction) {
-        super(clusterNode);
+        super();
         this.cluster = cluster;
         this.clusterNode = clusterNode;
         this.updateAction = updateAction;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/HDInsightRootModuleImpl.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/HDInsightRootModuleImpl.java
@@ -24,17 +24,23 @@ package com.microsoft.azure.hdinsight.serverexplore;
 import com.microsoft.azure.hdinsight.common.ClusterManagerEx;
 import com.microsoft.azure.hdinsight.common.CommonConst;
 import com.microsoft.azure.hdinsight.common.IconPathBuilder;
-import com.microsoft.azure.hdinsight.sdk.cluster.*;
+import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
 import com.microsoft.azure.hdinsight.serverexplore.hdinsightnode.ClusterNode;
 import com.microsoft.azure.hdinsight.serverexplore.hdinsightnode.HDInsightRootModule;
-import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.telemetry.AppInsightsClient;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
+import com.microsoft.azuretools.telemetrywrapper.EventType;
+import com.microsoft.azuretools.telemetrywrapper.EventUtil;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class HDInsightRootModuleImpl extends HDInsightRootModule {
+    private static final String HDINSIGHT_NODE_EXPAND = "HDInsightExplorer.HDInsightNodeExpand";
 
     private static final String HDInsight_SERVICE_MODULE_ID = HDInsightRootModuleImpl.class.getName();
     private static final String ICON_PATH = IconPathBuilder
@@ -68,5 +74,20 @@ public class HDInsightRootModuleImpl extends HDInsightRootModule {
                 }
             }
         }
+    }
+
+    @Override
+    protected void onNodeClick(NodeActionEvent e) {
+        // Send telemetry for expanding node action
+        AppInsightsClient.create(HDINSIGHT_NODE_EXPAND, null);
+        EventUtil.logEvent(EventType.info, TelemetryConstants.HDINSIGHT, HDINSIGHT_NODE_EXPAND, null);
+
+        super.onNodeClick(e);
+    }
+
+    @Override
+    @NotNull
+    public String getServiceName() {
+        return TelemetryConstants.HDINSIGHT;
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/BlobContainerNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/BlobContainerNode.java
@@ -23,6 +23,7 @@ package com.microsoft.azure.hdinsight.serverexplore.hdinsightnode;
 
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.hdinsight.common.CommonConst;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.model.storage.BlobContainer;
 import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount;
@@ -30,7 +31,6 @@ import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class BlobContainerNode extends Node{
@@ -82,5 +82,10 @@ public class BlobContainerNode extends Node{
                 "Refresh", RefreshAction.class,
                 "View Blob Container", ViewBlobContainer.class
                 );
+    }
+
+    @Override
+    public String getServiceName() {
+        return TelemetryConstants.HDINSIGHT;
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/JobViewNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/JobViewNode.java
@@ -29,9 +29,9 @@ import com.microsoft.azure.hdinsight.sdk.cluster.ClusterDetail;
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
 
 public class JobViewNode extends RefreshableNode implements ILogger {
@@ -46,18 +46,19 @@ public class JobViewNode extends RefreshableNode implements ILogger {
         super(NODE_ID, NODE_NAME, parent, NODE_ICON_PATH, true);
         this.clusterDetail = clusterDetail;
 
-        this.addClickActionListener(new NodeActionListener() {
-            @Override
-            protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
-                if (ClusterManagerEx.getInstance().isHdiReaderCluster(clusterDetail)) {
-                    HDInsightLoader.getHDInsightHelper().createRefreshHdiReaderJobsWarningForm(
-                            getHDInsightRootModule(), (ClusterDetail) clusterDetail);
-                } else {
-                    HDInsightLoader.getHDInsightHelper().openJobViewEditor(getProject(), clusterDetail.getName());
-                }
-            }
-        });
         this.loadActions();
+    }
+
+    @Override
+    protected void onNodeClick(NodeActionEvent e) {
+        if (ClusterManagerEx.getInstance().isHdiReaderCluster(clusterDetail)) {
+            HDInsightLoader.getHDInsightHelper().createRefreshHdiReaderJobsWarningForm(
+                    getHDInsightRootModule(), (ClusterDetail) clusterDetail);
+        } else {
+            HDInsightLoader.getHDInsightHelper().openJobViewEditor(getProject(), clusterDetail.getName());
+        }
+
+        super.onNodeClick(e);
     }
 
     @NotNull
@@ -69,5 +70,10 @@ public class JobViewNode extends RefreshableNode implements ILogger {
 
     @Override
     protected void refreshItems() throws AzureCmdException {
+    }
+
+    @Override
+    public String getServiceName() {
+        return TelemetryConstants.HDINSIGHT;
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/StorageAccountFolderNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/StorageAccountFolderNode.java
@@ -29,12 +29,11 @@ import com.microsoft.azure.hdinsight.sdk.cluster.HDInsightAdditionalClusterDetai
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
 import com.microsoft.azure.hdinsight.sdk.storage.HDStorageAccount;
 import com.microsoft.azure.hdinsight.sdk.storage.IHDIStorageAccount;
-import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
@@ -51,20 +50,20 @@ public class StorageAccountFolderNode extends RefreshableNode implements ILogger
     public StorageAccountFolderNode(Node parent, @NotNull IClusterDetail clusterDetail) {
         super(STORAGE_ACCOUNT_FOLDER_MODULE_ID, STORAGE_ACCOUNT_NAME, parent, ICON_PATH);
         this.clusterDetail = clusterDetail;
+    }
 
-        this.addClickActionListener(new NodeActionListener() {
-            @Override
-            protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
-                if (ClusterManagerEx.getInstance().isHdiReaderCluster(clusterDetail)) {
-                    HDInsightLoader.getHDInsightHelper().createRefreshHdiReaderStorageAccountsWarningForm(
-                            StorageAccountFolderNode.this, ClusterNode.ASE_DEEP_LINK);
-                } else if (clusterDetail instanceof HDInsightAdditionalClusterDetail
-                        && !isStorageAccountsAvailable(clusterDetail)) {
-                    HDInsightLoader.getHDInsightHelper().createRefreshHdiLinkedClusterStorageAccountsWarningForm(
-                            StorageAccountFolderNode.this, ClusterNode.ASE_DEEP_LINK);
-                }
-            }
-        });
+    @Override
+    protected void onNodeClick(NodeActionEvent e) {
+        if (ClusterManagerEx.getInstance().isHdiReaderCluster(clusterDetail)) {
+            HDInsightLoader.getHDInsightHelper().createRefreshHdiReaderStorageAccountsWarningForm(
+                    StorageAccountFolderNode.this, ClusterNode.ASE_DEEP_LINK);
+        } else if (clusterDetail instanceof HDInsightAdditionalClusterDetail
+                && !isStorageAccountsAvailable(clusterDetail)) {
+            HDInsightLoader.getHDInsightHelper().createRefreshHdiLinkedClusterStorageAccountsWarningForm(
+                    StorageAccountFolderNode.this, ClusterNode.ASE_DEEP_LINK);
+        }
+
+        super.onNodeClick(e);
     }
 
     @Override
@@ -100,5 +99,10 @@ public class StorageAccountFolderNode extends RefreshableNode implements ILogger
         List<HDStorageAccount> additionalStorageAccounts = clusterDetail.getAdditionalStorageAccounts();
         return defaultStorageAccount != null ||
                 (additionalStorageAccounts != null && additionalStorageAccounts.size() > 0);
+    }
+
+    @Override
+    public String getServiceName() {
+        return TelemetryConstants.HDINSIGHT;
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/StorageAccountNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/StorageAccountNode.java
@@ -35,6 +35,7 @@ import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.StringHelper;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetry.TelemetryProperties;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.model.storage.BlobContainer;
@@ -141,6 +142,11 @@ public class StorageAccountNode extends RefreshableNode implements TelemetryProp
         final Map<String, String> properties = new HashMap<>();
         properties.put(AppInsightsConstants.SubscriptionId, this.storageAccount.getSubscriptionId());
         return properties;
+    }
+
+    @Override
+    public String getServiceName() {
+        return TelemetryConstants.HDINSIGHT;
     }
 }
 

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterModule.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterModule.java
@@ -29,8 +29,7 @@ import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
 import com.microsoft.azure.sqlbigdata.sdk.cluster.SqlBigDataLivyLinkClusterDetail;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
-import com.microsoft.tooling.msservices.serviceexplorer.Node;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
 
 import java.util.List;
@@ -67,5 +66,10 @@ public class SqlBigDataClusterModule extends RefreshableNode implements ILogger 
     @Override
     public Object getProject() {
         return project;
+    }
+
+    @Override
+    public String getServiceName() {
+        return TelemetryConstants.SPARK_ON_SQL_SERVER;
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterNode.java
@@ -27,11 +27,9 @@ import com.microsoft.azure.hdinsight.common.CommonConst;
 import com.microsoft.azure.sqlbigdata.sdk.cluster.SqlBigDataLivyLinkClusterDetail;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
-import com.microsoft.tooling.msservices.serviceexplorer.Node;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
-import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
+import com.microsoft.tooling.msservices.serviceexplorer.*;
 
 import java.awt.*;
 import java.io.IOException;
@@ -74,7 +72,7 @@ public class SqlBigDataClusterNode extends RefreshableNode {
             }
         });
 
-        addAction("Unlink", new NodeActionListener() {
+        NodeActionListener listener = new NodeActionListener() {
             @Override
             protected void actionPerformed(NodeActionEvent e) {
                 boolean choice = DefaultLoader.getUIHelper().showConfirmation("Do you really want to unlink the SQL Server big data cluster?",
@@ -84,10 +82,17 @@ public class SqlBigDataClusterNode extends RefreshableNode {
                     ((RefreshableNode) getParent()).load(false);
                 }
             }
-        });
+        };
+        addAction("Unlink", new WrappedTelemetryNodeActionListener(
+                getServiceName(), TelemetryConstants.UNLINK_SPARK_CLUSTER, listener));
     }
 
     @Override
     protected void refreshItems() throws AzureCmdException {
+    }
+
+    @Override
+    public String getServiceName() {
+        return TelemetryConstants.SPARK_ON_SQL_SERVER;
     }
 }


### PR DESCRIPTION
### Code Refactor:
1. Remove unused field `name` for class `NodeActionListener` since it's never used.  Remove constructor `public NodeActionListener(Node node) {}` for class `NodeActionListener` since nothing is done in this constructor. We can call `public NodeActionListener() {}` instead.
2. Notice that every action in one `Node` shares the same operation name, we can implement a `getServiceName` method in class `Node`, and get service name just like the following way in `NodeActionListener`. Therefore, as you can see, we add a parameter `NodeActionEvent event` for `NodeActionListener::getServiceName`.
```
    protected String getServiceName(NodeActionEvent event) {
        try {
            return event.getAction().getNode().getServiceName();
        } catch (Exception ignore) {
            return TelemetryConstants.ACTION;
        }
    }
```
3. Slight change of `NodeActionListener::getOperationName` to align to the format of operation name in `TelemetryConstants`.
```
    protected String getOperationName(NodeActionEvent event) {
        try {
            return event.getAction().getName().toLowerCase().trim().replace(" ", "-");
        } catch (Exception ignore) {
            return "";
        }
    }
``` 
4. Remove all the `addClickActionListener` call in sub-class of `Node` class. Instead, we put those action into `onNodeClick` method. As you can see, `clickAction` is already bind to an action listener in class `Node`.

```
    protected void loadActions() {
        // add the click action handler
        addClickActionListener(new NodeActionListener() {
            @Override
            public void actionPerformed(NodeActionEvent e) {
                onNodeClick(e);
            }
        });
        // Other not related code are ignored...
}

    public void addClickActionListener(NodeActionListener actionListener) {
        clickAction.addListener(actionListener);
    }
```
If we bind another listener to `clickAction`, duplicate telemetries will be sent when each listener calls `actionPerformedAsync`. Check the definition for `NodeAction::fireNodeActionEvent`
```
    public void fireNodeActionEvent() {
        if (!listeners.isEmpty()) {
            final NodeActionEvent event = new NodeActionEvent(this);
            for (final NodeActionListener listener : listeners) {
                listener.beforeActionPerformed(event);
                Futures.addCallback(listener.actionPerformedAsync(event), new FutureCallback<Void>() {
                    @Override
                    public void onSuccess(Void aVoid) {
                        listener.afterActionPerformed(event);
                    }

                    @Override
                    public void onFailure(Throwable throwable) {
                        listener.afterActionPerformed(event);
                    }
                });
            }
        }
    }

```
