### PR TITLE
Fix run into exception when submit job to aris cluster issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -120,6 +120,7 @@
     <programRunner implementation="com.microsoft.azure.hdinsight.spark.run.CosmosSparkBatchRunner" />
     <programRunner implementation="com.microsoft.azure.hdinsight.spark.run.SparkBatchJobDebuggerRunner" />
     <programRunner implementation="com.microsoft.azure.hdinsight.spark.run.CosmosServerlessSparkBatchRunner" />
+    <programRunner implementation="com.microsoft.azure.hdinsight.spark.run.ArisSparkBatchRunner" />
     <configurationType implementation="com.microsoft.intellij.runner.container.AzureDockerSupportConfigurationType"/>
     <errorHandler implementation="com.microsoft.intellij.feedback.MSErrorReportHandler" />
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/ArisSparkBatchRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/ArisSparkBatchRunner.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.hdinsight.spark.run
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.RunProfile
+import com.intellij.execution.filters.BrowserHyperlinkInfo
+import com.intellij.execution.filters.Filter
+import com.intellij.execution.ui.ConsoleView
+import com.microsoft.azure.hdinsight.common.ClusterManagerEx
+import com.microsoft.azure.hdinsight.common.MessageInfoType
+import com.microsoft.azure.hdinsight.sdk.cluster.InternalUrlMapping
+import com.microsoft.azure.hdinsight.spark.common.ISparkBatchJob
+import com.microsoft.azure.hdinsight.spark.common.SparkBatchJob
+import com.microsoft.azure.hdinsight.spark.common.SparkBatchSubmission
+import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel
+import com.microsoft.azure.hdinsight.spark.run.configuration.ArisSparkConfiguration
+import rx.Observer
+import java.util.*
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.regex.Pattern
+
+class ArisSparkBatchRunner : SparkBatchJobRunner() {
+    private val sessionNameCounter: AtomicInteger = AtomicInteger(0)
+
+    override fun canRun(executorId: String, profile: RunProfile): Boolean {
+        return SparkBatchJobRunExecutor.EXECUTOR_ID == executorId && profile.javaClass == ArisSparkConfiguration::class.java
+    }
+
+    override fun getRunnerId(): String {
+        return "ArisSparkBatchRun"
+    }
+
+    override fun addConsoleViewFilter(job: ISparkBatchJob, consoleView: ConsoleView) {
+        (job as? SparkBatchJob)?.let {
+            val mapping = it.cluster as? InternalUrlMapping
+            if (mapping != null) {
+                consoleView.addMessageFilter { line, entireLength ->
+                    val matcher = Pattern.compile("http://[^\\s]+", Pattern.CASE_INSENSITIVE).matcher(line)
+                    val items = ArrayList<Filter.ResultItem>()
+                    val textStartOffset = entireLength - line.length
+                    while (matcher.find()) {
+                        val mappedUrl = mapping.mapInternalUrlToPublic(matcher.group(0))
+                        items.add(
+                            Filter.ResultItem(
+                                textStartOffset + matcher.start(), textStartOffset + matcher.end(),
+                                BrowserHyperlinkInfo(mappedUrl)
+                            )
+                        )
+                    }
+                    if (items.size != 0) Filter.Result(items) else null
+                }
+            }
+        }
+    }
+
+    override fun buildSparkBatchJobForExecution(
+        submitModel: SparkSubmitModel,
+        ctrlSubject: Observer<AbstractMap.SimpleImmutableEntry<MessageInfoType, String>>
+    ): ISparkBatchJob {
+        val clusterName = submitModel.submissionParameter.clusterName
+        val clusterDetail = ClusterManagerEx.getInstance().getClusterDetailByName(clusterName)
+            .orElseThrow { ExecutionException("Can't find cluster named $clusterName") }
+
+        val jobDeploy = SparkBatchJobDeployFactory.getInstance().buildSparkBatchJobDeploy(submitModel, ctrlSubject)
+        return SparkBatchJob(
+            clusterDetail,
+            // In the latest 0.6.0-incubating livy, livy prevents user from creating sessions that have the same session name
+            // Livy release notes: https://livy.apache.org/history/
+            // JIRA: https://issues.apache.org/jira/browse/LIVY-41
+            submitModel.submissionParameter.apply { name = mainClassName + "_${sessionNameCounter.getAndIncrement()}" },
+            SparkBatchSubmission.getInstance(),
+            ctrlSubject,
+            jobDeploy
+        )
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/ArisSparkBatchRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/ArisSparkBatchRunner.kt
@@ -35,6 +35,7 @@ import com.microsoft.azure.hdinsight.spark.common.SparkBatchJob
 import com.microsoft.azure.hdinsight.spark.common.SparkBatchSubmission
 import com.microsoft.azure.hdinsight.spark.common.SparkSubmitModel
 import com.microsoft.azure.hdinsight.spark.run.configuration.ArisSparkConfiguration
+import com.microsoft.azure.sqlbigdata.spark.common.ArisSparkBatchJob
 import rx.Observer
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
@@ -83,7 +84,7 @@ class ArisSparkBatchRunner : SparkBatchJobRunner() {
             .orElseThrow { ExecutionException("Can't find cluster named $clusterName") }
 
         val jobDeploy = SparkBatchJobDeployFactory.getInstance().buildSparkBatchJobDeploy(submitModel, ctrlSubject)
-        return SparkBatchJob(
+        return ArisSparkBatchJob(
             clusterDetail,
             // In the latest 0.6.0-incubating livy, livy prevents user from creating sessions that have the same session name
             // Livy release notes: https://livy.apache.org/history/

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
@@ -81,12 +81,6 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
     protected void addConsoleViewFilter(@NotNull ISparkBatchJob job, @NotNull ConsoleView consoleView) {
     }
 
-    @NotNull
-    protected ISparkBatchJob buildSparkBatchJobForExecution(@NotNull SparkSubmitModel submitModel,
-                                                            @NotNull Observer<SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject) throws ExecutionException {
-        return buildSparkBatchJob(submitModel, ctrlSubject);
-    }
-
     @Nullable
     @Override
     protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment environment) throws ExecutionException {
@@ -104,7 +98,7 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
         PublishSubject<SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject = PublishSubject.create();
         SparkBatchJobRemoteProcess remoteProcess = new SparkBatchJobRemoteProcess(
                 new IdeaSchedulers(project),
-                buildSparkBatchJobForExecution(submitModel, ctrlSubject),
+                buildSparkBatchJob(submitModel, ctrlSubject),
                 artifactPath,
                 submitModel.getSubmissionParameter().getMainClassName(),
                 ctrlSubject);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
@@ -29,10 +29,9 @@ import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
-import com.intellij.execution.filters.BrowserHyperlinkInfo;
-import com.intellij.execution.filters.Filter;
 import com.intellij.execution.runners.DefaultProgramRunner;
 import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.openapi.actionSystem.Separator;
 import com.intellij.openapi.project.Project;
@@ -40,10 +39,8 @@ import com.microsoft.azure.hdinsight.common.ClusterManagerEx;
 import com.microsoft.azure.hdinsight.common.MessageInfoType;
 import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
-import com.microsoft.azure.hdinsight.sdk.cluster.InternalUrlMapping;
 import com.microsoft.azure.hdinsight.spark.common.*;
 import com.microsoft.azure.hdinsight.spark.run.action.SparkBatchJobDisconnectAction;
-import com.microsoft.azure.hdinsight.spark.run.configuration.ArisSparkConfiguration;
 import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRunConfiguration;
 import com.microsoft.azure.hdinsight.spark.ui.SparkJobLogConsoleView;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
@@ -55,10 +52,6 @@ import rx.Observer;
 import rx.subjects.PublishSubject;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSubmissionRunner, ILogger {
     @NotNull
@@ -70,8 +63,7 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
     @Override
     public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
         return SparkBatchJobRunExecutor.EXECUTOR_ID.equals(executorId)
-                && (profile.getClass() == LivySparkBatchJobRunConfiguration.class
-                || profile.getClass() == ArisSparkConfiguration.class);
+                && profile.getClass() == LivySparkBatchJobRunConfiguration.class;
     }
 
     @Override
@@ -84,6 +76,15 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
 
         Deployable jobDeploy = SparkBatchJobDeployFactory.getInstance().buildSparkBatchJobDeploy(submitModel, ctrlSubject);
         return new SparkBatchJob(clusterDetail, submitModel.getSubmissionParameter(), SparkBatchSubmission.getInstance(), ctrlSubject, jobDeploy);
+    }
+
+    protected void addConsoleViewFilter(@NotNull ISparkBatchJob job, @NotNull ConsoleView consoleView) {
+    }
+
+    @NotNull
+    protected ISparkBatchJob buildSparkBatchJobForExecution(@NotNull SparkSubmitModel submitModel,
+                                                            @NotNull Observer<SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject) throws ExecutionException {
+        return buildSparkBatchJob(submitModel, ctrlSubject);
     }
 
     @Nullable
@@ -103,7 +104,7 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
         PublishSubject<SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject = PublishSubject.create();
         SparkBatchJobRemoteProcess remoteProcess = new SparkBatchJobRemoteProcess(
                 new IdeaSchedulers(project),
-                buildSparkBatchJob(submitModel, ctrlSubject),
+                buildSparkBatchJobForExecution(submitModel, ctrlSubject),
                 artifactPath,
                 submitModel.getSubmissionParameter().getMainClassName(),
                 ctrlSubject);
@@ -120,26 +121,8 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
         submissionState.setExecutionResult(result);
         submissionState.setConsoleView(jobOutputView.getSecondaryConsoleView());
 
-        SparkBatchJob sparkBatchJob = remoteProcess.getSparkJob() instanceof SparkBatchJob
-                ? (SparkBatchJob) remoteProcess.getSparkJob()
-                : null;
-        if (sparkBatchJob != null) {
-            InternalUrlMapping mapping = sparkBatchJob.getCluster() instanceof InternalUrlMapping
-                    ? (InternalUrlMapping) sparkBatchJob.getCluster()
-                    : null;
-            if (mapping != null) {
-                submissionState.getConsoleView().addMessageFilter((line, entireLength) -> {
-                    Matcher matcher = Pattern.compile("http://[^\\s]+", Pattern.CASE_INSENSITIVE).matcher(line);
-                    List<Filter.ResultItem> items = new ArrayList<>();
-                    int textStartOffset = entireLength - line.length();
-                    while (matcher.find()) {
-                        String mappedUrl = mapping.mapInternalUrlToPublic(matcher.group(0));
-                        items.add(new Filter.ResultItem(textStartOffset + matcher.start(), textStartOffset + matcher.end(), new BrowserHyperlinkInfo(mappedUrl)));
-                    }
-                    return items.size() != 0 ? new Filter.Result(items) : null;
-                });
-            }
-        }
+        addConsoleViewFilter(remoteProcess.getSparkJob(), submissionState.getConsoleView());
+
         submissionState.setRemoteProcessCtrlLogHandler(processHandler);
 
         ctrlSubject.subscribe(

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/YarnCluster.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/YarnCluster.java
@@ -22,9 +22,12 @@
 
 package com.microsoft.azure.hdinsight.sdk.cluster;
 
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
+
 public interface YarnCluster {
     String getYarnNMConnectionUrl();
 
+    @Nullable
     default String getYarnUIUrl() {
         return null;
     }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/YarnCluster.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/YarnCluster.java
@@ -24,4 +24,8 @@ package com.microsoft.azure.hdinsight.sdk.cluster;
 
 public interface YarnCluster {
     String getYarnNMConnectionUrl();
+
+    default String getYarnUIUrl() {
+        return null;
+    }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/CosmosSparkBatchJob.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/CosmosSparkBatchJob.java
@@ -132,7 +132,7 @@ public class CosmosSparkBatchJob extends SparkBatchJob {
     }
 
     @Override
-    Observable<String> getSparkJobDriverLogUrlObservable() {
+    protected Observable<String> getSparkJobDriverLogUrlObservable() {
         return Observable.just(Objects.requireNonNull(getConnectUri()).toString() + "/" + getBatchId() + "/log");
     }
 

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchJob.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchJob.java
@@ -650,7 +650,7 @@ public class SparkBatchJob implements ISparkBatchJob, ILogger {
      *
      * @return Yarn Application Attempt info Observable
      */
-    Observable<AppAttempt> getSparkJobYarnCurrentAppAttempt() {
+    protected Observable<AppAttempt> getSparkJobYarnCurrentAppAttempt() {
         if (getConnectUri() == null) {
             return Observable.error(new SparkJobNotConfiguredException("Can't get Spark job connection URI, " +
                     "please configure Spark cluster which the Spark job will be submitted."));
@@ -973,7 +973,7 @@ public class SparkBatchJob implements ISparkBatchJob, ILogger {
      *
      * @return Job Driver log URL observable
      */
-    Observable<String> getSparkJobDriverLogUrlObservable() {
+    protected Observable<String> getSparkJobDriverLogUrlObservable() {
         return getSparkJobYarnCurrentAppAttempt()
                 .map(AppAttempt::getLogsLink)
                 .map(URI::create)

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/sdk/cluster/SqlBigDataLivyLinkClusterDetail.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/sdk/cluster/SqlBigDataLivyLinkClusterDetail.java
@@ -12,6 +12,7 @@ import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import org.apache.commons.lang3.StringUtils;
 
+import java.net.URI;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,24 +51,30 @@ public class SqlBigDataLivyLinkClusterDetail implements IClusterDetail, LivyClus
     @Override
     @NotNull
     public String getConnectionUrl() {
-        return String.format("https://%s:%d/gateway/default/livy/v1/", host, knoxPort);
+        return String.format("https://%s:%d/gateway/default/", host, knoxPort);
     }
 
     @Override
     @NotNull
     public String getLivyConnectionUrl() {
-        return getConnectionUrl();
+        return URI.create(getConnectionUrl()).resolve("livy/v1/").toString();
     }
 
     @Override
     @NotNull
     public String getYarnNMConnectionUrl() {
-        return String.format("https://%s:%d/gateway/default/yarn/", host, knoxPort);
+        return URI.create(getConnectionUrl()).resolve("yarn/ws/v1/cluster/apps/").toString();
+    }
+
+    @Override
+    @NotNull
+    public String getYarnUIUrl() {
+        return URI.create(getConnectionUrl()).resolve("yarn/").toString();
     }
 
     @NotNull
     public String getSparkHistoryUrl() {
-        return String.format("https://%s:%d/gateway/default/sparkhistory/", host, knoxPort);
+        return URI.create(getConnectionUrl()).resolve("sparkhistory/").toString();
     }
 
     @Override

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/spark/common/ArisSparkBatchJob.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/spark/common/ArisSparkBatchJob.java
@@ -1,0 +1,36 @@
+package com.microsoft.azure.sqlbigdata.spark.common;
+
+import com.microsoft.azure.hdinsight.common.MessageInfoType;
+import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
+import com.microsoft.azure.hdinsight.spark.common.Deployable;
+import com.microsoft.azure.hdinsight.spark.common.SparkBatchJob;
+import com.microsoft.azure.hdinsight.spark.common.SparkBatchSubmission;
+import com.microsoft.azure.hdinsight.spark.common.SparkSubmissionParameter;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
+import rx.Observable;
+import rx.Observer;
+
+import java.util.AbstractMap;
+
+public class ArisSparkBatchJob extends SparkBatchJob {
+    public ArisSparkBatchJob(
+            @Nullable IClusterDetail cluster,
+            SparkSubmissionParameter submissionParameter,
+            SparkBatchSubmission sparkBatchSubmission,
+            @NotNull Observer<AbstractMap.SimpleImmutableEntry<MessageInfoType, String>> ctrlSubject,
+            @Nullable Deployable jobDeploy) {
+        super(cluster, submissionParameter, sparkBatchSubmission, ctrlSubject, jobDeploy);
+    }
+
+    @Override
+    protected Observable<String> getSparkJobDriverLogUrlObservable() {
+        return getSparkJobYarnCurrentAppAttempt()
+                .map(appAttempt -> {
+                    String nodeId = appAttempt.getNodeId();
+                    String containerId = appAttempt.getContainerId();
+                    String connectUrl = getCluster().getConnectionUrl();
+                    return String.format("%s/jobhistory/joblogs/%s/%s/%s/root", connectUrl, nodeId, containerId, containerId);
+                });
+    }
+}


### PR DESCRIPTION
These are 3 commit in this PR.
1. The first commit is to fix #3208 
2. The second commit is to fix another issue: If we re-submit a spark job to aris cluster it will fail with error code 400 and error message "Duplicate session name: Some{aris}".
3. The third commit is to support yarn log for Aris cluster.