### PR TITLE
Fix VM creation dialog will popup multi times

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/CreateArmStorageAccountForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/CreateArmStorageAccountForm.java
@@ -287,6 +287,19 @@ public class CreateArmStorageAccountForm extends AzureDialogWrapper {
 //        );
     }
 
+    @Override
+    public void doCancelAction() {
+        DefaultLoader.getIdeHelper().invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                if (onCreate != null) {
+                    onCreate.run();
+                }
+            }
+        });
+        super.doCancelAction();
+    }
+
     private boolean createStorageAccount() {
         Operation operation = TelemetryManager.createOperation(STORAGE, CREATE_STORAGE_ACCOUNT);
         try {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/wizards/createarmvm/SettingsStep.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/wizards/createarmvm/SettingsStep.java
@@ -418,10 +418,10 @@ public class SettingsStep extends AzureWizardStep<VMWizardModel> implements Tele
         final DefaultComboBoxModel refreshedSAModel = new DefaultComboBoxModel(accounts) {
             @Override
             public void setSelectedItem(Object o) {
+                super.setSelectedItem(o);
                 if (CREATE_NEW.equals(o)) {
                     showNewStorageForm();
                 } else {
-                    super.setSelectedItem(o);
                     if (o instanceof StorageAccount) {
                         model.setStorageAccount((StorageAccount) o);
                     } else {
@@ -733,6 +733,8 @@ public class SettingsStep extends AzureWizardStep<VMWizardModel> implements Tele
                             model.setWithNewStorageAccount(true);
                             ((DefaultComboBoxModel)storageComboBox.getModel()).insertElementAt(newStorageAccount.getName() + " (New)", 0);
                             storageComboBox.setSelectedIndex(0);
+                        } else {
+                            storageComboBox.setSelectedItem(null);
                         }
                     }
                 });


### PR DESCRIPTION
Fix VM creation dialog will popup multi times, for issue #3228 
- Execute `super.setSelectedItem()` for storageComboBox
- Update `onCreate` method, set storageComboBox to null when no account created and execute `onCreate` method when close StorageCreationDialog.