### PR TITLE
Fix UnsupportedOperationException for telemetry code

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/Test/java/com/microsoft/intellij/telemetry/ContainerTelemetryExtensionTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/Test/java/com/microsoft/intellij/telemetry/ContainerTelemetryExtensionTest.kt
@@ -134,7 +134,7 @@ class FormBuilderPanel {
     }
 }
 
-class IdeaTelemetryUtilsTest : LightProjectDescriptor() {
+class ContainerTelemetryExtensionTest : LightProjectDescriptor() {
     override fun getSdk(): Sdk? {
         return IdeaTestUtil.getMockJdk18()
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/CommonUtil.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/CommonUtil.java
@@ -24,6 +24,7 @@ package com.microsoft.azuretools.telemetrywrapper;
 
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.azuretools.adauth.StringUtils;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -50,11 +51,12 @@ public class CommonUtil {
 
     public synchronized static void sendTelemetry(EventType eventType, String serviceName, Map<String, String> properties,
         Map<String, Double> metrics) {
+        Map<String, String> mutableProps = properties == null ? new HashMap<>() : new HashMap<>(properties);
         if (client != null) {
             if (!StringUtils.isNullOrEmpty(serviceName)) {
-                properties.put(SERVICE_NAME, serviceName);
+                mutableProps.put(SERVICE_NAME, serviceName);
             }
-            client.trackEvent(getFullEventName(eventType), properties, metrics);
+            client.trackEvent(getFullEventName(eventType), mutableProps, metrics);
             client.flush();
         }
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/DefaultOperation.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/DefaultOperation.java
@@ -22,19 +22,11 @@
 
 package com.microsoft.azuretools.telemetrywrapper;
 
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.DURATION;
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.ERROR_CLASSNAME;
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.ERROR_CODE;
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.ERROR_MSG;
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.ERROR_TYPE;
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.OPERATION_ID;
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.OPERATION_NAME;
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.mergeProperties;
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.sendTelemetry;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+
+import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.*;
 
 public class DefaultOperation implements Operation {
 
@@ -63,19 +55,15 @@ public class DefaultOperation implements Operation {
             if (eventType == EventType.opStart || eventType == EventType.opEnd) {
                 return;
             }
-            if (properties == null) {
-                properties = new HashMap<>();
-            }
-            if (metrics == null) {
-                metrics = new HashMap<>();
-            }
-            properties.put(OPERATION_ID, operationId);
-            properties.put(OPERATION_NAME, operationName);
+            Map<String, String> mutableProps = properties == null ? new HashMap<>() : new HashMap<>(properties);
+            mutableProps.put(OPERATION_ID, operationId);
+            mutableProps.put(OPERATION_NAME, operationName);
 
+            Map<String, Double> mutableMetrics = properties == null ? new HashMap<>() : new HashMap<>(metrics);
             if (eventType == EventType.step) {
-                metrics.put(DURATION, Double.valueOf(System.currentTimeMillis() - timeStart));
+                mutableMetrics.put(DURATION, Double.valueOf(System.currentTimeMillis() - timeStart));
             }
-            sendTelemetry(eventType, serviceName, mergeProperties(properties), metrics);
+            sendTelemetry(eventType, serviceName, mergeProperties(mutableProps), mutableMetrics);
         } catch (Exception ignore) {
         }
     }
@@ -86,26 +74,23 @@ public class DefaultOperation implements Operation {
             if (isComplete) {
                 return;
             }
-            if (properties == null) {
-                properties = new HashMap<>();
-            }
-            if (metrics == null) {
-                metrics = new HashMap<>();
-            }
+            Map<String, String> mutableProps = properties == null ? new HashMap<>() : new HashMap<>(properties);
+            Map<String, Double> mutableMetrics = properties == null ? new HashMap<>() : new HashMap<>(metrics);
+
             error = new Error();
             error.errorType = errorType == null ? ErrorType.systemError : errorType;
             error.errMsg = e == null ? "" : e.getMessage();
             error.className = e == null ? "" : e.getClass().getName();
 
-            properties.put(ERROR_CODE, "1");
-            properties.put(ERROR_MSG, error.errMsg);
-            properties.put(ERROR_TYPE, error.errorType.name());
-            properties.put(ERROR_CLASSNAME, error.className);
-            properties.put(OPERATION_ID, operationId);
-            properties.put(OPERATION_NAME, operationName);
+            mutableProps.put(ERROR_CODE, "1");
+            mutableProps.put(ERROR_MSG, error.errMsg);
+            mutableProps.put(ERROR_TYPE, error.errorType.name());
+            mutableProps.put(ERROR_CLASSNAME, error.className);
+            mutableProps.put(OPERATION_ID, operationId);
+            mutableProps.put(OPERATION_NAME, operationName);
 
-            metrics.put(DURATION, Double.valueOf(System.currentTimeMillis() - timeStart));
-            sendTelemetry(EventType.error, serviceName, mergeProperties(properties), metrics);
+            mutableMetrics.put(DURATION, Double.valueOf(System.currentTimeMillis() - timeStart));
+            sendTelemetry(EventType.error, serviceName, mergeProperties(mutableProps), mutableMetrics);
         } catch (Exception ignore) {
         }
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/EventUtil.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/EventUtil.java
@@ -22,25 +22,24 @@
 
 package com.microsoft.azuretools.telemetrywrapper;
 
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.mergeProperties;
-import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.sendTelemetry;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
+
+import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.mergeProperties;
+import static com.microsoft.azuretools.telemetrywrapper.CommonUtil.sendTelemetry;
 
 public class EventUtil {
 
     public static void logEvent(EventType eventType, String serviceName, String operName, Map<String, String> properties,
         Map<String, Double> metrics) {
         try {
-            if (properties == null) {
-                properties = new HashMap<>();
-            }
-            properties.put(CommonUtil.OPERATION_NAME, operName);
-            properties.put(CommonUtil.OPERATION_ID, UUID.randomUUID().toString());
-            sendTelemetry(eventType, serviceName, mergeProperties(properties), metrics);
+            // Parameter properties might be a ImmutableMap, which means calling properties.put will lead to UnsupportedOperationException
+            Map<String, String> mutableProps = properties == null ? new HashMap<>() : new HashMap<>(properties);
+            mutableProps.put(CommonUtil.OPERATION_NAME, operName);
+            mutableProps.put(CommonUtil.OPERATION_ID, UUID.randomUUID().toString());
+            sendTelemetry(eventType, serviceName, mergeProperties(mutableProps), metrics);
         } catch (Exception ignore) {
         }
     }
@@ -53,16 +52,14 @@ public class EventUtil {
     public static void logError(String serviceName, String operName, ErrorType errorType, Exception e,
         Map<String, String> properties, Map<String, Double> metrics) {
         try {
-            if (properties == null) {
-                properties = new HashMap<>();
-            }
-            properties.put(CommonUtil.OPERATION_NAME, operName);
-            properties.put(CommonUtil.OPERATION_ID, UUID.randomUUID().toString());
-            properties.put(CommonUtil.ERROR_CODE, "1");
-            properties.put(CommonUtil.ERROR_MSG, e != null ? e.getMessage() : "");
-            properties.put(CommonUtil.ERROR_CLASSNAME, e != null ? e.getClass().getName() : "");
-            properties.put(CommonUtil.ERROR_TYPE, errorType.name());
-            sendTelemetry(EventType.error, serviceName, mergeProperties(properties), metrics);
+            Map<String, String> mutableProps = properties == null ? new HashMap<>() : new HashMap<>(properties);
+            mutableProps.put(CommonUtil.OPERATION_NAME, operName);
+            mutableProps.put(CommonUtil.OPERATION_ID, UUID.randomUUID().toString());
+            mutableProps.put(CommonUtil.ERROR_CODE, "1");
+            mutableProps.put(CommonUtil.ERROR_MSG, e != null ? e.getMessage() : "");
+            mutableProps.put(CommonUtil.ERROR_CLASSNAME, e != null ? e.getClass().getName() : "");
+            mutableProps.put(CommonUtil.ERROR_TYPE, errorType.name());
+            sendTelemetry(EventType.error, serviceName, mergeProperties(mutableProps), metrics);
         } catch (Exception ignore) {
         }
     }


### PR DESCRIPTION
 - When we call `EventUtil.logEvent(EventType.info, serviceName, operationName, properties, null)`, if the `properties` we passed as a parameter is an immutable map, codes will run into `UnsupportedOperationExceptin` and the telemetry will not be sent.
 - The following kotlin sample code shows that without this PR the following two lines will both run into `UnsupportedOperationException`
```
        EventUtil.logEvent(EventType.info, "TestService", "TestOperation", mapOf("first" to "1"))
        EventUtil.logEvent(EventType.info, "TestService", "TestOperation", ImmutableMap.of("second", "2"))
```