### PR TITLE
Fix travis build will break when install oracle jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ branches:
 script:
 - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_wait 40 ./BuildDevint -q -e eclipse; fi'
 - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then travis_wait 40 ./BuildDevint -q; fi'
+dist: trusty
+


### PR DESCRIPTION
Fix travis build will break when download jdk
Refers https://travis-ci.community/t/solved-oraclejdk8-installation-failing-still-again/3428