### PR TITLE
Reset webapp checkbox after create new web app

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/slimui/WebAppSlimSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/slimui/WebAppSlimSettingPanel.java
@@ -322,6 +322,7 @@ public class WebAppSlimSettingPanel extends AzureSettingPanel<WebAppConfiguratio
     private void selectWebApp() {
         Object value = cbxWebApp.getSelectedItem();
         if (Comparing.equal(CREATE_NEW_WEBAPP, value) && !refreshingWebApp) {
+            cbxWebApp.setSelectedItem(null);
             createNewWebApp();
         } else if (value == null || value instanceof String) {
             return;


### PR DESCRIPTION
Reset web app checkbox after create new web apps, for 2019.2 regression which may trigger `createNewWebApp()` multi-times.