### PR TITLE
Show error message in error text field

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/ui/AppServiceBaseDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/ui/AppServiceBaseDialog.java
@@ -37,7 +37,7 @@ import org.eclipse.swt.widgets.Shell;
 public abstract class AppServiceBaseDialog extends AzureTitleAreaDialogWrapper {
 
     private List<ControlDecoration> decorations = new LinkedList<>();
-    private static final String FORM_VALIDATION_ERROR = "Form validation error.";
+    private static final String FORM_VALIDATION_ERROR = "Validation error: %s";
 
     public AppServiceBaseDialog(Shell parentShell) {
         super(parentShell);
@@ -57,7 +57,7 @@ public abstract class AppServiceBaseDialog extends AzureTitleAreaDialogWrapper {
     protected void setError(ControlDecoration d, String message) {
         Display.getDefault().asyncExec(() -> {
             d.setDescriptionText(message);
-            setErrorMessage(FORM_VALIDATION_ERROR);
+            setErrorMessage(String.format(FORM_VALIDATION_ERROR, message));
             d.show();
         });
     }


### PR DESCRIPTION
Show error message in error text field as description text can not be read by narrator, for issue #3311 

![image](https://user-images.githubusercontent.com/12445236/64085938-0f63c380-cd68-11e9-974d-2765a61a948e.png)
