### PR TITLE
Fix keyboard trap in error message dialog

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/ui/ErrorWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/ui/ErrorWindow.java
@@ -22,6 +22,8 @@ public class ErrorWindow extends AzureTitleAreaDialogWrapper {
         w.create();
         w.setTitle(title);
         w.setErrorDescription(errorDescription);
+        // Skip title text field while tab
+        w.dialogArea.getParent().getParent().setTabList(new Control[] { w.dialogArea.getParent() });
         w.open();
     }
 
@@ -54,6 +56,7 @@ public class ErrorWindow extends AzureTitleAreaDialogWrapper {
         container.setLayoutData(new GridData(GridData.FILL_BOTH));
         
         text = new Text(container, SWT.BORDER | SWT.WRAP | SWT.MULTI);
+        text.setEditable(false);
 
         return area;
     }


### PR DESCRIPTION
Fix keyboard trap in error message dialog, for issue #3322 
![3322](https://user-images.githubusercontent.com/12445236/64141554-1c051c00-ce3b-11e9-85ae-6873da59fe4d.gif)
