### PR TITLE
Don't write error message when retry check new created service principal

### DIFF
--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/srvpri/SrvPriManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/srvpri/SrvPriManager.java
@@ -250,7 +250,7 @@ public class SrvPriManager {
                         fileReporter.report(String.format("Failed to check cred file -retry limit %s has reached, error: %s", RETRY_QNTY, e.getMessage()));
                         throw e;
                     }
-                    fileReporter.report(String.format("Failed, will retry in %s seconds, error: %s", SLEEP_SEC, e.getMessage()));
+                    LOGGER.info(String.format("Failed %d/%d, will retry in %s seconds, error: %s", retry_count, RETRY_QNTY, SLEEP_SEC, e.getMessage()));
                     try {
                         Thread.sleep(SLEEP_SEC * 1000);
                     } catch (InterruptedException e1) {


### PR DESCRIPTION
Don't write error message when retry check new created service principal, for issue #3643 