### PR TITLE
Fix focus is invisible in run configuration dialog issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkSubmissionJobUploadStorageWithUploadPathPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkSubmissionJobUploadStorageWithUploadPathPanel.kt
@@ -59,7 +59,10 @@ import rx.schedulers.Schedulers
 import rx.subjects.ReplaySubject
 import java.awt.CardLayout
 import java.util.concurrent.TimeUnit
-import javax.swing.*
+import javax.swing.DefaultComboBoxModel
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JTextField
 
 class SparkSubmissionJobUploadStorageWithUploadPathPanel
     : JPanel(), Disposable, SettableControl<SparkSubmitJobUploadStorageModel>, ILogger {
@@ -77,7 +80,6 @@ class SparkSubmissionJobUploadStorageWithUploadPathPanel
     private val uploadPathLabel = JLabel("Upload Path")
     private val uploadPathField = JTextField().apply {
         isEditable = false
-        border = BorderFactory.createEmptyBorder()
     }
 
     val storagePanel = SparkSubmissionJobUploadStoragePanel().apply {


### PR DESCRIPTION
To address #3602. WIth this PR, the focus flow will work as the following gif.
![fix_issue_3602](https://user-images.githubusercontent.com/32627233/67067335-8b935880-f1a8-11e9-9f56-e6195c4cbc0c.gif)
