### PR TITLE
Fix focus invisible issue in autofix dialog

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/ErrorWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/ErrorWindow.java
@@ -66,6 +66,9 @@ public class ErrorWindow extends AzureDialogWrapper {
         Font labelFont = UIManager.getFont("Label.font");
         textPane.setFont(labelFont);
 
+        // To fix accessibility focus issue: https://github.com/microsoft/azure-tools-for-java/issues/3606
+        textPane.setFocusable(false);
+
         init();
     }
 


### PR DESCRIPTION
To address #3606. The focus order would be like the following way with this PR.
![fix_issue_3606](https://user-images.githubusercontent.com/32627233/67171912-d51fb580-f3eb-11e9-9db4-948f909abd7a.gif)
