### PR TITLE
Update creation dialog configuration in `apply()`

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/slimui/WebAppSlimSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/slimui/WebAppSlimSettingPanel.java
@@ -373,6 +373,7 @@ public class WebAppSlimSettingPanel extends AzureSettingPanel<WebAppConfiguratio
         }
         configuration.setDeployToRoot(chkToRoot.isVisible() && chkToRoot.isSelected());
         configuration.setOpenBrowserAfterDeployment(chkOpenBrowser.isSelected());
+        this.webAppConfiguration = configuration;
     }
 
     private void selectWebApp() {


### PR DESCRIPTION
Update configuration in creation dialog in `apply()`, in case configuration in SettingPanel out of data, which may caused configuration issues. 
For instance, the target name may not updated in time, which will make toolkit unable to determine project type(jar?war?) and show wrong web containers in creation dialog.