### PR TITLE
Fix API change caused arcadia job submission failed issue

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/projectarcadia/common/ArcadiaSparkCompute.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/projectarcadia/common/ArcadiaSparkCompute.java
@@ -107,9 +107,11 @@ public class ArcadiaSparkCompute extends SparkCluster implements ILogger {
     @Nullable
     @Override
     public String getConnectionUrl() {
-        if (this.workSpace.getSparkUrl() == null) {
-            return null;
-        }
+        // Comment the following codes since the "spark" field replacing with "dev" field in API
+        // which causes connection URL returns null
+//        if (this.workSpace.getSparkUrl() == null) {
+//            return null;
+//        }
 
         try {
             // TODO: Enable it when the workspace's Spark URL is usable.


### PR DESCRIPTION
Please find the latest response when we send the request to get workspace list.
`GET /subscriptions/************/providers/Microsoft.ProjectArcadia/workspaces?api-version=2019-06-01-preview HTTP/1.1`
```
{
    "value": [
        {
            "id": "/************",
            "location": "************",
            "name": "************",
            "type": "************",
            "identity": {
                "type": "************",
                "principalId": "************",
                "tenantId": "************"
            },
            "tags": {},
            "properties": {
                "connectivityEndpoints": {
                    "web": "************",
                    "sql": "************",
                    "dev": "https://westworkspace.dev.projectarcadia.net"
                },
                "managedResourceGroupName": "************",
                "provisioningState": "************"
            }
        },{
}]
```

The change happens at the `connectivityEndpoints`. Previously the connectivity defines in the following way. As you can see, there is a `spark` field indicating the host URL for job submission. However, in the latest response, we find the `spark` field is renamed to `dev`. This PR is to fix this change caused job submission failure.
```
    "ConnectivityEndpoints": {
      "description": "Workspace connectivity endpoints",
      "type": "object",
      "properties": {
        "web": {
          "type": "string",
          "description": "Web endpoint"
        },
        "spark": {
          "type": "string",
          "description": "Spark endpoint"
        },
        "artifacts": {
          "type": "string",
          "description": "Artifacts endpoint"
        },
        "sql": {
          "type": "string",
          "description": "SQL endpoint"
        }
      }
    }
```
