### PR TITLE
Implement HintTextField with IntelliJ SDK to match IntelliJ theme

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewClusterForm.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/serverexplore/ui/AddNewClusterForm.form
@@ -80,7 +80,9 @@
                       </component>
                       <component id="ef732" class="com.microsoft.azuretools.ijidea.ui.HintTextField" binding="clusterNameOrUrlField" custom-create="true">
                         <constraints>
-                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                            <preferred-size width="300" height="-1"/>
+                          </grid>
                         </constraints>
                         <properties/>
                       </component>
@@ -193,9 +195,7 @@
                       </component>
                       <component id="7bd75" class="com.microsoft.azuretools.ijidea.ui.HintTextField" binding="arisHostField" custom-create="true" default-binding="true">
                         <constraints>
-                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                            <preferred-size width="150" height="-1"/>
-                          </grid>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties/>
                       </component>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/HintTextField.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/HintTextField.java
@@ -1,66 +1,11 @@
 package com.microsoft.azuretools.ijidea.ui;
 
-import com.intellij.util.ui.UIUtil;
+import com.intellij.ui.components.JBTextField;
+import org.jetbrains.annotations.NotNull;
 
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
-
-/**
- * Created by vlashch on 2/13/17.
- */
-public class HintTextField extends JTextField implements FocusListener {
-
-    private final String hint;
-    private boolean showingHint;
-
-    public HintTextField(final String hint) {
-        super(hint);
-        setText(hint);
-        this.hint = hint;
-        setShowingHint(true);
-        super.addFocusListener(this);
-    }
-
-    @Override
-    public void focusGained(FocusEvent e) {
-        if (this.getText().isEmpty()) {
-            setShowingHint(false);
-            super.setText("");
-        }
-    }
-
-    @Override
-    public void focusLost(FocusEvent e) {
-        if (this.getText().isEmpty()) {
-            setShowingHint(true);
-            super.setText(hint);
-        }
-    }
-
-    @Override
-    public String getText() {
-        return showingHint ? "" : super.getText();
-    }
-
-    @Override
-    public void setText(String t) {
-        if (t == null || t.isEmpty()) return;
-        super.setText(t);
-        setShowingHint(false);
-    }
-
-    private void setShowingHint(boolean showingHint) {
-        this.showingHint = showingHint;
-        if (!showingHint) {
-            if (UIUtil.isUnderDarcula()) {
-                super.setForeground(new Color(187, 187, 187));
-            } else {
-                super.setForeground(Color.BLACK);
-            }
-        } else {
-            super.setForeground(Color.GRAY);
-        }
+public class HintTextField extends JBTextField {
+    public HintTextField(@NotNull String hint) {
+        super();
+        getEmptyText().setText(hint);
     }
 }


### PR DESCRIPTION
 - To address #3626  
 - Now `Link A Cluster` dialog in high contrast theme will look like the following way
![image](https://user-images.githubusercontent.com/32627233/67734094-1727a780-fa3b-11e9-882f-7aa2e163087a.png)
![fix_issue_3626](https://user-images.githubusercontent.com/32627233/67734257-80a7b600-fa3b-11e9-968c-5784938dfecb.gif)
