### PR TITLE
Refine the upload path in gen2 deploy

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/ADLSGen2Deploy.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/ADLSGen2Deploy.java
@@ -39,6 +39,8 @@ import rx.exceptions.Exceptions;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ADLSGen2Deploy implements Deployable, ILogger {
     @NotNull
@@ -97,8 +99,12 @@ public class ADLSGen2Deploy implements Deployable, ILogger {
 
     @Nullable
     private String getArtifactUploadedPath(String rootPath) throws URISyntaxException {
-        //convert https://fullAccountName/fileSystem/sparksubmission/guid/artifact.jar to /SparkSubmission/xxxx
-        int index = rootPath.indexOf("SparkSubmission");
-        return String.format("/%s", rootPath.substring(index));
+        //convert https://fullAccountName/fileSystem/subfolder/guid/artifact.jar to /subfolder/xxxx
+        Matcher m = Pattern.compile(SparkBatchJob.AdlsGen2RestfulPathPattern).matcher(rootPath);
+        if (m.find()) {
+            return m.group("subpath");
+        }
+
+        throw new URISyntaxException(rootPath, "Cannot get valid artifact path");
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchJob.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchJob.java
@@ -64,7 +64,7 @@ import static rx.exceptions.Exceptions.propagate;
 
 public class SparkBatchJob implements ISparkBatchJob, ILogger {
     public static final String WebHDFSPathPattern = "^(https?://)([^/]+)(/.*)?(/webhdfs/v1)(/.*)?$";
-    public static final String AdlsGen2RestfulPathPattern = "^(https://)(?<accountName>[^/.\\s]+)(\\.)(dfs\\.core\\.windows\\.net)(/)(?<fileSystem>[^/.\\s]+)(/[^/.\\s]+)*/?$";
+    public static final String AdlsGen2RestfulPathPattern = "^(https://)(?<accountName>[^/.\\s]+)(\\.)(dfs\\.core\\.windows\\.net)(/)(?<fileSystem>[^/.\\s]+)(?<subpath>/[^\\s]+)*/?$";
 
     @Nullable
     private String currentLogUrl;


### PR DESCRIPTION
Since for esp cluster ,the uploaded path changes from /SparkSubmission/xx  to /user/username/xx ,
refine the getuploadedpath method