### PR TITLE
Fix creation dialog will not auto select previous deployment target

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/slimui/WebAppSlimSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/webapp/webappconfig/slimui/WebAppSlimSettingPanel.java
@@ -224,6 +224,8 @@ public class WebAppSlimSettingPanel extends AzureSettingPanel<WebAppConfiguratio
                 }
             }
         });
+        cbArtifact.addItemListener((itemEvent)->updateArtifactConfiguration());
+        cbMavenProject.addItemListener((itemEvent)->updateArtifactConfiguration());
 
         JLabel labelForNewSlotName = new JLabel("Slot Name");
         labelForNewSlotName.setLabelFor(txtNewSlotName);
@@ -373,7 +375,6 @@ public class WebAppSlimSettingPanel extends AzureSettingPanel<WebAppConfiguratio
         }
         configuration.setDeployToRoot(chkToRoot.isVisible() && chkToRoot.isSelected());
         configuration.setOpenBrowserAfterDeployment(chkOpenBrowser.isSelected());
-        this.webAppConfiguration = configuration;
     }
 
     private void selectWebApp() {
@@ -454,6 +455,11 @@ public class WebAppSlimSettingPanel extends AzureSettingPanel<WebAppConfiguratio
         cbxWebApp.setEnabled(false);
         cbxWebApp.addItem(REFRESHING_WEBAPP);
         presenter.loadWebApps(force);
+    }
+
+    private void updateArtifactConfiguration() {
+        webAppConfiguration.setTargetName(getTargetName());
+        webAppConfiguration.setTargetPath(getTargetPath());
     }
 
     class WebAppCombineBoxRender extends ListCellRendererWrapper {


### PR DESCRIPTION
IntelliJ will execute `apply()` continuously to update configuration with ui, we used to update dialog configuration in this dialog #3672, but this will clear attributes stored in dialog configuration too, which will make deployment dialog always show the first app service as the deployment target.(Plugin will auto select webapp which name equals to configuration, however, configuration will be replaced in `apply()`)

 so fix #3672 by update dialog configuration target value in correspond ui component action listener.