### PR TITLE
Fix non-existent MFA cluster property caused NPE issue

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/ClusterManagerEx.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/ClusterManagerEx.java
@@ -410,10 +410,11 @@ public class ClusterManagerEx implements ILogger {
 
         isListAdditionalClusterSuccess = false;
         Gson gson = new Gson();
-        String additionalClustersJson = DefaultLoader.getIdeHelper().getApplicationProperty(CommonConst.HDINSIGHT_ADDITIONAL_CLUSTERS);
-        String additionalMfaClustersJson = DefaultLoader.getIdeHelper().getApplicationProperty(CommonConst.HDINSIGHT_ADDITIONAL_MFA_CLUSTERS);
-        String livyLinkClustersJson = DefaultLoader.getIdeHelper().getApplicationProperty(CommonConst.HDINSIGHT_LIVY_LINK_CLUSTERS);
-        String sqlBigDataClustersJson = DefaultLoader.getIdeHelper().getApplicationProperty(CommonConst.SQL_BIG_DATA_LIVY_LINK_CLUSTERS);
+        final String DEFAULT_EMPTY_JSON = "[]";
+        String additionalClustersJson = DefaultLoader.getIdeHelper().getPropertyWithDefault(CommonConst.HDINSIGHT_ADDITIONAL_CLUSTERS, DEFAULT_EMPTY_JSON);
+        String additionalMfaClustersJson = DefaultLoader.getIdeHelper().getPropertyWithDefault(CommonConst.HDINSIGHT_ADDITIONAL_MFA_CLUSTERS, DEFAULT_EMPTY_JSON);
+        String livyLinkClustersJson = DefaultLoader.getIdeHelper().getPropertyWithDefault(CommonConst.HDINSIGHT_LIVY_LINK_CLUSTERS, DEFAULT_EMPTY_JSON);
+        String sqlBigDataClustersJson = DefaultLoader.getIdeHelper().getPropertyWithDefault(CommonConst.SQL_BIG_DATA_LIVY_LINK_CLUSTERS, DEFAULT_EMPTY_JSON);
         if (!StringHelper.isNullOrWhiteSpace(additionalClustersJson) && !StringHelper.isNullOrWhiteSpace(livyLinkClustersJson)) {
             try {
                 hdiAdditionalClusters = gson.fromJson(additionalClustersJson, new TypeToken<ArrayList<HDInsightAdditionalClusterDetail>>() {


### PR DESCRIPTION
 - Currently when we start IntelliJ, we will see an NPE error with stacktrace below. This PR is to fix the following NPE issue.
```
java.lang.NullPointerException
	at com.microsoft.azure.hdinsight.common.ClusterManagerEx.loadAdditionalClusters(ClusterManagerEx.java:441)
	at com.microsoft.azure.hdinsight.common.ClusterManagerEx.getClusterDetails(ClusterManagerEx.java:239)
	at com.microsoft.azure.sqlbigdata.serverexplore.SqlBigDataClusterModule.refreshItems(SqlBigDataClusterModule.java:53)
	at com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode.refreshItems(RefreshableNode.java:94)
	at com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode$2.run(RefreshableNode.java:160)
	at com.microsoft.intellij.helpers.IDEHelperImpl$2$1.run(IDEHelperImpl.java:158)
	at com.intellij.openapi.progress.impl.CoreProgressManager$TaskRunnable.run(CoreProgressManager.java:894)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:169)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:591)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:537)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:59)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:156)
	at com.intellij.openapi.progress.impl.CoreProgressManager$4.run(CoreProgressManager.java:408)
	at com.intellij.openapi.application.impl.ApplicationImpl$1.run(ApplicationImpl.java:294)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```