### PR TITLE
Show specific job detail page URL for submitted Synapse Spark batch job

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/ArcadiaSparkBatchRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/ArcadiaSparkBatchRunner.kt
@@ -56,8 +56,6 @@ class ArcadiaSparkBatchRunner : SparkBatchJobRunner() {
                 throw ExecutionException("Synapse Spark pool is not selected")
             }
         }
-        val submission = SparkBatchArcadiaSubmission(
-                arcadiaModel.tenantId, arcadiaModel.sparkWorkspace, URI.create(arcadiaModel.livyUri), arcadiaModel.jobName)
 
         val compute = try {
             ArcadiaSparkComputeManager.getInstance().findCompute(
@@ -69,6 +67,14 @@ class ArcadiaSparkBatchRunner : SparkBatchJobRunner() {
                 "Can't find Synapse Spark pool (${arcadiaModel.sparkWorkspace}:${arcadiaModel.sparkCompute})"
                         + " at tenant ${arcadiaModel.tenantId}.")
         }
+
+        val submission = SparkBatchArcadiaSubmission(
+            arcadiaModel.tenantId,
+            arcadiaModel.sparkWorkspace,
+            URI.create(arcadiaModel.livyUri),
+            arcadiaModel.jobName,
+            compute.workSpace.webUrl
+        )
 
         if (submitModel.jobUploadStorageModel.storageAccountType == SparkSubmitStorageType.BLOB) {
             val fsRoot = WasbUri.parse(arcadiaModel.jobUploadStorageModel.uploadPath

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/ArcadiaSparkBatchRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/ArcadiaSparkBatchRunner.kt
@@ -57,7 +57,7 @@ class ArcadiaSparkBatchRunner : SparkBatchJobRunner() {
             }
         }
         val submission = SparkBatchArcadiaSubmission(
-                arcadiaModel.tenantId, arcadiaModel.sparkWorkspace, URI.create(arcadiaModel.livyUri))
+                arcadiaModel.tenantId, arcadiaModel.sparkWorkspace, URI.create(arcadiaModel.livyUri), arcadiaModel.jobName)
 
         val compute = try {
             ArcadiaSparkComputeManager.getInstance().findCompute(

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchArcadiaSubmission.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/SparkBatchArcadiaSubmission.java
@@ -61,13 +61,16 @@ public class SparkBatchArcadiaSubmission extends SparkBatchSubmission {
     private final @NotNull String workspaceName;
     private final @NotNull String tenantId;
     private final @NotNull URI livyUri;
+    private final @NotNull String jobName;
 
     public SparkBatchArcadiaSubmission(final @NotNull String tenantId,
                                        final @NotNull String workspaceName,
-                                       final @NotNull URI livyUri) {
+                                       final @NotNull URI livyUri,
+                                       final @NotNull String jobName) {
         this.workspaceName = workspaceName;
         this.tenantId = tenantId;
         this.livyUri = UriUtil.normalizeWithSlashEnding(livyUri);
+        this.jobName = jobName;
     }
 
     @Override
@@ -188,8 +191,13 @@ public class SparkBatchArcadiaSubmission extends SparkBatchSubmission {
                                 .findWorkspace(getTenantId(), getWorkspaceName())
                                 .toBlocking()
                                 .first();
-                return new URL(String.format("https://web.azuresynapse.net/monitoring/sparkapplication?" +
+                // Currently we just concatenate the string and show it as the Spark job detail page URL.
+                // We don't check if the URL is valid or not because we have never met any exceptions when clicking the
+                // link during test. If there are errors reported by user that URL is invalid in the future, we will
+                // add more validation code here at that time.
+                return new URL(String.format("https://web.azuresynapse.net/monitoring/sparkapplication/%s?" +
                                 "workspace=%s&livyId=%d&sparkPoolName=%s",
+                        this.jobName,
                         workSpace.getId(),
                         livyId,
                         matcher.group("compute")));


### PR DESCRIPTION
Currently we just concatenate the string and show it as the Spark job detail page URL. We don't check if the URL is valid or not because we have never met any exceptions when clicking the
link during test. If there are errors reported by user that URL is invalid in the future, we will
add more validation code at that time.
