### PR TITLE
Encode special characters in ADLS Gen2 URI

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkSubmissionContentPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/SparkSubmissionContentPanel.kt
@@ -38,7 +38,6 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.fields.ExpandableTextField
 import com.intellij.ui.table.JBTable
 import com.intellij.uiDesigner.core.GridConstraints.*
-import com.intellij.util.execution.ParametersListUtil
 import com.microsoft.azure.cosmosspark.common.JXHyperLinkWithUri
 import com.microsoft.azure.hdinsight.common.AbfsUri
 import com.microsoft.azure.hdinsight.common.ClusterManagerEx
@@ -298,10 +297,10 @@ open class SparkSubmissionContentPanel(private val myProject: Project, val type:
     }
 
     private val refJarsPrompt: JLabel = JLabel("Referenced Jars(spark.jars)").apply {
-        toolTipText = "Files to be placed on the java classpath; The path needs to be an Azure Blob Storage Path (path started with wasb://); Multiple paths should be split by semicolon (;)"
+        toolTipText = "Files to be placed on the java classpath. Multiple paths should be split by space."
     }
 
-    private val referencedJarsTextField: TextFieldWithBrowseButton = TextFieldWithBrowseButton(ExpandableTextField(ParametersListUtil.COLON_LINE_PARSER, ParametersListUtil.COLON_LINE_JOINER).apply {
+    private val referencedJarsTextField: TextFieldWithBrowseButton = TextFieldWithBrowseButton(ExpandableTextField().apply {
         toolTipText = "Artifact from remote storage account."
     }).apply {
         textField.name = "referencedJarsTextFieldText"
@@ -322,17 +321,17 @@ open class SparkSubmissionContentPanel(private val myProject: Project, val type:
                     // Warning: We have overridden toString method in class AdlsGen2VirtualFile
                     // If we implement virtual file for Gen1, blob or other storage later, remember to implement toString method
                     // for those virtual file class later.
-                    text = chooseFiles.joinToString(";") { vf -> vf.toString() }
+                    text = chooseFiles.joinToString(" ") { vf -> vf.toString() }
                 }
             }
         }
     }
 
     private val refFilesPrompt: JLabel = JLabel("Referenced Files(spark.files)").apply {
-        toolTipText = "Files to be placed in executor working directory. The path needs to be an Azure Blob Storage Path (path started with wasb://); Multiple paths should be split by semicolon (;) "
+        toolTipText = "Files to be placed in executor working directory. Multiple paths should be split by space."
     }
 
-    private val referencedFilesTextField: TextFieldWithBrowseButton = TextFieldWithBrowseButton(ExpandableTextField(ParametersListUtil.COLON_LINE_PARSER, ParametersListUtil.COLON_LINE_JOINER).apply {
+    private val referencedFilesTextField: TextFieldWithBrowseButton = TextFieldWithBrowseButton(ExpandableTextField().apply {
         toolTipText = refFilesPrompt.toolTipText
     }).apply {
         textField.name = "referencedFilesTextFieldText"
@@ -352,7 +351,7 @@ open class SparkSubmissionContentPanel(private val myProject: Project, val type:
                     // Warning: We have overridden toString method in class AdlsGen2VirtualFile
                     // If we implement virtual file for Gen1, blob or other storage later, remember to implement toString method
                     // for those virtual file class later.
-                    text = chooseFiles.joinToString(";") { vf -> vf.toString() }
+                    text = chooseFiles.joinToString(" ") { vf -> vf.toString() }
                 }
             }
         }
@@ -613,8 +612,8 @@ open class SparkSubmissionContentPanel(private val myProject: Project, val type:
 
             localArtifactTextField.text = data.localArtifactPath
             commandLineTextField.text = data.commandLineArgs.joinToString(" ")
-            referencedJarsTextField.text = data.referenceJars.joinToString(";")
-            referencedFilesTextField.text = data.referenceFiles.joinToString(";")
+            referencedJarsTextField.text = data.referenceJars.joinToString(" ")
+            referencedFilesTextField.text = data.referenceFiles.joinToString(" ")
 
             // update job configuration table
             if (jobConfigurationTable.model != data.tableModel) {
@@ -647,13 +646,13 @@ open class SparkSubmissionContentPanel(private val myProject: Project, val type:
         val selectedClusterName = viewModel.clusterSelection.selectedCluster?.name
         val selectedClusterId = viewModel.clusterSelection.toSelectClusterByIdBehavior.value as? String
 
-        val referencedFileList = referencedFilesTextField.text.split(";").dropLastWhile { it.isEmpty() }
+        val referencedFileList = referencedFilesTextField.text.split(" ").dropLastWhile { it.isEmpty() }
                 .asSequence()
                 .map { it.trim() }
                 .filter { s -> !s.isEmpty() }
                 .toList()
 
-        val uploadedFilePathList = referencedJarsTextField.text.split(";").dropLastWhile { it.isEmpty() }
+        val uploadedFilePathList = referencedJarsTextField.text.split(" ").dropLastWhile { it.isEmpty() }
                 .asSequence()
                 .map { it.trim() }
                 .filter { s -> !s.isEmpty() }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/filesystem/ADLSGen2FileSystem.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/filesystem/ADLSGen2FileSystem.java
@@ -73,7 +73,7 @@ public class ADLSGen2FileSystem extends AzureStorageVirtualFileSystem {
                     // sample remoteFile.getName(): sub/path/to/SparkSubmission
                     .map(remoteFile -> new AdlsGen2VirtualFile(
                             (AbfsUri) AbfsUri.parse(rootUrl.toString())
-                                    .resolveAsRoot(AzureStorageUri.encodePath(remoteFile.getName())),
+                                    .resolveAsRoot(AzureStorageUri.encodeAndNormalizePath(remoteFile.getName())),
                             remoteFile.isDirectory(),
                             this))
                     .doOnNext(file -> file.setParent(vf))

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/filesystem/ADLSGen2FileSystem.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/filesystem/ADLSGen2FileSystem.java
@@ -24,6 +24,7 @@ package com.microsoft.azure.hdinsight.spark.ui.filesystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileListener;
 import com.microsoft.azure.hdinsight.common.AbfsUri;
+import com.microsoft.azure.hdinsight.common.AzureStorageUri;
 import com.microsoft.azure.hdinsight.common.UriUtil;
 import com.microsoft.azure.hdinsight.sdk.common.HttpObservable;
 import com.microsoft.azure.hdinsight.sdk.common.errorresponse.ForbiddenHttpErrorStatus;
@@ -67,12 +68,12 @@ public class ADLSGen2FileSystem extends AzureStorageVirtualFileSystem {
             // sample rootUrl: https://accountName.dfs.core.windows.net/fileSystem
             URL rootUrl = this.rootPathUri.getUrl();
             // sample directoryParam: sub/path/to
-            URI directoryParam = vf.getAbfsUri().getDirectoryParam();
-            childrenList = this.op.list(rootUrl.toString(), directoryParam.toString())
+            String directoryParam = vf.getAbfsUri().getDirectoryParam();
+            childrenList = this.op.list(rootUrl.toString(), directoryParam)
                     // sample remoteFile.getName(): sub/path/to/SparkSubmission
                     .map(remoteFile -> new AdlsGen2VirtualFile(
-                            AbfsUri.parse(UriUtil.normalizeWithSlashEnding(URI.create(rootUrl.toString()))
-                                    .resolve(remoteFile.getName()).toString()),
+                            (AbfsUri) AbfsUri.parse(rootUrl.toString())
+                                    .resolveAsRoot(AzureStorageUri.encodePath(remoteFile.getName())),
                             remoteFile.isDirectory(),
                             this))
                     .doOnNext(file -> file.setParent(vf))

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/filesystem/AdlsGen2VirtualFile.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/ui/filesystem/AdlsGen2VirtualFile.kt
@@ -29,7 +29,7 @@ import com.microsoft.azuretools.azurecommons.helpers.Nullable
 
 open class AdlsGen2VirtualFile(val abfsUri: AbfsUri, private val myIsDirectory: Boolean, private val myFileSystem: VirtualFileSystem) : AzureStorageVirtualFile() {
     private var parent: VirtualFile? = null
-    override fun getPath(): String = abfsUri.url.path
+    override fun getPath(): String = abfsUri.path
     override fun getName(): String {
         return path.substring(path.lastIndexOf("/") + 1)
     }

--- a/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/common/AbfsUriScenario.kt
+++ b/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/common/AbfsUriScenario.kt
@@ -27,8 +27,16 @@ import cucumber.api.java.en.Given
 import cucumber.api.java.en.Then
 import java.util.*
 import java.util.stream.Collectors
+import kotlin.test.assertEquals
 
 class AbfsUriScenario {
+    data class AbfsUriAndProperties(val url: String,
+                                    val accountName: String,
+                                    val fileSystem: String,
+                                    val rawPath: String,
+                                    val path: String,
+                                    val directoryParam: String)
+
     private var restfulGen2Paths: List<String> = emptyList()
     private var abfsUris: List<String> = emptyList()
 
@@ -75,20 +83,23 @@ class AbfsUriScenario {
         }
     }
 
-    @Then("^the Gen two directory param should be$")
-    fun gen2SubPathShouldBe(expectedSubPath: DataTable) {
-        val actualSubPath = this.abfsUris.stream()
-            .map { path ->
-                try {
-                    AbfsUri.parse(path).directoryParam.toString()
-                } catch (ex: Throwable) {
-                    "invalid Gen2 URI"
-                }
+    @Then("^properties of abfs URI should be$")
+    fun pathAndRawPathShouldBe(checkTable: List<AbfsUriAndProperties>) {
+        checkTable.forEach {
+            try {
+                val abfsUri = AbfsUri.parse(it.url)
+                assertEquals(abfsUri.accountName, it.accountName)
+                assertEquals(abfsUri.fileSystem, it.fileSystem)
+                assertEquals(abfsUri.rawPath, it.rawPath)
+                assertEquals(abfsUri.path, it.path)
+                assertEquals(abfsUri.directoryParam, it.directoryParam)
+            } catch (ex: Throwable) {
+                assertEquals("<invalid>", it.accountName, "Get error when parsing accountName from AbfsUri ${it.url}. ${ex.message}")
+                assertEquals("<invalid>", it.fileSystem, "Get error when parsing fileSystem from AbfsUri ${it.url}. ${ex.message}")
+                assertEquals("<invalid>", it.rawPath, "Get error when parsing rawPath from AbfsUri ${it.url}. ${ex.message}")
+                assertEquals("<invalid>", it.path, "Get error when parsing path from AbfsUri ${it.url}. ${ex.message}")
+                assertEquals("<invalid>", it.directoryParam, "Get error when parsing directoryParam from AbfsUri ${it.url}. ${ex.message}")
             }
-            .collect(Collectors.toList())
-
-        (0 until actualSubPath.size).forEach {
-            assert(actualSubPath[it] == expectedSubPath.asList(String::class.java)[it])
         }
     }
 }

--- a/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/common/AbfsUriScenario.kt
+++ b/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/common/AbfsUriScenario.kt
@@ -84,14 +84,14 @@ class AbfsUriScenario {
     }
 
     @Then("^properties of abfs URI should be$")
-    fun pathAndRawPathShouldBe(checkTable: List<AbfsUriAndProperties>) {
+    fun abfsUriPropertiesShouldBe(checkTable: List<AbfsUriAndProperties>) {
         checkTable.forEach {
             try {
                 val abfsUri = AbfsUri.parse(it.url)
                 assertEquals(abfsUri.accountName, it.accountName)
                 assertEquals(abfsUri.fileSystem, it.fileSystem)
                 assertEquals(abfsUri.rawPath, it.rawPath)
-                assertEquals(abfsUri.path, it.path)
+                assertEquals(abfsUri.getPath(), it.path)
                 assertEquals(abfsUri.directoryParam, it.directoryParam)
             } catch (ex: Throwable) {
                 assertEquals("<invalid>", it.accountName, "Get error when parsing accountName from AbfsUri ${it.url}. ${ex.message}")

--- a/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/common/AdlUriScenario.kt
+++ b/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/common/AdlUriScenario.kt
@@ -66,7 +66,7 @@ class AdlUriScenario {
             try {
                 val adlUri = AdlUri.parse(it.uri)
 
-                assertEquals(it.path, adlUri.path.toString(), "Check ADL Gen1 URI ${it.uri} path parameter")
+                assertEquals(it.path, adlUri.getPath(), "Check ADL Gen1 URI ${it.uri} path parameter")
                 assertEquals(it.storageName, adlUri.storageName.toString(), "Check ADL Gen1 URI ${it.uri} storage parameter")
             } catch (ex: UnknownFormatConversionException) {
                 assertEquals(it.path, "<invalid>", "Get ${ex.message} when parsing ${it.uri} to GEN 1 AdlURI")

--- a/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/common/WasbUriScenario.kt
+++ b/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/common/WasbUriScenario.kt
@@ -67,7 +67,7 @@ class WasbUriScenario {
             try {
                 val wasbUri = WasbUri.parse(it.uri)
 
-                assertEquals(it.path, wasbUri.path.toString(), "Check Wasb URI ${it.uri} path parameter")
+                assertEquals(it.path, wasbUri.getPath(), "Check Wasb URI ${it.uri} path parameter")
                 assertEquals(it.account, wasbUri.storageAccount.toString(), "Check Wasb URI ${it.uri} account parameter")
                 assertEquals(it.container, wasbUri.container.toString(), "Check Wasb URI ${it.uri} container parameter")
                 assertEquals(it.endpointSuffix, wasbUri.endpointSuffix.toString(), "Check Wasb URI ${it.uri} endpointSuffix parameter")
@@ -124,7 +124,7 @@ class WasbUriScenario {
             val rawPath = it.rawPath
             val expectedEncodedPath = it.encodedPath
             try {
-                assertEquals(AzureStorageUri.encodePath(rawPath), expectedEncodedPath, "Check encode path $rawPath")
+                assertEquals(AzureStorageUri.encodeAndNormalizePath(rawPath), expectedEncodedPath, "Check encode path $rawPath")
             } catch (ex: Throwable) {
                 assertEquals("<invalid>", expectedEncodedPath, "Get error when encode path $rawPath. ${ex.message}")
             }

--- a/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/common/WasbUriScenario.kt
+++ b/Utils/hdinsight-node-common/Test/java/com/microsoft/azure/hdinsight/common/WasbUriScenario.kt
@@ -33,6 +33,7 @@ class WasbUriScenario {
     data class UrlUriEqualEntry(val src: String, val dest: String, val isEqualed: Boolean)
     data class UriPathResolveAsRootEntry(val uri: String, val path: String, val result: String)
     data class UriRelativizeCheckEntry(val src: String, val dest: String, val result: String)
+    data class rawPathEncodedPathEntry(val rawPath: String, val encodedPath: String)
 
     @Then("convert Wasb URL restful path to URI should be")
     fun checkWasb2HttpConversion(checkTable: List<UrlUriEntry>) {
@@ -114,6 +115,19 @@ class WasbUriScenario {
                     src.relativize(dest),
                     "Check Wasb URI ${it.src} relativite ${it.dest} as root path"
             )
+        }
+    }
+
+    @Then("^check the encoded path as below$")
+    fun checkEncodedPath(checkTable: List<rawPathEncodedPathEntry>) {
+        checkTable.forEach {
+            val rawPath = it.rawPath
+            val expectedEncodedPath = it.encodedPath
+            try {
+                assertEquals(AzureStorageUri.encodePath(rawPath), expectedEncodedPath, "Check encode path $rawPath")
+            } catch (ex: Throwable) {
+                assertEquals("<invalid>", expectedEncodedPath, "Get error when encode path $rawPath. ${ex.message}")
+            }
         }
     }
 }

--- a/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/common/AbfsUriScenario.feature
+++ b/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/common/AbfsUriScenario.feature
@@ -34,30 +34,25 @@ Feature: ADLS Gen2 URI operation
       | https://accountName.dfs.core.windows.net/fs0/subPath0/         |
       | https://accountName.dfs.core.windows.net/fs0/subPath0/subPath1 |
 
-  Scenario: Get Gen2 directory param from ABFS URI
-    Given ABFS URI is
-      | abfs://accountName.dfs.core.windows.net                        |
-      | abfs://fs0@accountName.dfs.core.windows.net                    |
-      | abfs://fs0@accountName.dfs.core.windows.net/                   |
-      | abfs://fs0@accountName.dfs.core.windows.net/subPath0           |
-      | abfs://fs0@accountName.dfs.core.windows.net/subPath0/          |
-      | abfs://fs0@accountName.dfs.core.windows.net/subPath0/subPath1  |
-      | https://accountName.dfs.core.windows.net                       |
-      | https://accountName.dfs.core.windows.net/fs0                   |
-      | https://accountName.dfs.core.windows.net/fs0/                  |
-      | https://accountName.dfs.core.windows.net/fs0/subPath0          |
-      | https://accountName.dfs.core.windows.net/fs0/subPath0/         |
-      | https://accountName.dfs.core.windows.net/fs0/subPath0/subPath1 |
-    Then the Gen two directory param should be
-      | invalid Gen2 URI  |
-      | /                 |
-      | /                 |
-      | subPath0          |
-      | subPath0/         |
-      | subPath0/subPath1 |
-      | invalid Gen2 URI  |
-      | /                 |
-      | /                 |
-      | subPath0          |
-      | subPath0/         |
-      | subPath0/subPath1 |
+  Scenario: Get properties from ABFS URI
+    Then properties of abfs URI should be
+      | url                                                            | accountName | fileSystem | rawPath             | path               | directoryParam    |
+      | abfs://accountName.dfs.core.windows.net                        | <invalid>   | <invalid>  | <invalid>           | <invalid>          | <invalid>         |
+      | abfs://fs0@accountName.dfs.core.windows.net                    | accountName | fs0        |                     |                    | /                 |
+      | abfs://fs0@accountName.dfs.core.windows.net/                   | accountName | fs0        | /                   | /                  | /                 |
+      | abfs://fs0@accountName.dfs.core.windows.net/subPath0           | accountName | fs0        | /subPath0           | /subPath0          | subPath0          |
+      | abfs://fs0@accountName.dfs.core.windows.net/subPath0/          | accountName | fs0        | /subPath0/          | /subPath0/         | subPath0/         |
+      | abfs://fs0@accountName.dfs.core.windows.net/subPath0/subPath1  | accountName | fs0        | /subPath0/subPath1  | /subPath0/subPath1 | subPath0/subPath1 |
+      | https://accountName.dfs.core.windows.net                       | <invalid>   | <invalid>  | <invalid>           | <invalid>          | <invalid>         |
+      | https://accountName.dfs.core.windows.net/fs0                   | accountName | fs0        |                     |                    | /                 |
+      | https://accountName.dfs.core.windows.net/fs0/                  | accountName | fs0        | /                   | /                  | /                 |
+      | https://accountName.dfs.core.windows.net/fs0/subPath0          | accountName | fs0        | /subPath0           | /subPath0          | subPath0          |
+      | https://accountName.dfs.core.windows.net/fs0/subPath0/         | accountName | fs0        | /subPath0/          | /subPath0/         | subPath0/         |
+      | https://accountName.dfs.core.windows.net/fs0/subPath0/subPath1 | accountName | fs0        | /subPath0/subPath1  | /subPath0/subPath1 | subPath0/subPath1 |
+      | abfs://fs0@accountName.dfs.core.windows.net/new%20%23%25folder | accountName | fs0        | /new%20%23%25folder | /new #%folder      | new #%folder      |
+      | abfs://fs0@accountName.dfs.core.windows.net/.~_@:!$'()*+,;=    | accountName | fs0        | /.~_@:!$'()*+,;=    | /.~_@:!$'()*+,;=   | .~_@:!$'()*+,;=   |
+      | abfs://fs0@accountName.dfs.core.windows.net/aaa%3Fbbb          | accountName | fs0        | /aaa%3Fbbb          | /aaa?bbb           | aaa?bbb           |
+      | abfs://fs0@accountName.dfs.core.windows.net/aaa?bbb            | <invalid>   | <invalid>  | <invalid>           | <invalid>          | <invalid>         |
+      | abfs://fs0@accountName.dfs.core.windows.net/new folder         | <invalid>   | <invalid>  | <invalid>           | <invalid>          | <invalid>         |
+      | abfs://fs0@accountName.dfs.core.windows.net/new#folder         | <invalid>   | <invalid>  | <invalid>           | <invalid>          | <invalid>         |
+      | abfs://fs0@accountName.dfs.core.windows.net/new%folder         | <invalid>   | <invalid>  | <invalid>           | <invalid>          | <invalid>         |

--- a/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/common/WasbUriScenario.feature
+++ b/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/common/WasbUriScenario.feature
@@ -23,18 +23,18 @@ Feature: Wasb URI operation
 
   Scenario: Check Wasb path parameters from URI
     Then check Wasb URI parameters as below
-      | uri                                                                    | container  | endpointSuffix   | path                | account |
-      | wasbs://container0@accountName.blob.core.windows.net                   | container0 | core.windows.net | /                   | accountName |
-      | wasbs://container0@accountName.blob.core.windows.net/                  | container0 | core.windows.net | /                   | accountName |
-      | wasbs://container0@accountName.blob.core.windows.net/subPath0          | container0 | core.windows.net | /subPath0           | accountName |
-      | wasbs://container0@accountName.blob.core.windows.net/subPath0/         | container0 | core.windows.net | /subPath0/          | accountName |
-      | wasbs://container0@accountName.blob.core.windows.net/subPath0/subPath1 | container0 | core.windows.net | /subPath0/subPath1  | accountName |
-      | https://accountName.blob.core.windows.net                              | <invalid>  | <invalid>        | <invalid>           | <invalid>   |
-      | https://accountName.blob.core.windows.net/fs0                          | fs0        | core.windows.net | /                   | accountName |
-      | https://accountName.blob.core.windows.net/                             | <invalid>  | <invalid>        | <invalid>           | <invalid>   |
-      | https://accountName.blob.core.windows.net/fs0/subPath0                 | fs0        | core.windows.net | /subPath0           | accountName |
-      | https://accountName.blob.core.windows.net/fs0/subPath0/                | fs0        | core.windows.net | /subPath0/          | accountName |
-      | https://accountName.blob.core.windows.net/fs0/subPath0/subPath1        | fs0        | core.windows.net | /subPath0/subPath1  | accountName |
+      | uri                                                                    | container  | endpointSuffix   | path               | account     |
+      | wasbs://container0@accountName.blob.core.windows.net                   | container0 | core.windows.net | /                  | accountName |
+      | wasbs://container0@accountName.blob.core.windows.net/                  | container0 | core.windows.net | /                  | accountName |
+      | wasbs://container0@accountName.blob.core.windows.net/subPath0          | container0 | core.windows.net | /subPath0          | accountName |
+      | wasbs://container0@accountName.blob.core.windows.net/subPath0/         | container0 | core.windows.net | /subPath0/         | accountName |
+      | wasbs://container0@accountName.blob.core.windows.net/subPath0/subPath1 | container0 | core.windows.net | /subPath0/subPath1 | accountName |
+      | https://accountName.blob.core.windows.net                              | <invalid>  | <invalid>        | <invalid>          | <invalid>   |
+      | https://accountName.blob.core.windows.net/fs0                          | fs0        | core.windows.net | /                  | accountName |
+      | https://accountName.blob.core.windows.net/                             | <invalid>  | <invalid>        | <invalid>          | <invalid>   |
+      | https://accountName.blob.core.windows.net/fs0/subPath0                 | fs0        | core.windows.net | /subPath0          | accountName |
+      | https://accountName.blob.core.windows.net/fs0/subPath0/                | fs0        | core.windows.net | /subPath0/         | accountName |
+      | https://accountName.blob.core.windows.net/fs0/subPath0/subPath1        | fs0        | core.windows.net | /subPath0/subPath1 | accountName |
 
   Scenario: Check Wasb URI equality
     Then check Wasb URI equality as below
@@ -54,15 +54,20 @@ Feature: Wasb URI operation
 
   Scenario: Check Wasb URI resolve as root path
     Then check Wasb URI resolve as root path as below
-      | uri                                                       | path     | result                                                        |
-      | wasbs://container0@account.blob.core.windows.net/         | sp0      | wasbs://container0@account.blob.core.windows.net/sp0          |
-      | wasbs://container0@account.blob.core.windows.net          | sp0      | wasbs://container0@account.blob.core.windows.net/sp0          |
-      | wasbs://container0@account.blob.core.windows.net/sp0      | sp1      | wasbs://container0@account.blob.core.windows.net/sp0/sp1      |
-      | wasbs://container0@account.blob.core.windows.net/sp0/     | sp1      | wasbs://container0@account.blob.core.windows.net/sp0/sp1      |
-      | wasbs://container0@account.blob.core.windows.net/sp0      | /sp1     | wasbs://container0@account.blob.core.windows.net/sp0/sp1      |
-      | wasbs://container0@account.blob.core.windows.net/sp0/     | /sp1     | wasbs://container0@account.blob.core.windows.net/sp0/sp1      |
-      | wasbs://container0@account.blob.core.windows.net/sp0/     | /sp1/    | wasbs://container0@account.blob.core.windows.net/sp0/sp1/     |
-      | wasbs://container0@account.blob.core.windows.net/root/sp0 | sp1      | wasbs://container0@account.blob.core.windows.net/root/sp0/sp1 |
+      | uri                                                       | path                                 | result                                                                               |
+      | wasbs://container0@account.blob.core.windows.net/         | sp0                                  | wasbs://container0@account.blob.core.windows.net/sp0                                 |
+      | wasbs://container0@account.blob.core.windows.net          | sp0                                  | wasbs://container0@account.blob.core.windows.net/sp0                                 |
+      | wasbs://container0@account.blob.core.windows.net/sp0      | sp1                                  | wasbs://container0@account.blob.core.windows.net/sp0/sp1                             |
+      | wasbs://container0@account.blob.core.windows.net/sp0/     | sp1                                  | wasbs://container0@account.blob.core.windows.net/sp0/sp1                             |
+      | wasbs://container0@account.blob.core.windows.net/sp0      | /sp1                                 | wasbs://container0@account.blob.core.windows.net/sp0/sp1                             |
+      | wasbs://container0@account.blob.core.windows.net/sp0/     | /sp1                                 | wasbs://container0@account.blob.core.windows.net/sp0/sp1                             |
+      | wasbs://container0@account.blob.core.windows.net/sp0/     | /sp1/                                | wasbs://container0@account.blob.core.windows.net/sp0/sp1/                            |
+      | wasbs://container0@account.blob.core.windows.net/root/sp0 | sp1                                  | wasbs://container0@account.blob.core.windows.net/root/sp0/sp1                        |
+      | wasbs://container0@account.blob.core.windows.net/         | -a-zA-Z0-9.~_@:!$'()*+,;=            | wasbs://container0@account.blob.core.windows.net/-a-zA-Z0-9.~_@:!$'()*+,;=           |
+      | wasbs://container0@account.blob.core.windows.net          | -a-zA-Z0-9.~_@:!$'()*+,;=/words.txt  | wasbs://container0@account.blob.core.windows.net/-a-zA-Z0-9.~_@:!$'()*+,;=/words.txt |
+      | wasbs://container0@account.blob.core.windows.net          | /-a-zA-Z0-9.~_@:!$'()*+,;=/words.txt | wasbs://container0@account.blob.core.windows.net/-a-zA-Z0-9.~_@:!$'()*+,;=/words.txt |
+      | wasbs://container0@account.blob.core.windows.net/         | -a-zA-Z0-9.~_@:!$'()*+,;=/words.txt  | wasbs://container0@account.blob.core.windows.net/-a-zA-Z0-9.~_@:!$'()*+,;=/words.txt |
+      | wasbs://container0@account.blob.core.windows.net/         | /-a-zA-Z0-9.~_@:!$'()*+,;=/words.txt | wasbs://container0@account.blob.core.windows.net/-a-zA-Z0-9.~_@:!$'()*+,;=/words.txt |
 
   Scenario: Check Wasb URI relativize
     Then check Wasb URI relativize as below
@@ -77,3 +82,13 @@ Feature: Wasb URI operation
       | wasbs://container0@accountName.blob.core.windows.net/sp0/ | wasbs://container0@otherName.blob.core.windows.net/sp1       | <null> |
       | wasbs://container0@accountName.blob.core.windows.net/sp0/ | wasbs://container0@otherName.blob.core.windows.net/sp0/sp1   | <null> |
 
+  Scenario: Encode path
+    Then check the encoded path as below
+      | rawPath            | encodedPath            |
+      | subPath            | subPath                |
+      | /subPath           | /subPath               |
+      | /subPath/file      | /subPath/file          |
+      | new folder         | new%20folder           |
+      | new folder/file    | new%20folder/file      |
+      | .~_@:!$'()*+,;=%?  | .~_@:!$'()*+,;=%25%3F  |
+      | /.~_@:!$'()*+,;=%? | /.~_@:!$'()*+,;=%25%3F |

--- a/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/common/WasbUriScenario.feature
+++ b/Utils/hdinsight-node-common/Test/resources/com/microsoft/azure/hdinsight/common/WasbUriScenario.feature
@@ -84,11 +84,13 @@ Feature: Wasb URI operation
 
   Scenario: Encode path
     Then check the encoded path as below
-      | rawPath            | encodedPath            |
-      | subPath            | subPath                |
-      | /subPath           | /subPath               |
-      | /subPath/file      | /subPath/file          |
-      | new folder         | new%20folder           |
-      | new folder/file    | new%20folder/file      |
-      | .~_@:!$'()*+,;=%?  | .~_@:!$'()*+,;=%25%3F  |
-      | /.~_@:!$'()*+,;=%? | /.~_@:!$'()*+,;=%25%3F |
+      | rawPath                          | encodedPath                     |
+      | subPath                          | subPath                         |
+      | /subPath                         | /subPath                        |
+      | /subPath/file                    | /subPath/file                   |
+      | new folder                       | new%20folder                    |
+      | % ?                              | %25%20%3F                       |
+      | /.~_@:!$'()*+,;=% ?              | /.~_@:!$'()*+,;=%25%20%3F       |
+      | ./.~_@:!$'()*+,;////=%?%?aa//./ | .~_@:!$'()*+,;/=%25%3F%25%3Faa/ |
+      | ./bbb                            | bbb                             |
+      | ./:bbb                           | :bbb                            |

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/AbfsUri.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/AbfsUri.java
@@ -34,14 +34,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class AbfsUri extends AzureStorageUri {
-    public static final String AdlsGen2PathPattern = "^(?<schema>abfss?)://(?<fileSystem>[^/.\\s]+)@(?<accountName>[^/.\\s]+)(\\.)(dfs\\.core\\.windows\\.net)(?<relativePath>(/[^\\s]+)*/?)$";
-    public static final String AdlsGen2RestfulPathPattern = "^(?<schema>https?)://(?<accountName>[^/.\\s]+)(\\.)(dfs\\.core\\.windows\\.net)(/)(?<fileSystem>[^/.\\s]+)(?<relativePath>(/[^\\s]+)*/?)$";
+    public static final String AdlsGen2PathPattern = "^(?<schema>abfss?)://(?<fileSystem>[^/.\\s]+)@(?<accountName>[^/.\\s]+)(\\.)(dfs\\.core\\.windows\\.net)(?<relativePath>(/[-a-zA-Z0-9.~_@:!$'()*+,;=%]+)*/?)$";
+    public static final String AdlsGen2RestfulPathPattern = "^(?<schema>https?)://(?<accountName>[^/.\\s]+)(\\.)(dfs\\.core\\.windows\\.net)(/)(?<fileSystem>[^/.\\s]+)(?<relativePath>(/[-a-zA-Z0-9.~_@:!$'()*+,;=%]+)*/?)$";
     public static final Pattern ABFS_URI_PATTERN = Pattern.compile(AdlsGen2PathPattern, Pattern.CASE_INSENSITIVE);
     public static final Pattern HTTP_URI_PATTERN = Pattern.compile(AdlsGen2RestfulPathPattern, Pattern.CASE_INSENSITIVE);
 
     private final LaterInit<String> fileSystem = new LaterInit<>();
     private final LaterInit<String> accountName = new LaterInit<>();
-    private final LaterInit<String> relativePath = new LaterInit<>();
+    private final LaterInit<String> path = new LaterInit<>();
 
     private AbfsUri(URI rawUri) {
         super(rawUri);
@@ -57,42 +57,43 @@ public final class AbfsUri extends AzureStorageUri {
 
     @Override
     public String getPath() {
-        return relativePath.get();
+        return URI.create(path.get()).getPath();
     }
 
     @Override
-    AzureStorageUri resolve(String path) {
-        return AbfsUri.parse(getUri().resolve(path).toString());
+    public String getRawPath() {
+        return path.get();
     }
 
     @Override
-    AzureStorageUri normalizeWithSlashEnding() {
-        return AbfsUri.parse(UriUtil.normalizeWithSlashEnding(getUri()).toString());
+    AzureStorageUri parseUri(String encodedUri) {
+        return AbfsUri.parse(encodedUri);
     }
 
     @Override
     public URI getUri() {
         return URI.create(String.format("abfs://%s@%s.dfs.core.windows.net%s",
-                getFileSystem(), getAccountName(), getPath()));
+                getFileSystem(), getAccountName(), getRawPath()));
     }
 
     @Override
     public URL getUrl() {
         try {
             return URI.create(String.format("https://%s.dfs.core.windows.net/%s%s",
-                    getAccountName(), getFileSystem(), getPath())).toURL();
+                    getAccountName(), getFileSystem(), getRawPath())).toURL();
         } catch (MalformedURLException ex) {
             throw new IllegalArgumentException(ex.getMessage(), ex);
         }
     }
 
     // get subPath starting without "/" except when subPath is empty
-    public URI getDirectoryParam() {
+    public String getDirectoryParam() {
         return getPath().length() == 0 || getPath().equals("/")
-                ? URI.create("/")
-                : URI.create(getPath().substring(1));
+                ? "/"
+                : getPath().substring(1);
     }
 
+    // We assume rawUri is already encoded
     public static AbfsUri parse(final String rawUri) {
         Matcher matcher;
         if (StringUtils.startsWithIgnoreCase(rawUri, "abfs")) {
@@ -107,7 +108,7 @@ public final class AbfsUri extends AzureStorageUri {
             AbfsUri abfsUri = new AbfsUri(URI.create(rawUri));
             abfsUri.accountName.set(matcher.group("accountName"));
             abfsUri.fileSystem.set(matcher.group("fileSystem"));
-            abfsUri.relativePath.set(matcher.group("relativePath"));
+            abfsUri.path.set(matcher.group("relativePath"));
             return abfsUri;
         }
 

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/AbfsUri.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/AbfsUri.java
@@ -41,7 +41,6 @@ public final class AbfsUri extends AzureStorageUri {
 
     private final LaterInit<String> fileSystem = new LaterInit<>();
     private final LaterInit<String> accountName = new LaterInit<>();
-    private final LaterInit<String> path = new LaterInit<>();
 
     private AbfsUri(URI rawUri) {
         super(rawUri);
@@ -56,18 +55,8 @@ public final class AbfsUri extends AzureStorageUri {
     }
 
     @Override
-    public String getPath() {
-        return URI.create(path.get()).getPath();
-    }
-
-    @Override
-    public String getRawPath() {
-        return path.get();
-    }
-
-    @Override
-    AzureStorageUri parseUri(String encodedUri) {
-        return AbfsUri.parse(encodedUri);
+    AzureStorageUri parseUri(URI encodedUri) {
+        return AbfsUri.parse(encodedUri.toString());
     }
 
     @Override
@@ -108,7 +97,7 @@ public final class AbfsUri extends AzureStorageUri {
             AbfsUri abfsUri = new AbfsUri(URI.create(rawUri));
             abfsUri.accountName.set(matcher.group("accountName"));
             abfsUri.fileSystem.set(matcher.group("fileSystem"));
-            abfsUri.path.set(matcher.group("relativePath"));
+            abfsUri.path.set(URI.create(matcher.group("relativePath")));
             return abfsUri;
         }
 

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/AdlUri.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/AdlUri.java
@@ -44,7 +44,6 @@ public class AdlUri extends AzureStorageUri {
             Pattern.CASE_INSENSITIVE);
 
     private final LaterInit<String> storageName = new LaterInit<>();
-    private final LaterInit<String> path = new LaterInit<>();
 
     private AdlUri(URI rawUri) {
         super(rawUri);
@@ -71,18 +70,8 @@ public class AdlUri extends AzureStorageUri {
     }
 
     @Override
-    public String getPath() {
-        return URI.create(this.path.get()).getPath();
-    }
-
-    @Override
-    public String getRawPath() {
-        return this.path.get();
-    }
-
-    @Override
-    AzureStorageUri parseUri(String encodedUri) {
-        return AdlUri.parse(encodedUri);
+    AzureStorageUri parseUri(URI encodedUri) {
+        return AdlUri.parse(encodedUri.toString());
     }
 
     @Override
@@ -114,7 +103,7 @@ public class AdlUri extends AzureStorageUri {
 
         final String pathMatched = matcher.group("path");
         final String relativePathMatched = URI.create("/" + (pathMatched == null ? "" : pathMatched)).getPath();
-        uri.path.set(relativePathMatched);
+        uri.path.set(URI.create(relativePathMatched));
 
         // TODO: matcher.group("port") is ignored now, should be fixed later
 

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/AdlUri.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/AdlUri.java
@@ -22,9 +22,8 @@
 
 package com.microsoft.azure.hdinsight.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
+import org.apache.commons.lang3.StringUtils;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -73,17 +72,17 @@ public class AdlUri extends AzureStorageUri {
 
     @Override
     public String getPath() {
+        return URI.create(this.path.get()).getPath();
+    }
+
+    @Override
+    public String getRawPath() {
         return this.path.get();
     }
 
     @Override
-    AzureStorageUri resolve(String path) {
-        return AdlUri.parse(getUri().resolve(path).toString());
-    }
-
-    @Override
-    AzureStorageUri normalizeWithSlashEnding() {
-        return AdlUri.parse(UriUtil.normalizeWithSlashEnding(getUri()).toString());
+    AzureStorageUri parseUri(String encodedUri) {
+        return AdlUri.parse(encodedUri);
     }
 
     @Override

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/WasbUri.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/WasbUri.java
@@ -47,7 +47,6 @@ public final class WasbUri extends AzureStorageUri {
     private final LaterInit<String> container = new LaterInit<>();
     private final LaterInit<String> storageAccount = new LaterInit<>();
     private final LaterInit<String> endpointSuffix = new LaterInit<>();
-    private final LaterInit<String> path = new LaterInit<>();
 
     private WasbUri(final URI rawUri) {
         super(rawUri);
@@ -82,18 +81,8 @@ public final class WasbUri extends AzureStorageUri {
     }
 
     @Override
-    public String getPath() {
-        return URI.create(this.path.get()).getPath();
-    }
-
-    @Override
-    public String getRawPath() {
-        return this.path.get();
-    }
-
-    @Override
-    AzureStorageUri parseUri(String encodedUri) {
-        return WasbUri.parse(encodedUri);
+    AzureStorageUri parseUri(URI encodedUri) {
+        return WasbUri.parse(encodedUri.toString());
     }
 
     @Override
@@ -124,7 +113,7 @@ public final class WasbUri extends AzureStorageUri {
 
             final String pathMatched = matcher.group("path");
             final String relativePathMatched = URI.create("/" + (pathMatched == null ? "" : pathMatched)).getPath();
-            wasbUri.path.set(relativePathMatched);
+            wasbUri.path.set(URI.create(relativePathMatched));
 
             return wasbUri;
         }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/WasbUri.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/WasbUri.java
@@ -83,17 +83,17 @@ public final class WasbUri extends AzureStorageUri {
 
     @Override
     public String getPath() {
+        return URI.create(this.path.get()).getPath();
+    }
+
+    @Override
+    public String getRawPath() {
         return this.path.get();
     }
 
     @Override
-    AzureStorageUri resolve(String path) {
-        return WasbUri.parse(getUri().resolve(path).toString());
-    }
-
-    @Override
-    AzureStorageUri normalizeWithSlashEnding() {
-        return WasbUri.parse(UriUtil.normalizeWithSlashEnding(getUri()).toString());
+    AzureStorageUri parseUri(String encodedUri) {
+        return WasbUri.parse(encodedUri);
     }
 
     @Override


### PR DESCRIPTION
 #### Changed 
 - Multiple paths in referenced jars and referenced files should be split by space rather than semicolon
 #### Fixed
 - #3899 Fix VFS for Gen2 storage broken issue when the folder name contains space
 #### Feature Request
 - Currently we only encode URI for user selected jars & files on VFS for Gen2. We should also encode URI for user input ADLS Gen2 URI, ADLS Gen1 URI and Azure Blob URI. Impacted user input text fields contains user input referenced jars/files, Gen2 root path in linked Gen2 storage card, Gen2 root path in linked ESP Gen2 storage card, Gen1 path in linked Gen1 storage card.