### PR TITLE
Fix Intellij development IDEA version to 192

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -55,7 +55,7 @@
   </change-notes>
 
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="182" until-build="182.*"/>
+  <idea-version since-build="192.5728" until-build="192.*"/>
   <resource-bundle>com.microsoft.intellij.ui.messages.messages</resource-bundle>
   <resource-bundle>com.microsoft.intellij.hdinsight.messages.messages</resource-bundle>
   <depends optional="true">org.intellij.scala</depends>


### PR DESCRIPTION
Refer to: https://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+2019.2+Release+%28192.5728.98+build%29+Release+Notes
starting from IDEA 192 official build number 5728