### PR TITLE
Fix SparkBatchJobDebugExecutor equals() stack overflow

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobDebugExecutor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobDebugExecutor.java
@@ -96,28 +96,27 @@ public class SparkBatchJobDebugExecutor extends Executor {
 
     @Override
     public boolean equals(@Nullable Object obj) {
+        if (!(obj instanceof Executor)) {
+            return false;
+        }
+
+        Executor other = (Executor) obj;
         Executor defaultDebugExecutor;
 
         try {
             // Workaround for Issue #2983
             // Mute the error of "Fatal error initializing 'com.intellij.execution.ExecutorRegistry'"
             defaultDebugExecutor = DefaultDebugExecutor.getDebugExecutorInstance();
-        } catch (Exception ignored) {
-            return false;
-        }
 
-        if (obj == null || defaultDebugExecutor == null) {
+            if (defaultDebugExecutor == null) {
+                return false;
+            }
+        } catch (Throwable ignored) {
             return false;
         }
 
         // Intellij requires the executor equaling DefaultDebugExecutor to enable the support for multiple debug tabs
         // And all executors are Singletons, only compare the ID
-        if (!(obj instanceof Executor)) {
-            return false;
-        }
-
-        Executor other = (Executor) obj;
-
         return other.getId().equals(defaultDebugExecutor.getId()) || other.getId().equals(this.getId());
     }
 }


### PR DESCRIPTION
The SparkBatchJobDebugExecutor is registered into system components, whose
equal() will be called when getting components from ServiceManager.getService.
So, check the type at beginning to avoid the infinite loop by
DefaultDebugExecutor.getDebugExecutorInstance()