### PR TITLE
Fix cannot parse joda DateTime from json string issue

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/synapse/models/LibraryRequirements.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/synapse/models/LibraryRequirements.java
@@ -24,7 +24,6 @@
 package com.microsoft.azure.hdinsight.sdk.rest.azure.synapse.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.joda.time.DateTime;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -37,7 +36,7 @@ public class LibraryRequirements {
      * The last update time of the library requirements file.
      */
     @JsonProperty(value = "time", access = JsonProperty.Access.WRITE_ONLY)
-    private DateTime time;
+    private String time;
 
     /**
      * The library requirements.
@@ -56,7 +55,7 @@ public class LibraryRequirements {
      *
      * @return the time value
      */
-    public DateTime time() {
+    public String time() {
         return this.time;
     }
 


### PR DESCRIPTION
When we refresh a workspace to get spark pools in the workspace, we might encounter the following exception.
```
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `org.joda.time.DateTime` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('2020-02-14T09:09:27.1749604Z')
 at [Source: (String)"{"value":[{"properties":{"creationDate":"2020-02-14T10:20:39.73Z","sparkVersion":"2.4","nodeCount":3,"nodeSize":"Medium","nodeSizeFamily":"MemoryOptimized","autoScale":{"enabled":false,"minNodeCount":3,"maxNodeCount":40},"autoPause":{"enabled":true,"delayInMinutes":15},"provisioningState":"Succeeded"},"id":"/subscriptions/051ddeca-1ed6-4d8b-ba6f-1ff561e5f3b3/resourceGroups/mandywtest/providers/Microsoft.Synapse/workspaces/mandyw1025a/bigDataPools/lirsuntest2","name":"lirsuntest2","type":"Microso"[truncated 1362 chars]; line: 1, column: 1530] (through reference chain: com.microsoft.azure.hdinsight.sdk.rest.azure.synapse.models.BigDataPoolResourceInfoListResult["value"]->java.util.ArrayList[2]->com.microsoft.azure.hdinsight.sdk.rest.azure.synapse.models.BigDataPoolResourceInfo["properties"]->com.microsoft.azure.hdinsight.sdk.rest.azure.synapse.models.BigDataPoolResourceInfo$Properties["libraryRequirements"]->com.microsoft.azure.hdinsight.sdk.rest.azure.synapse.models.LibraryRequirements["time"])
```

In this PR, we replace `DateTime` with `String` to avoid this kind of errors.

FYI, to repro the issue, you can try to refresh workspace `mandyw1025a` in subscription `Arcadia Web tooling`. Before this PR, you will get no spark pools after refresh this workspace. If you check the logs, you will find the similar error log as I pasted. With this PR, the spark pools will be successfully listed after refreshing the workspace.