### PR TITLE
Fix Spark remote debug regression caused by executor's job ref not set

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkBatchJobRunConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkBatchJobRunConfiguration.java
@@ -336,6 +336,10 @@ public class LivySparkBatchJobRunConfiguration extends AbstractRunConfiguration
         }
     }
 
+    public void setSparkRemoteBatch(ISparkBatchJob sparkRemoteBatch) {
+        this.sparkRemoteBatch = sparkRemoteBatch;
+    }
+
     public void setRunMode(@NotNull RunMode mode) {
         this.mode = mode;
     }


### PR DESCRIPTION
To address #4061