### PR TITLE
Fix 193 Spark run configuration module selection might be null issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfiguration.kt
@@ -61,9 +61,13 @@ open class SparkScalaLivyConsoleRunConfiguration(project: Project,
     protected var cluster: IClusterDetail? = null
 
     protected val consoleBuilder: SparkScalaConsoleBuilder
-        get() = SparkScalaConsoleBuilder(project, batchRunConfiguration?.modules?.firstOrNull()
-            ?: throw ExecutionException(RuntimeConfigurationError(
-                    "The default module needs to be set in the local run tab of Run Configuration")))
+        get() {
+            batchRunConfiguration?.configurationModule?.setModuleToAnyFirstIfNotSpecified()
+
+            return SparkScalaConsoleBuilder(project, batchRunConfiguration?.modules?.firstOrNull()
+                    ?: throw ExecutionException(RuntimeConfigurationError(
+                            "The default module needs to be set in the local run tab of Run Configuration")))
+        }
 
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> =

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleRunConfiguration.kt
@@ -240,6 +240,8 @@ class SparkScalaLocalConsoleRunConfiguration(
             }
         }
 
+        batchRunConfiguration.configurationModule.setModuleToAnyFirstIfNotSpecified()
+
         state.consoleBuilder = SparkScalaConsoleBuilder(project, batchRunConfiguration.modules.firstOrNull()
                 ?: throw ExecutionException(RuntimeConfigurationError(
                         "The default module needs to be set in the local run tab of Run Configuration")))


### PR DESCRIPTION
To address #4079 exception root cause by auto selecting the first module in list.