### PR TITLE
Fix Spark Livy session regression on Synapse with long not started

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/livy/interactive/Session.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/livy/interactive/Session.java
@@ -461,7 +461,6 @@ public abstract class Session implements AutoCloseable, Closeable, ILogger {
 
     public boolean isStop() {
         return getLastState() == SessionState.SHUTTING_DOWN ||
-                getLastState() == SessionState.NOT_STARTED ||
                 getLastState() == SessionState.DEAD ||
                 getLastState() == SessionState.KILLED ||
                 getLastState() == SessionState.ERROR ||


### PR DESCRIPTION
To address #4139 