### PR TITLE
Enable Trigger TimerTrigger in Azure Explorer

### DIFF
--- a/Utils/azure-explorer-common/pom.xml
+++ b/Utils/azure-explorer-common/pom.xml
@@ -121,6 +121,11 @@
             <!--<systemPath>${project.basedir}/../azuretools-core/lib/azure-keyvault-1.0.0-beta5-SNAPSHOT.jar</systemPath>-->
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.12</version>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.azure.appplatform.v2019_05_01_preview</groupId>
             <artifactId>azure-mgmt-appplatform</artifactId>
             <version>1.0.0-beta-2</version>

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/SubFunctionNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/SubFunctionNode.java
@@ -88,6 +88,7 @@ public class SubFunctionNode extends Node {
         final Map triggerBinding = getTriggerBinding();
         if (triggerBinding == null || !triggerBinding.containsKey("type")) {
             DefaultLoader.getUIHelper().showError(this, String.format("Failed to get trigger of function %s", name));
+            return;
         }
         final String triggerType = (String) triggerBinding.get("type");
         switch (triggerType.toLowerCase()) {

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/SubFunctionNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/SubFunctionNode.java
@@ -22,17 +22,28 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.function;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.microsoft.azure.functions.annotation.AuthorizationLevel;
 import com.microsoft.azure.management.appservice.FunctionApp;
 import com.microsoft.azure.management.appservice.FunctionEnvelope;
+import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
+import com.microsoft.azuretools.core.mvp.model.springcloud.IdHelper;
+import com.microsoft.azuretools.sdkmanage.AzureManager;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.WrappedTelemetryNodeActionListener;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClients;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
 
@@ -44,6 +55,7 @@ public class SubFunctionNode extends Node {
     private static final String SUB_FUNCTION_ICON_PATH = "azure-function-trigger-small.png";
     private static final String HTTP_TRIGGER_URL = "https://%s/api/%s";
     private static final String HTTP_TRIGGER_URL_WITH_CODE = "https://%s/api/%s?code=%s";
+    private static final String NONE_HTTP_TRIGGER_URL = "https://%s/admin/functions/%s";
     private static final String DEFAULT_FUNCTION_KEY = "default";
     private static final String MASTER_FUNCTION_KEY = "_master";
     private FunctionApp functionApp;
@@ -75,9 +87,48 @@ public class SubFunctionNode extends Node {
     private void trigger() {
         final Map binding = getHTTPTriggerBinding();
         if (binding == null) {
-            DefaultLoader.getUIHelper().showInfo(this, "Only HTTP Trigger is supported for now");
-            return;
+            triggerNoneHttpTrigger();
+        } else {
+            triggerHttpTrigger(binding);
         }
+    }
+
+    // Refers https://docs.microsoft.com/mt-mt/Azure/azure-functions/functions-manually-run-non-http
+    private void triggerNoneHttpTrigger() {
+        try {
+            final String masterKey = getFunctionMasterKey();
+            final String targetUrl = String.format(NONE_HTTP_TRIGGER_URL, functionApp.defaultHostName(), this.name);
+            final HttpPost request = new HttpPost(targetUrl);
+            request.setHeader("x-functions-key", masterKey);
+            request.setHeader("Content-Type", "application/json");
+            // Add empty json body, could set some values according to function.json in later pr
+            final StringEntity entity = new StringEntity("{}");
+            request.setEntity(entity);
+            HttpClients.createDefault().execute(request);
+        } catch (IOException e) {
+            DefaultLoader.getUIHelper().showError(this,
+                    String.format("Failed to trigger function %s, %s", this.name, e.getMessage()));
+        }
+    }
+
+    // work around for API getMasterKey failed
+    private String getFunctionMasterKey() throws IOException {
+        final AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
+        final String subscriptionId = IdHelper.getSubscriptionId(functionApp.id());
+        final String resourceGroup = IdHelper.getResourceGroup(functionApp.id());
+        final String tenant = azureManager.getTenantIdBySubscription(subscriptionId);
+        final String authToken = azureManager.getAccessToken(tenant);
+        final String targetUrl = String.format("https://management.azure.com/subscriptions/%s/resourceGroups/%s/" +
+                "providers/Microsoft.Web/sites/%s/host/default/listkeys?api-version=2019-08-01", subscriptionId, resourceGroup, functionApp.name());
+
+        final HttpPost request = new HttpPost(targetUrl);
+        request.setHeader("Authorization", "Bearer " + authToken);
+        CloseableHttpResponse response = HttpClients.createDefault().execute(request);
+        JsonObject jsonObject = new Gson().fromJson(new InputStreamReader(response.getEntity().getContent()), JsonObject.class);
+        return jsonObject.get("masterKey").getAsString();
+    }
+
+    private void triggerHttpTrigger(Map binding) {
         final String authLevel = (String) binding.get("authLevel");
         final String url = StringUtils.equalsIgnoreCase(authLevel, AuthorizationLevel.ANONYMOUS.toString()) ?
                 getHttpTriggerUrl() : getHttpTriggerUrlWithCode();
@@ -91,7 +142,7 @@ public class SubFunctionNode extends Node {
     private String getHttpTriggerUrlWithCode() {
         final Map<String, String> keyMap = functionApp.listFunctionKeys(this.name);
         final String key = keyMap.containsKey(DEFAULT_FUNCTION_KEY) ?
-                keyMap.get(DEFAULT_FUNCTION_KEY) : keyMap.get(MASTER_FUNCTION_KEY);
+                keyMap.get(DEFAULT_FUNCTION_KEY) : keyMap.values().iterator().next();
         return String.format(HTTP_TRIGGER_URL_WITH_CODE, functionApp.defaultHostName(), this.name, key);
     }
 

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/function/AzureFunctionMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/function/AzureFunctionMvpModel.java
@@ -136,7 +136,6 @@ public class AzureFunctionMvpModel {
 
     public List<FunctionEnvelope> listFunctionEnvelopeInFunctionApp(String sid, String id) throws IOException {
         FunctionApp app = getFunctionById(sid, id);
-        app.getMasterKey()
         PagedList<FunctionEnvelope> functions = app.manager().functionApps().listFunctions(app.resourceGroupName(), app.name());
         functions.loadAll();
         return new ArrayList<>(functions);

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/function/AzureFunctionMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/function/AzureFunctionMvpModel.java
@@ -136,6 +136,7 @@ public class AzureFunctionMvpModel {
 
     public List<FunctionEnvelope> listFunctionEnvelopeInFunctionApp(String sid, String id) throws IOException {
         FunctionApp app = getFunctionById(sid, id);
+        app.getMasterKey()
         PagedList<FunctionEnvelope> functions = app.manager().functionApps().listFunctions(app.resourceGroupName(), app.name());
         functions.loadAll();
         return new ArrayList<>(functions);


### PR DESCRIPTION
Enable Trigger TimerTrigger in Azure Explorer, refers https://docs.microsoft.com/mt-mt/Azure/azure-functions/functions-manually-run-non-http, related feature request https://github.com/Azure/azure-libraries-for-java/issues/1155

As SDK FunctionApp.getMasterKey is out of date(https://github.com/Azure/azure-libraries-for-java/issues/1154), calling List Host Keys API manually as workaround.