### PR TITLE
Fix bug introduced by coding style PR

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosspark/serverexplore/ui/CosmosSparkProvisionDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosspark/serverexplore/ui/CosmosSparkProvisionDialog.java
@@ -37,7 +37,6 @@ import com.intellij.ui.HideableDecorator;
 import com.microsoft.azure.cosmosspark.common.IntegerWithErrorHintedField;
 import com.microsoft.azure.cosmosspark.common.JXHyperLinkWithUri;
 import com.microsoft.azure.cosmosspark.common.TextWithErrorHintedField;
-import com.microsoft.azure.cosmosspark.common.Validatable;
 import com.microsoft.azure.cosmosspark.serverexplore.CosmosSparkClusterProvisionCtrlProvider;
 import com.microsoft.azure.cosmosspark.serverexplore.CosmosSparkClusterProvisionSettingsModel;
 import com.microsoft.azure.cosmosspark.serverexplore.cosmossparknode.CosmosSparkADLAccountNode;
@@ -306,10 +305,10 @@ public class CosmosSparkProvisionDialog extends DialogWrapper
     }
 
     private boolean isAllFieldsLegal() {
-        return Stream.concat(allTextFields.stream(), allAURelatedFields.stream()).allMatch(Validatable::isLegal);
+        return Stream.concat(allTextFields.stream(), allAURelatedFields.stream()).allMatch(comp -> comp.isLegal());
     }
 
     private boolean isAllAURelatedFieldsLegal() {
-        return allAURelatedFields.stream().allMatch(IntegerWithErrorHintedField::isLegal);
+        return allAURelatedFields.stream().allMatch(comp -> comp.isLegal());
     }
 }


### PR DESCRIPTION
 - To fix the following exeception when provision a SoC cluster which is introduced in #4212. As you can see from the screenshot, if we execute the action to replace lamba function with method reference, it will trigger an exception.
![image](https://user-images.githubusercontent.com/32627233/79642437-0547e580-81d0-11ea-93b7-a56da872be42.png)

```java
java.lang.BootstrapMethodError: call site initialization exception
	at java.lang.invoke.CallSite.makeSite(CallSite.java:341)
	at java.lang.invoke.MethodHandleNatives.linkCallSiteImpl(MethodHandleNatives.java:307)
	at java.lang.invoke.MethodHandleNatives.linkCallSite(MethodHandleNatives.java:297)
	at com.microsoft.azure.cosmosspark.serverexplore.ui.CosmosSparkProvisionDialog.isAllFieldsLegal(CosmosSparkProvisionDialog.java:309)
	at com.microsoft.azure.cosmosspark.serverexplore.ui.CosmosSparkProvisionDialog.access$100(CosmosSparkProvisionDialog.java:67)
	at com.microsoft.azure.cosmosspark.serverexplore.ui.CosmosSparkProvisionDialog$2.textChanged(CosmosSparkProvisionDialog.java:180)
	at com.intellij.ui.DocumentAdapter.removeUpdate(DocumentAdapter.java:20)
	at javax.swing.text.AbstractDocument.fireRemoveUpdate(AbstractDocument.java:259)
	at javax.swing.text.AbstractDocument.handleRemove(AbstractDocument.java:622)
	at javax.swing.text.AbstractDocument.remove(AbstractDocument.java:590)
	at javax.swing.text.AbstractDocument.replace(AbstractDocument.java:666)
	at javax.swing.text.JTextComponent.setText(JTextComponent.java:1669)
	at com.microsoft.azure.cosmosspark.serverexplore.ui.CosmosSparkProvisionDialog.lambda$setData$5(CosmosSparkProvisionDialog.java:237)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:519)
	at com.microsoft.azure.cosmosspark.serverexplore.ui.CosmosSparkProvisionDialog.setData(CosmosSparkProvisionDialog.java:233)
	at com.microsoft.azure.cosmosspark.serverexplore.ui.CosmosSparkProvisionDialog.setData(CosmosSparkProvisionDialog.java:67)
	at rx.internal.util.ActionObserver.onNext(ActionObserver.java:39)
	at rx.internal.operators.OnSubscribeDoOnEach$DoOnEachSubscriber.onNext(OnSubscribeDoOnEach.java:96)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:77)
	at rx.internal.util.ScalarSynchronousObservable$WeakSingleProducer.request(ScalarSynchronousObservable.java:276)
	at rx.Subscriber.setProducer(Subscriber.java:211)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.setProducer(OnSubscribeMap.java:102)
	at rx.Subscriber.setProducer(Subscriber.java:205)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.setProducer(OnSubscribeMap.java:102)
	at rx.internal.util.ScalarSynchronousObservable$JustOnSubscribe.call(ScalarSynchronousObservable.java:138)
	at rx.internal.util.ScalarSynchronousObservable$JustOnSubscribe.call(ScalarSynchronousObservable.java:129)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeDoOnEach.call(OnSubscribeDoOnEach.java:41)
	at rx.internal.operators.OnSubscribeDoOnEach.call(OnSubscribeDoOnEach.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeDoOnEach.call(OnSubscribeDoOnEach.java:41)
	at rx.internal.operators.OnSubscribeDoOnEach.call(OnSubscribeDoOnEach.java:30)
	at rx.Observable.subscribe(Observable.java:10423)
	at rx.Observable.subscribe(Observable.java:10390)
	at rx.Observable.subscribe(Observable.java:10230)
	at com.microsoft.azure.cosmosspark.serverexplore.ui.CosmosSparkProvisionDialog$3.windowOpened(CosmosSparkProvisionDialog.java:187)
	at java.awt.AWTEventMulticaster.windowOpened(AWTEventMulticaster.java:340)
	at java.awt.AWTEventMulticaster.windowOpened(AWTEventMulticaster.java:339)
	at java.awt.Window.processWindowEvent(Window.java:2051)
	at javax.swing.JDialog.processWindowEvent(JDialog.java:683)
	at java.awt.Window.processEvent(Window.java:2013)
	at java.awt.Component.dispatchEventImpl(Component.java:4889)
	at java.awt.Container.dispatchEventImpl(Container.java:2297)
	at java.awt.Window.dispatchEventImpl(Window.java:2746)
	at java.awt.Component.dispatchEvent(Component.java:4711)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:760)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:84)
	at java.awt.EventQueue$4.run(EventQueue.java:733)
	at java.awt.EventQueue$4.run(EventQueue.java:731)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:730)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:906)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:779)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:422)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:687)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:421)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:109)
	at java.awt.WaitDispatchSupport$2.run(WaitDispatchSupport.java:190)
	at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:235)
	at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:233)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:233)
	at java.awt.Dialog.show(Dialog.java:1084)
	at com.intellij.openapi.ui.impl.DialogWrapperPeerImpl$MyDialog.show(DialogWrapperPeerImpl.java:708)
	at com.intellij.openapi.ui.impl.DialogWrapperPeerImpl.show(DialogWrapperPeerImpl.java:433)
	at com.intellij.openapi.ui.DialogWrapper.doShow(DialogWrapper.java:1698)
	at com.intellij.openapi.ui.DialogWrapper.show(DialogWrapper.java:1657)
	at com.microsoft.azure.cosmosspark.CosmosSparkClusterOpsCtrl.lambda$new$2(CosmosSparkClusterOpsCtrl.java:102)
	at rx.internal.util.ActionSubscriber.onNext(ActionSubscriber.java:39)
	at rx.observers.SafeSubscriber.onNext(SafeSubscriber.java:134)
	at rx.internal.operators.OperatorObserveOn$ObserveOnSubscriber.call(OperatorObserveOn.java:224)
	at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:55)
	at rx.internal.schedulers.ExecutorScheduler$ExecutorSchedulerWorker.run(ExecutorScheduler.java:107)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun(LaterInvocator.java:441)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.runNextEvent(LaterInvocator.java:424)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.run(LaterInvocator.java:407)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:906)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:779)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:422)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:698)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:421)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
Caused by: java.lang.invoke.LambdaConversionException: Invalid receiver type class javax.swing.JTextField; not a subtype of implementation type interface com.microsoft.azure.cosmosspark.common.Validatable
	at java.lang.invoke.AbstractValidatingLambdaMetafactory.validateMetafactoryArgs(AbstractValidatingLambdaMetafactory.java:233)
	at java.lang.invoke.LambdaMetafactory.metafactory(LambdaMetafactory.java:303)
	at java.lang.invoke.CallSite.makeSite(CallSite.java:302)
	... 113 more
```