### PR TITLE
Fix uploading jar with interactive session caused job submission failure issue

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/jobs/JobUtils.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/jobs/JobUtils.java
@@ -672,7 +672,7 @@ public class JobUtils {
                                              .subscribe(logLine -> ctrlInfo(legacyLogSubject, newLogSubject,
                                                                             logLine.getRawLog()),
                                                         err -> ctrlError(legacyLogSubject, newLogSubject, err),
-                                                        () -> ctrlComplete(legacyLogSubject, newLogSubject));
+                                                        () -> {});
 
                                  ClusterFileBase64BufferedOutputStream clusterFileBase64Out =
                                          new ClusterFileBase64BufferedOutputStream(sparkSession, destUri);


### PR DESCRIPTION
This is a customer reported issue. Repro steps:
1. Link to an Aris cluster.
2. Add a new Spark on SQL Server run configuration, select the cluster you linked and specify "Use Spark Interacive session to upload" as job upload storage type.
3. Click Remote Run button. We expect the job should successfully run. But what we find is that the log stopped at "Uploading artifact..." and the job disconnected then.
![image](https://user-images.githubusercontent.com/32627233/80445320-8d538b00-8946-11ea-9352-a03a10b4d991.png)

After debug, we find when the session is closed, the onComplete message passed to logSubject. In class `SparkBatchJobRunProcessHandler` when the ctrlSubject receives onComplete message, it will `notifyProcessDetached` which leads to `process.disconnect()`. Please find the following code snippet in class `SparkBatchJobRunProcessHandler`.
```java
        super.addProcessListener(new ProcessAdapter() {
            @Override
            public void processWillTerminate(@NotNull ProcessEvent event, boolean willBeDestroyed) {
                if (willBeDestroyed) {
                    // Kill the Spark Batch Job
                    process.destroy();
                } else {
                    // Just detach
                    process.disconnect();
                }
                super.processWillTerminate(event, willBeDestroyed);
            }
        });

        process.getCtrlSubject().subscribe(
                ignored -> {},
                err -> notifyProcessTerminated(-1),
                this::notifyProcessDetached
        );

```