### PR TITLE
Rename `Deploy to Azure` action to `Deploy to Azure Web Apps`

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -227,7 +227,7 @@
     <action class="com.microsoft.azuretools.ijidea.actions.NewFeatureRequestFeedbackAction" id="AzureToolkit.FeatureRequest" text="Request Feature" />
     <action class="com.microsoft.intellij.actions.QualtricsSurveyAction" id="AzureToolkit.Survey" text="Provide Feedback" />
     <action id="Actions.WebDeployAction" class="com.microsoft.intellij.actions.WebDeployAction"
-            text="Deploy to Azure" description="Deploy to Azure"
+            text="Deploy to Azure Web Apps" description="Deploy to Azure Web Apps"
             icon="/icons/PublishWebApp_16.png">
     </action>
     <!-- Functions Start -->


### PR DESCRIPTION
Rename `Deploy to Azure` action to `Deploy to Azure Web Apps`, fixes #4333 