### PR TITLE
Sort SoC serverless job list by state and submitTime

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosspark/CosmosSparkClusterOpsCtrl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosspark/CosmosSparkClusterOpsCtrl.java
@@ -297,8 +297,13 @@ public class CosmosSparkClusterOpsCtrl implements ILogger {
             public List<UniqueColumnNameTableSchema.RowDescriptor> items() {
                 CosmosServerlessSparkBatchJobsTableSchema tableSchema = new CosmosServerlessSparkBatchJobsTableSchema();
                 return jobList.value().stream()
-                        .map(sparkBatchJob -> tableSchema.new CosmosServerlessSparkJobDescriptor(account, sparkBatchJob))
-                        .collect(Collectors.toList());
+                              .sorted((job1, job2) -> job1.state().compareTo(job2.state()) != 0
+                                                      // sort by job state in ascending order
+                                                      ? job1.state().compareTo(job2.state())
+                                                      // then sort by submit time in descending order
+                                                      : -job1.submitTime().compareTo(job2.submitTime()))
+                              .map(sparkBatchJob -> tableSchema.new CosmosServerlessSparkJobDescriptor(account, sparkBatchJob))
+                              .collect(Collectors.toList());
             }
 
             @Nullable

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/ODataParam.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/ODataParam.java
@@ -30,6 +30,10 @@ public class ODataParam extends BasicNameValuePair {
         return new ODataParam("$filter", value);
     }
 
+    public static ODataParam orderby(String value) {
+        return new ODataParam("$orderby", value);
+    }
+
     private ODataParam(@NotNull String name, @NotNull String value) {
         super(name, value);
     }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/azure/serverless/AzureSparkServerlessAccount.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/azure/serverless/AzureSparkServerlessAccount.java
@@ -22,6 +22,7 @@
 
 package com.microsoft.azure.hdinsight.sdk.common.azure.serverless;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import com.microsoft.azure.hdinsight.common.logger.ILogger;
 import com.microsoft.azure.hdinsight.sdk.cluster.ClusterContainer;
@@ -168,7 +169,9 @@ public class AzureSparkServerlessAccount implements IClusterDetail, ClusterConta
 
         return getHttp()
                 .withUuidUserAgent()
-                .get(uri.toString(), null, null, SparkBatchJobList.class);
+                // Fetch the jobs sorted by submitTime in descending order
+                .get(uri.toString(), ImmutableList.of(ODataParam.orderby("submitTime desc")), null,
+                     SparkBatchJobList.class);
     }
 
     /**

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/serverless/spark/models/SchedulerState.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/serverless/spark/models/SchedulerState.java
@@ -25,7 +25,6 @@ package com.microsoft.azure.hdinsight.sdk.rest.azure.serverless.spark.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.microsoft.rest.ExpandableStringEnum;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -85,7 +84,11 @@ public final class SchedulerState extends ExpandableStringEnum<SchedulerState> i
     }
 
     @Override
-    public int compareTo(@NotNull final SchedulerState other) {
+    public int compareTo(final SchedulerState other) {
+        if (this == other) {
+            return 0;
+        }
+
         return TO_PRIORITY.getOrDefault(this, 0).compareTo(TO_PRIORITY.getOrDefault(other, 0));
     }
 }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/serverless/spark/models/SchedulerState.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/serverless/spark/models/SchedulerState.java
@@ -22,16 +22,20 @@
 
 package com.microsoft.azure.hdinsight.sdk.rest.azure.serverless.spark.models;
 
-import java.util.Collection;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.microsoft.rest.ExpandableStringEnum;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Defines values for SchedulerState.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class SchedulerState extends ExpandableStringEnum<SchedulerState> {
+public final class SchedulerState extends ExpandableStringEnum<SchedulerState> implements Comparable<SchedulerState> {
     /** Static value Any for SchedulerState. */
     public static final SchedulerState ANY = fromString("Any");
 
@@ -53,6 +57,16 @@ public final class SchedulerState extends ExpandableStringEnum<SchedulerState> {
     /** Static value Ended for SchedulerState. */
     public static final SchedulerState ENDED = fromString("Ended");
 
+    public static final Map<SchedulerState, Integer> TO_PRIORITY = new HashMap<SchedulerState, Integer>() {{
+        put(ANY, 1);
+        put(SUBMITTED, 2);
+        put(PREPARING, 3);
+        put(QUEUED, 4);
+        put(SCHEDULED, 5);
+        put(FINALIZING, 6);
+        put(ENDED, 7);
+    }};
+
     /**
      * Creates or finds a SchedulerState from its string representation.
      * @param name a name to look for
@@ -68,5 +82,10 @@ public final class SchedulerState extends ExpandableStringEnum<SchedulerState> {
      */
     public static Collection<SchedulerState> values() {
         return values(SchedulerState.class);
+    }
+
+    @Override
+    public int compareTo(@NotNull final SchedulerState other) {
+        return TO_PRIORITY.getOrDefault(this, 0).compareTo(TO_PRIORITY.getOrDefault(other, 0));
     }
 }


### PR DESCRIPTION
For SoC serverless jobs, we will sort in the following way
 - Sort the job list by submitTime in descending order in server side(Implement by `$orderby` ODataParam in HTTP request).
 - At tool side, we sort by job state in ascending order first. The order for job state is: ANY, SUBMITTED, PREPARING, QUEUED, SCHEDULED, FINALIZING, ENDED. If the job state is the same, we will sort by submit time in descending order then, which means the new submitted job will show up in front of the old job.