### PR TITLE
Fix term Spark usage in toolkit UI

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
 
   <description><![CDATA[
       <html>
-        <p>These plugins allow Java developers, Azure HDInsight developers and SQL Server Spark users to easily create, develop, configure, test, and deploy highly available and scalable Java web apps and Spark/Hadoop jobs to Azure from IntelliJ on all supported platforms.</p>
+        <p>These plugins allow Java developers, Azure HDInsight developers and Apache Spark on SQL Server users to easily create, develop, configure, test, and deploy highly available and scalable Java web apps and Apache Spark/Hadoop jobs to Azure from IntelliJ on all supported platforms.</p>
         <ul>
           <li>Azure Web App Workflow: Run your web applications on Azure Web App and view logs.</li>
           <li>Azure Functions Workflow: Scaffold, run, debug your Functions App locally and deploy it on Azure.</li>
@@ -14,8 +14,8 @@
           <li>Azure Container Workflow: You can dockerize and run your web application on Azure Web App (Linux) via Azure Container Registry.</li>
           <li>Azure Explorer: View and manage your cloud resources on Azure with embedded Azure Explorer.</li>
           <li>Azure Resource Management template: Create and update your Azure resource deployments with ARM template support.</li>
-          <li>Azure HDInsight: Create a Spark project, author and submit Spark jobs to HDInsight cluster; Monitor and debug Spark jobs easily; Support HDInsight ESP cluster MFA Authentication.</li>
-          <li>SQL Server Big Data Cluster: Link to SQL Server Big Data Cluster; Create a Spark project, author and submit Spark jobs to cluster; Monitor and debug Spark jobs easily.</li>
+          <li>Azure HDInsight: Create an Apache Spark project, author and submit Apache Spark jobs to HDInsight cluster; Monitor and debug Apache Spark jobs easily; Support HDInsight ESP cluster MFA Authentication.</li>
+          <li>SQL Server Big Data Cluster: Link to SQL Server Big Data Cluster; Create an Apache Spark project, author and submit Apache Spark jobs to cluster; Monitor and debug Apache Spark jobs easily.</li>
         </ul>
       </html>
     ]]></description>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -206,23 +206,27 @@
     </action>
 
     <action id="Actions.SubmitSparkApplicationAction"
-            class="com.microsoft.azure.hdinsight.spark.actions.SparkSubmitJobAction" text="Submit Spark Application"
-            description="Submit Spark Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.actions.SparkSubmitJobAction"
+            text="Submit Apache Spark Application"
+            description="Submit Apache Spark Application" icon="/icons/Spark.png"/>
     <action id="Actions.SubmitLivySparkApplicationAction"
-            class="com.microsoft.azure.hdinsight.spark.actions.LivySparkSelectAndSubmitAction" text="Spark on HDInsight"
-            description="Submit Spark on HDInsight Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.actions.LivySparkSelectAndSubmitAction" text="Apache Spark on HDInsight"
+            description="Submit Apache Spark on HDInsight Application" icon="/icons/Spark.png"/>
     <action id="Actions.SubmitCosmosSparkApplicationAction"
-            class="com.microsoft.azure.hdinsight.spark.actions.CosmosSparkSelectAndSubmitAction" text="Spark on Cosmos"
-            description="Submit Spark on Cosmos Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.actions.CosmosSparkSelectAndSubmitAction"
+            text="Apache Spark on Cosmos"
+            description="Submit Apache Spark on Cosmos Application" icon="/icons/Spark.png"/>
     <action id="Actions.SubmitCosmosServerlessSparkApplicationAction"
-            class="com.microsoft.azure.hdinsight.spark.actions.CosmosServerlessSparkSelectAndSubmitAction" text="Spark on Cosmos Serverless"
-            description="Submit Spark on Cosmos Serverless Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.actions.CosmosServerlessSparkSelectAndSubmitAction" text="Apache Spark on Cosmos Serverless"
+            description="Submit Apache Spark on Cosmos Serverless Application" icon="/icons/Spark.png"/>
     <action id="Actions.SubmitArisSparkApplicationAction"
-            class="com.microsoft.azure.hdinsight.spark.actions.ArisSparkSelectAndSubmitAction" text="Spark on SQL Server Big Data Cluster"
-            description="Submit Spark on SQL Server Big Data Cluster Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.actions.ArisSparkSelectAndSubmitAction"
+            text="Apache Spark on SQL Server Big Data Cluster"
+            description="Submit Apache Spark on SQL Server Big Data Cluster Application" icon="/icons/Spark.png"/>
     <action id="Actions.SubmitArcadiaSparkApplicationAction"
-            class="com.microsoft.azure.hdinsight.spark.actions.ArcadiaSparkSelectAndSubmitAction" text="Spark on Synapse"
-            description="Submit Spark on Synapse Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.actions.ArcadiaSparkSelectAndSubmitAction"
+            text="Apache Spark on Azure Synapse"
+            description="Submit Apache Spark on Azure Synapse Application" icon="/icons/Spark.png"/>
 
     <action id="AzureToolkit.AzureSignIn" class="com.microsoft.azuretools.ijidea.actions.AzureSignInAction" text="Azure Sign In..." />
     <action id="AzureToolkit.SelectSubscriptions" class="com.microsoft.azuretools.ijidea.actions.SelectSubscriptionsAction" text="Select Subscriptions..."
@@ -276,17 +280,17 @@
       <keyboard-shortcut first-keystroke="ctrl shift alt F2" keymap="$default"/>
     </action>
     <action id="Spark.RunScalaLocalConsole" class="com.microsoft.azure.hdinsight.spark.console.RunSparkLocalConsoleActionDelegate"
-            text="Run Spark Local Console(Scala)" description="Run Spark Local Console (Scala language)">
+            text="Run Apache Spark Local Console(Scala)" description="Run Apache Spark Local Console (Scala language)">
     </action>
     <action id="Spark.RunScalaLivyConsole" class="com.microsoft.azure.hdinsight.spark.console.RunSparkLivyConsoleActionDelegate"
-            text="Run Spark Livy Interactive Session Console(Scala)" description="Run Spark Livy Interactive Session Console (Scala language)">
+            text="Run Apache Spark Livy Interactive Session Console(Scala)" description="Run Apache Spark Livy Interactive Session Console (Scala language)">
     </action>
     <action id="SparkConsole.Execute" class="com.microsoft.azure.hdinsight.spark.console.SparkConsoleExecuteAction" text="Execute Spark Console Statement">
       <keyboard-shortcut first-keystroke="control ENTER" keymap="$default"/>
       <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta shift ENTER"/>
     </action>
     <action id="Spark.SendSelectionToConsole" class="com.microsoft.azure.hdinsight.spark.console.SparkSendSelectionToConsoleActionDelegate"
-            text="Send Selection To Spark Console" description="Send selection to Spark console">
+            text="Send Selection To Apache Spark Console" description="Send selection to Apache Spark console">
       <add-to-group group-id="RunContextPopupGroup" anchor="last"/>
       <keyboard-shortcut first-keystroke="control shift S" keymap="$default"/>
       <keyboard-shortcut keymap="Mac OS X" first-keystroke="ctrl shift S"/>
@@ -354,7 +358,7 @@
       <reference ref="Actions.WhatsNew"/>
     </group>
 
-    <group id="SparkConsoleGroup" text="Spark Console" description="Spark Console" popup="true">
+    <group id="SparkConsoleGroup" text="Apache Spark Console" description="Apache Spark Console" popup="true">
       <add-to-group group-id="RunContextPopupGroup" anchor="last"/>
       <add-to-group group-id="ToolsMenu" anchor="last"/>
       <reference ref="Spark.RunScalaLocalConsole"/>
@@ -368,53 +372,58 @@
               class="com.microsoft.azure.hdinsight.spark.run.action.SelectNoneSparkTypeAction" text="None" >
       </action>
       <action id="Actions.SelectCosmosSparkType"
-              class="com.microsoft.azure.hdinsight.spark.run.action.SelectCosmosSparkTypeAction" text="Spark on Cosmos" >
+              class="com.microsoft.azure.hdinsight.spark.run.action.SelectCosmosSparkTypeAction" text="Apache Spark on Cosmos" >
       </action>
       <action id="Actions.SelectCosmosServerlessSparkType"
-              class="com.microsoft.azure.hdinsight.spark.run.action.SelectCosmosServerlessSparkTypeAction" text="Spark on Cosmos Serverless" >
+              class="com.microsoft.azure.hdinsight.spark.run.action.SelectCosmosServerlessSparkTypeAction" text="Apache Spark on Cosmos Serverless" >
       </action>
       <action id="Actions.SelectHDInsightSparkType"
-              class="com.microsoft.azure.hdinsight.spark.run.action.SelectHDInsightSparkTypeAction" text="Spark on HDInsight" >
+              class="com.microsoft.azure.hdinsight.spark.run.action.SelectHDInsightSparkTypeAction" text="Apache Spark on HDInsight" >
       </action>
       <action id="Actions.SelectArisSparkType"
-              class="com.microsoft.azure.hdinsight.spark.run.action.SelectArisSparkTypeAction" text="Spark on SQL Server Big Data Cluster" >
+              class="com.microsoft.azure.hdinsight.spark.run.action.SelectArisSparkTypeAction"
+              text="Apache Spark on SQL Server Big Data Cluster" >
       </action>
       <action id="Actions.SelectArcadiaSparkType"
-              class="com.microsoft.azure.hdinsight.spark.run.action.SelectArcadiaSparkTypeAction" text="Spark on Synapse" >
+              class="com.microsoft.azure.hdinsight.spark.run.action.SelectArcadiaSparkTypeAction"
+              text="Apache Spark on Azure Synapse" >
       </action>
     </group>
 
-    <action id="Actions.SparkSubmitJobActionGroups" class="com.microsoft.azure.hdinsight.spark.run.action.SparkSubmitJobActionGroups" text="Submit Spark Application"/>
+    <action id="Actions.SparkSubmitJobActionGroups" class="com.microsoft.azure.hdinsight.spark.run.action.SparkSubmitJobActionGroups" text="Submit Apache Spark Application"/>
 
-    <action id="Actions.SparkRunLivyConsoleActionGroups" class="com.microsoft.azure.hdinsight.spark.console.SparkRunLivyConsoleActionGroups" text="Run Spark Console"/>
+    <action id="Actions.SparkRunLivyConsoleActionGroups" class="com.microsoft.azure.hdinsight.spark.console.SparkRunLivyConsoleActionGroups" text="Run Apache Spark Console"/>
 
-    <action id="Actions.SparkRunLocalConsoleActionGroups" class="com.microsoft.azure.hdinsight.spark.console.SparkRunLocalConsoleActionGroups" text="Run Spark Local Console"/>
+    <action id="Actions.SparkRunLocalConsoleActionGroups" class="com.microsoft.azure.hdinsight.spark.console.SparkRunLocalConsoleActionGroups" text="Run Apache Spark Local Console"/>
 
     <action id="Actions.RunArcadiaSparkConsoleAction"
-            class="com.microsoft.azure.hdinsight.spark.console.SelectArcadiaSparkTypeThenRunLivyConsoleAction" text="Spark on Arcadia"
-            description="Start an interactive console for Spark on Arcadia Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.console.SelectArcadiaSparkTypeThenRunLivyConsoleAction"
+            text="Apache Spark on Azure Synapse"
+            description="Start an interactive console for Apache Spark on Azure Synapse Application" icon="/icons/Spark.png"/>
     <action id="Actions.RunLivySparkConsoleAction"
-            class="com.microsoft.azure.hdinsight.spark.console.SelectLivySparkTypeThenRunLivyConsoleAction" text="Spark on HDInsight"
-            description="Start an interactive console for Spark on HDInsight Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.console.SelectLivySparkTypeThenRunLivyConsoleAction" text="Apache Spark on HDInsight"
+            description="Start an interactive console for Apache Spark on HDInsight Application" icon="/icons/Spark.png"/>
     <action id="Actions.RunCosmosSparkConsoleAction"
-            class="com.microsoft.azure.hdinsight.spark.console.SelectCosmosSparkTypeThenRunLivyConsoleAction" text="Spark on Cosmos"
-            description="Start an interactive console for Spark on Cosmos Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.console.SelectCosmosSparkTypeThenRunLivyConsoleAction" text="Apache Spark on Cosmos"
+            description="Start an interactive console for Apache Spark on Cosmos Application" icon="/icons/Spark.png"/>
     <action id="Actions.RunArisSparkConsoleAction"
-            class="com.microsoft.azure.hdinsight.spark.console.SelectArisSparkTypeThenRunLivyConsoleAction" text="Spark on SQL Server Big Data Cluster"
-            description="Start an interactive console for Spark on SQL Server Big Data Cluster Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.console.SelectArisSparkTypeThenRunLivyConsoleAction"
+            text="Apache Spark on SQL Server Big Data Cluster"
+            description="Start an interactive console for Apache Spark on SQL Server Big Data Cluster Application" icon="/icons/Spark.png"/>
 
     <action id="Actions.RunArcadiaSparkLocalConsoleAction"
-            class="com.microsoft.azure.hdinsight.spark.console.SelectArcadiaSparkTypeThenRunLocalConsoleAction" text="Spark on Arcadia"
-            description="Start a Spark local console for Spark on Arcadia Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.console.SelectArcadiaSparkTypeThenRunLocalConsoleAction" text="Apache Spark on Azure Synapse"
+            description="Start a Apache Spark local console for Apache Spark on Azure Synapse Application" icon="/icons/Spark.png"/>
     <action id="Actions.RunLivySparkLocalConsoleAction"
-            class="com.microsoft.azure.hdinsight.spark.console.SelectLivySparkTypeThenRunLocalConsoleAction" text="Spark on HDInsight"
-            description="Start a Spark local console for Spark on HDInsight Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.console.SelectLivySparkTypeThenRunLocalConsoleAction" text="Apache Spark on HDInsight"
+            description="Start a Apache Spark local console for Apache Spark on HDInsight Application" icon="/icons/Spark.png"/>
     <action id="Actions.RunCosmosSparkLocalConsoleAction"
-            class="com.microsoft.azure.hdinsight.spark.console.SelectCosmosSparkTypeThenRunLocalConsoleAction" text="Spark on Cosmos"
-            description="Start a Spark local console for Spark on Cosmos Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.console.SelectCosmosSparkTypeThenRunLocalConsoleAction" text="Apache Spark on Cosmos"
+            description="Start a Apache Spark local console for Apache Spark on Cosmos Application" icon="/icons/Spark.png"/>
     <action id="Actions.RunArisSparkLocalConsoleAction"
-            class="com.microsoft.azure.hdinsight.spark.console.SelectArisSparkTypeThenRunLocalConsoleAction" text="Spark on SQL Server Big Data Cluster"
-            description="Start a Spark local console for Spark on SQL Server Big Data Cluster Application" icon="/icons/Spark.png"/>
+            class="com.microsoft.azure.hdinsight.spark.console.SelectArisSparkTypeThenRunLocalConsoleAction"
+            text="Apache Spark on SQL Server Big Data Cluster"
+            description="Start a Apache Spark local console for Apache Spark on SQL Server Big Data Cluster Application" icon="/icons/Spark.png"/>
     <action id="page.new" class="com.microsoft.intellij.actions.CreateFunctionAction"
             text="Azure Function Class"
             description="Create New Azure Function Class">

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosspark/CosmosSparkClusterOpsCtrl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/cosmosspark/CosmosSparkClusterOpsCtrl.java
@@ -276,7 +276,7 @@ public class CosmosSparkClusterOpsCtrl implements ILogger {
                     String errorHint = "Error loading Serverless jobs. ";
                     log().warn(errorHint + ExceptionUtils.getStackTrace(err));
                     // show warning message when view serverless jobs failed
-                    PluginUtil.displayWarningDialog("View Spark on Cosmos Serverless Jobs ", errorHint + err.getMessage());
+                    PluginUtil.displayWarningDialog("View Apache Spark on Cosmos Serverless Jobs ", errorHint + err.getMessage());
                 })
                 // retry should be allowed when error happened
                 .retry()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/common/CosmosSparkSubmitModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/common/CosmosSparkSubmitModel.kt
@@ -51,5 +51,5 @@ open class CosmosSparkSubmitModel : SparkSubmitModel {
                 Pair(SparkSubmissionParameter.ExecutorCores, SparkSubmissionParameter.ExecutorCoresDefaultValue)).stream()
     }
 
-    override fun getSparkClusterTypeDisplayName(): String = "Azure Data Lake Spark cluster"
+    override fun getSparkClusterTypeDisplayName(): String = "Apache Spark on Cosmos cluster"
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkLivySessionProcessHandler.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkLivySessionProcessHandler.kt
@@ -69,7 +69,7 @@ class SparkLivySessionProcessHandler(val process: SparkLivySessionProcess)
     }
 
     override fun startNotify() {
-        notifyTextAvailable("Start Spark Livy Interactive Session Console in cluster ${process.session.baseUrl.host}...\n", SYSTEM)
+        notifyTextAvailable("Start Apache Spark Livy Interactive Session Console in cluster ${process.session.baseUrl.host}...\n", SYSTEM)
         addProcessListener(object : ProcessAdapter() {
             override fun startNotified(event: ProcessEvent) {
                 val stdoutReader = SparkSimpleLogStreamReader(this@SparkLivySessionProcessHandler, process.inputStream, STDOUT)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleConfigurationType.kt
@@ -35,7 +35,8 @@ class SparkScalaLivyConsoleConfigurationType : ScalaConsoleConfigurationType() {
 
     override fun getDisplayName(): String = "Spark Livy Interactive Session Console(Scala)"
 
-    override fun getConfigurationTypeDescription(): String = "Spark Livy Interactive Session Console(Scala) run configurations"
+    override fun getConfigurationTypeDescription(): String = "Apache Spark Livy Interactive Session Console(Scala) " +
+            "run configurations"
 
     override fun getId(): String = "SparkScalaLivyConsoleRunConfiguration"
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfigurationFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLivyConsoleRunConfigurationFactory.kt
@@ -45,13 +45,13 @@ class SparkScalaLivyConsoleRunConfigurationFactory(sparkConsoleType: SparkScalaL
                             template.project,
                             this,
                             template,
-                            "${template.name} >> Synapse Spark Livy Interactive Session Console(Scala)")
+                            "${template.name} >> Apache Spark on Azure Synapse Livy Interactive Session Console(Scala)")
                 is CosmosSparkRunConfiguration ->
                     CosmosSparkScalaLivyConsoleRunConfiguration(
                             template.project,
                             this,
                             template,
-                            "${template.name} >> Azure Data Lake Spark Livy Interactive Session Console(Scala)")
+                            "${template.name} >> Apache Spark on Cosmos Livy Interactive Session Console(Scala)")
                 is LivySparkBatchJobRunConfiguration ->
                     SparkScalaLivyConsoleRunConfiguration(
                             template.project,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleConfigurationType.kt
@@ -35,7 +35,7 @@ class SparkScalaLocalConsoleConfigurationType : ScalaConsoleConfigurationType() 
 
     override fun getDisplayName(): String = "Spark Local Console(Scala)"
 
-    override fun getConfigurationTypeDescription(): String = "Spark local console(Scala) run configurations"
+    override fun getConfigurationTypeDescription(): String = "Apache Spark local console(Scala) run configurations"
 
     override fun getId(): String = "SparkScalaLocalConsoleRunConfiguration"
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleRunConfiguration.kt
@@ -217,7 +217,7 @@ class SparkScalaLocalConsoleRunConfiguration(
             val newLibConf: NewLibraryConfiguration = JarRepositoryManager.resolveAndDownload(
                     project, libraryCoord, false, false, true, null, projectRepositories) ?: return@runInWriteAction
             val libraryType = newLibConf.libraryType
-            val library = LibraryTablesRegistrar.getInstance().getLibraryTable(project).createLibrary("Spark Console(auto-fix): $libraryCoord")
+            val library = LibraryTablesRegistrar.getInstance().getLibraryTable(project).createLibrary("Apache Spark Console(auto-fix): $libraryCoord")
 
             val editor = NewLibraryEditor(libraryType, newLibConf.properties)
             newLibConf.addRoots(editor)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkSendSelectionToConsoleAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/console/SparkSendSelectionToConsoleAction.kt
@@ -63,7 +63,7 @@ class SparkSendSelectionToConsoleAction : AzureAnAction(), ILogger {
 
             setEnabled(true)
         } catch (ex: Exception) {
-            log().debug("Send to Spark Console action is Disabled", ex)
+            log().debug("Send to Apache Spark Console action is Disabled", ex)
         }
     }
 
@@ -96,7 +96,7 @@ class SparkSendSelectionToConsoleAction : AzureAnAction(), ILogger {
             outputStream.write("$text\n".toByteArray(UTF_8))
             outputStream.flush()
         } catch (ex: Exception) {
-            val errMsg = "Failed to send codes `$text` to Spark Console"
+            val errMsg = "Failed to send codes `$text` to Apache Spark Console"
             log().warn(errMsg, ex)
             EventUtil.logError(operation, ErrorType.systemError, IOException(errMsg, ex), null, null)
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/ArcadiaSparkBatchRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/ArcadiaSparkBatchRunner.kt
@@ -49,9 +49,9 @@ class ArcadiaSparkBatchRunner : SparkBatchJobRunner() {
             : Observable<ISparkBatchJob> = Observable.fromCallable {
         (submitModel as ArcadiaSparkSubmitModel).apply {
             if (sparkCompute == null || tenantId == null || sparkWorkspace == null) {
-                log().warn("Synapse Spark pool is not selected. " +
+                log().warn("Apache Spark Pool for Azure Synapse is not selected. " +
                         "spark pool: $sparkCompute, tenant id: $tenantId, spark workspace: $sparkWorkspace")
-                throw ExecutionException("Synapse Spark pool is not selected")
+                throw ExecutionException("Apache Spark Pool for Azure Synapse is not selected")
             }
         }
     }.flatMap { arcadiaModel -> ArcadiaSparkComputeManager.getInstance()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkJobDebugAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkJobDebugAction.kt
@@ -36,7 +36,7 @@ import com.microsoft.azuretools.telemetry.TelemetryConstants
 class SparkJobDebugAction
     : SparkRunConfigurationAction(
         "SparkJobDebug",
-        "Submit Spark Application to remote cluster with debugging support",
+        "Submit Apache Spark Application to remote cluster with debugging support",
         StreamUtil.getImageResourceFile(CommonConst.ToolWindowSparkJobDebugIcon_13x_Path)?: AllIcons.Toolwindows.ToolWindowDebugger) {
     override val runExecutor: Executor
         get() = ExecutorRegistry.getInstance().getExecutorById(EXECUTOR_ID)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkJobRunAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/action/SparkJobRunAction.kt
@@ -36,7 +36,7 @@ import com.microsoft.azuretools.telemetry.TelemetryConstants
 class SparkJobRunAction
     : SparkRunConfigurationAction(
         "SparkJobRun",
-        "Submit Spark Application to remote cluster",
+        "Submit Apache Spark Application to remote cluster",
         StreamUtil.getImageResourceFile(CommonConst.ToolWindowSparkJobRunIcon_13x_Path)?: AllIcons.Actions.Upload) {
 
     override val runExecutor: Executor

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArcadiaSparkConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArcadiaSparkConfiguration.kt
@@ -43,7 +43,7 @@ class ArcadiaSparkConfiguration (
     }
 
     override fun getSuggestedNamePrefix(): String {
-        return "[Spark on Synapse]"
+        return "[Apache Spark on Azure Synapse]"
     }
 
     override fun getErrorMessageClusterNull(): String {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArcadiaSparkConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArcadiaSparkConfigurationType.kt
@@ -39,7 +39,7 @@ object ArcadiaSparkConfigurationType : ConfigurationType {
     }
 
     override fun getDisplayName(): String {
-        return "Apache Spark on Synapse"
+        return "Apache Spark on Azure Synapse"
     }
 
     override fun getId(): String {
@@ -47,7 +47,7 @@ object ArcadiaSparkConfigurationType : ConfigurationType {
     }
 
     override fun getConfigurationTypeDescription(): String {
-        return "Spark on Synapse Run Configuration"
+        return "Apache Spark on Azure Synapse Run Configuration"
     }
 
     override fun getConfigurationFactories(): Array<ConfigurationFactory> {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArcadiaSparkSubmissionContentPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArcadiaSparkSubmissionContentPanel.kt
@@ -39,7 +39,7 @@ class ArcadiaSparkSubmissionContentPanel (project: Project) : SparkSubmissionCon
     } }
 
     override val clusterHint: String
-        get() = "Spark pool"
+        get() = "Apache Spark Pool for Azure Synapse"
 
     override fun getData(data: SparkSubmitModel) {
         // Component -> Data
@@ -55,7 +55,7 @@ class ArcadiaSparkSubmissionContentPanel (project: Project) : SparkSubmissionCon
             arcadiaData.sparkWorkspace = cluster.workSpace.name
             arcadiaData.sparkCompute = cluster.name
             arcadiaData.livyUri = cluster.connectionUrl
-                    ?: throw RuntimeConfigurationWarning("Can't get Synapse Spark pool connection URL")
+                    ?: throw RuntimeConfigurationWarning("Can't get Apache Spark Pool for Azure Synapse connection URL")
             arcadiaData.sparkApplicationType = when (cluster) {
                 is SynapseCosmosSparkPool -> SparkApplicationType.CosmosSpark
                 is ArcadiaSparkCompute -> SparkApplicationType.ArcadiaSpark

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArcadiaSparkSubmitModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArcadiaSparkSubmitModel.kt
@@ -39,5 +39,5 @@ class ArcadiaSparkSubmitModel(project: Project) : SparkSubmitModel(project) {
     @Attribute("spark_app_type")
     var sparkApplicationType: SparkApplicationType = SparkApplicationType.None
 
-    override fun getSparkClusterTypeDisplayName(): String = "Synapse Spark Pool"
+    override fun getSparkClusterTypeDisplayName(): String = "Apache Spark Pool for Azure Synapse"
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArisSparkConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArisSparkConfiguration.kt
@@ -42,6 +42,6 @@ class ArisSparkConfiguration(
     }
 
     override fun getSuggestedNamePrefix(): String {
-        return "[Spark on SQL]"
+        return "[Apache Spark on SQL]"
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArisSparkConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/ArisSparkConfigurationType.kt
@@ -47,7 +47,7 @@ object ArisSparkConfigurationType : ConfigurationType {
     }
 
     override fun getConfigurationTypeDescription(): String {
-        return "Spark on SQL Server Big Data Cluster Run Configuration"
+        return "Apache Spark on SQL Server Big Data Cluster Run Configuration"
     }
 
     override fun getConfigurationFactories(): Array<ConfigurationFactory> {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkConfiguration.kt
@@ -22,7 +22,7 @@ class CosmosServerlessSparkConfiguration(
         return LivySparkRunConfigurationSettingsEditor(CosmosServerlessSparkConfigurable(project))
     }
 
-    override fun getSuggestedNamePrefix() : String = "[Spark on Cosmos Serverless]"
+    override fun getSuggestedNamePrefix() : String = "[Apache Spark on Cosmos Serverless]"
 
     override fun getErrorMessageClusterNull(): String = "The account should be selected as the target for Spark application submission"
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosServerlessSparkConfigurationType.kt
@@ -13,7 +13,7 @@ object CosmosServerlessSparkConfigurationType : ConfigurationType {
     }
 
     override fun getConfigurationTypeDescription(): String {
-        return "Spark on Cosmos Serverless Configuration"
+        return "Apache Spark on Cosmos Serverless Configuration"
     }
 
     override fun getDisplayName(): String {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosSparkConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosSparkConfigurationType.kt
@@ -35,7 +35,7 @@ object CosmosSparkConfigurationType : ConfigurationType {
     }
 
     override fun getConfigurationTypeDescription(): String {
-        return "Spark on Cosmos Run Configuration"
+        return "Apache Spark on Cosmos Run Configuration"
     }
 
     override fun getId(): String {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosSparkRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/CosmosSparkRunConfiguration.kt
@@ -43,5 +43,5 @@ open class CosmosSparkRunConfiguration (project: Project,
         return LivySparkRunConfigurationSettingsEditor(CosmosSparkConfigurable(project))
     }
 
-    override fun getSuggestedNamePrefix(): String = "[Spark on Cosmos]"
+    override fun getSuggestedNamePrefix(): String = "[Apache Spark on Cosmos]"
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkBatchJobRunConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkBatchJobRunConfiguration.java
@@ -482,7 +482,7 @@ public class LivySparkBatchJobRunConfiguration extends ModuleBasedConfiguration<
     }
 
     public String getSuggestedNamePrefix() {
-        return "[Spark on HDInsight]";
+        return "[Apache Spark on HDInsight]";
     }
 
     @Nullable

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkBatchJobRunConfigurationType.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkBatchJobRunConfigurationType.java
@@ -70,7 +70,7 @@ public class LivySparkBatchJobRunConfigurationType implements ConfigurationType 
 
     @Override
     public String getConfigurationTypeDescription() {
-        return "Spark on HDInsight Run Configuration";
+        return "Apache Spark on HDInsight Run Configuration";
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/SparkFailureTaskDebugConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/SparkFailureTaskDebugConfigurationType.kt
@@ -40,7 +40,7 @@ class SparkFailureTaskDebugConfigurationType : ConfigurationType {
     }
 
     override fun getConfigurationTypeDescription(): String {
-        return "Spark Failure Local Debugging"
+        return "Apache Spark Failure Local Debugging"
     }
 
     override fun getId(): String {
@@ -48,7 +48,7 @@ class SparkFailureTaskDebugConfigurationType : ConfigurationType {
     }
 
     override fun getDisplayName(): String {
-        return "Spark Failure Debug"
+        return "Apache Spark Failure Debug"
     }
 
     override fun getConfigurationFactories(): Array<ConfigurationFactory> {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/projectarcadia/spark/console/ArcadiaSparkScalaLivyConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/projectarcadia/spark/console/ArcadiaSparkScalaLivyConsoleRunConfiguration.kt
@@ -47,7 +47,7 @@ class ArcadiaSparkScalaLivyConsoleRunConfiguration(project: Project,
 
     override fun createSession(sparkCluster: IClusterDetail): SparkSession {
         val livyUrl = sparkCluster.connectionUrl ?: throw RuntimeConfigurationError(
-                "Can't prepare Synapse Spark interactive session since Livy URL is empty")
+                "Can't prepare Apache Spark for Azure Synapse interactive session since Livy URL is empty")
 
         return ArcadiaSparkSession(name, URI.create(livyUrl), sparkCluster.subscription.tenantId)
     }
@@ -55,9 +55,9 @@ class ArcadiaSparkScalaLivyConsoleRunConfiguration(project: Project,
     override fun findCluster(clusterName: String): ArcadiaSparkCompute {
         val arcadiaModel = (submitModel as? ArcadiaSparkSubmitModel)?.apply {
             if (sparkCompute == null || tenantId == null || sparkWorkspace == null) {
-                log().warn("Synapse Spark pool is not selected. " +
+                log().warn("Apache Spark Pool for Azure Synapse is not selected. " +
                         "Spark pool: $sparkCompute, tenant id: $tenantId, spark workspace: $sparkWorkspace")
-                throw RuntimeConfigurationError("Synapse Spark pool is not selected")
+                throw RuntimeConfigurationError("Apache Spark Pool for Azure Synapse is not selected")
             }
         } ?: throw RuntimeConfigurationError("Can't cast submitModel to ArcadiaSparkSubmitModel")
 
@@ -68,7 +68,7 @@ class ArcadiaSparkScalaLivyConsoleRunConfiguration(project: Project,
                     .first()
         } catch (ex: NoSuchElementException) {
             throw RuntimeConfigurationError(
-                    "Can't find Synapse Spark pool (${arcadiaModel.sparkWorkspace}:${arcadiaModel.sparkCompute})"
+                    "Can't find Apache Spark Pool for Azure Synapse (${arcadiaModel.sparkWorkspace}:${arcadiaModel.sparkCompute})"
                             + " at tenant ${arcadiaModel.tenantId}.")
         }
     }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/arcadia/serverexplore/ArcadiaSparkClusterRootModuleImpl.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/arcadia/serverexplore/ArcadiaSparkClusterRootModuleImpl.java
@@ -34,7 +34,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.Node;
 public class ArcadiaSparkClusterRootModuleImpl extends HDInsightRootModule {
     private static final String SERVICE_MODULE_ID = ArcadiaSparkClusterRootModuleImpl.class.getName();
     private static final String ICON_PATH = CommonConst.ARCADIA_WORKSPACE_MODULE_ICON_PATH;
-    private static final String BASE_MODULE_NAME = "Apache Spark on Synapse";
+    private static final String BASE_MODULE_NAME = "Apache Spark on Azure Synapse";
 
     public ArcadiaSparkClusterRootModuleImpl(@NotNull Node parent) {
         super(SERVICE_MODULE_ID, BASE_MODULE_NAME, parent, ICON_PATH, true);

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/cosmosspark/serverexplore/cosmossparknode/CosmosSparkADLAccountNode.java
@@ -80,9 +80,9 @@ public class CosmosSparkADLAccountNode extends AzureRefreshableNode implements I
 
         addAction("Provision Spark Cluster", new CosmosSparkProvisionAction(
                 this, adlAccount, CosmosSparkClusterOps.getInstance().getProvisionAction()));
-        addAction("Submit Spark on Cosmos Serverless Job", new CosmosServerlessSparkSubmitAction(
+        addAction("Submit Apache Spark on Cosmos Serverless Job", new CosmosServerlessSparkSubmitAction(
                 this, adlAccount, CosmosSparkClusterOps.getInstance().getServerlessSubmitAction()));
-        addAction("View Spark on Cosmos Serverless Jobs", new CosmosServerlessSparkViewJobsAction(
+        addAction("View Apache Spark on Cosmos Serverless Jobs", new CosmosServerlessSparkViewJobsAction(
                 this, adlAccount, CosmosSparkClusterOps.getInstance().getViewServerlessJobsAction()));
     }
 

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/azure/serverless/AzureSparkCosmosClusterManager.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/azure/serverless/AzureSparkCosmosClusterManager.java
@@ -167,7 +167,7 @@ public class AzureSparkCosmosClusterManager implements ClusterContainer,
         try {
             return get().toBlocking().singleOrDefault(this);
         } catch (Exception ex) {
-            log().warn("Got exceptions when refresh Azure Data Lake Spark pool: " + ex);
+            log().warn("Got exceptions when refresh Apache Spark pool on Cosmos: " + ex);
 
             return this;
         }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/ArcadiaSparkBatchJob.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/common/ArcadiaSparkBatchJob.java
@@ -64,7 +64,8 @@ public class ArcadiaSparkBatchJob extends SparkBatchJob {
     public Observable<String> awaitStarted() {
         // No submission log and driver log fetching supports
         return Observable.just("no_waiting")
-                         .doOnNext(state -> ctrlInfo("The Spark Batch job has been submitted to Synapse Spark pool"
+                         .doOnNext(state -> ctrlInfo("The Spark Batch job has been submitted to "
+                                                             + "Apache Spark Pool for Azure Synapse "
                                                              + getConnectUri().toString()
                                                              + " with the following parameters: "
                                                              + getSubmissionParameter().serializeToJson()));

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/projectarcadia/common/ArcadiaWorkSpace.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/projectarcadia/common/ArcadiaWorkSpace.java
@@ -110,7 +110,7 @@ public class ArcadiaWorkSpace implements ClusterContainer, Comparable<ArcadiaWor
         try {
             return fetchClusters().toBlocking().singleOrDefault(this);
         } catch (Exception ignored) {
-            log().warn("Got Exceptions when refreshing Synapse Spark pools. " + ExceptionUtils.getStackTrace(ignored));
+            log().warn("Got Exceptions when refreshing Apache Spark Pool for Azure Synapse. " + ExceptionUtils.getStackTrace(ignored));
             return this;
         }
     }


### PR DESCRIPTION
We did the following wording update in this PR.
```
Synapse Spark pool -> Apache Spark pool for Azure Synapse
Synapse Spark -> Apache Spark for Azure Synapse
Apache Spark on Synapse -> Apache Spark on Azure Synapse
Spark on Synapse -> Apache Spark on Azure Synapse
Spark on HDInsight -> Apache Spark on HDInsight
Spark on Cosmos -> Apache Spark on Cosmos
Spark on Cosmos Serverless -> Apache Spark on Cosmos
Spark on SQL Server big data cluster -> Apache Spark on Spark on SQL Server big data cluster
Spark local console -> Apache Spark local console
Spark Livy Interactive session console -> Apache Spark Livy Interactive session console
Submit Spark Application -> Submit Apache Spark Application
Spark failure task debug -> Apache Spark failure task debug
Azure Data Lake Spark -> Apache Spark on Cosoms
```