### PR TITLE
Fix new config in job config table doesn not take effect after click cancel button issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkBatchJobRunConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/configuration/LivySparkBatchJobRunConfiguration.java
@@ -280,6 +280,13 @@ public class LivySparkBatchJobRunConfiguration extends ModuleBasedConfiguration<
             return Observable.empty();
         }
 
+        // To fix issue https://github.com/microsoft/azure-tools-for-java/issues/4419
+        // When we updated the job configurations table and clicked cancel, the new table config actually takes
+        // effect. However, the new table config doesn't apply to submission parameter. So we need to manually update
+        // the submission parameter with the new table here.
+        getSubmitModel().getSubmissionParameter().applyFlattedJobConf(
+                getSubmitModel().getTableModel().getJobConfigMap());
+
         return ((SparkSubmissionRunner) runner).buildSparkBatchJob(getSubmitModel())
                                                .doOnNext(batch -> sparkRemoteBatch = batch);
     }


### PR DESCRIPTION
 #### About the bug
This is to address #4419. As for the bug, after we updated an item in the job configurations table and click `close` button or close dialog directly, the new config actually takes effect. That means if we reopen the dialog agian, we will find the config in the table is updated as the new config. The bug is, if we submit the job now, we will find that we are still using the old config in the config table for the submitted job.
![image](https://user-images.githubusercontent.com/32627233/84168528-17485500-aaaa-11ea-82ef-b7a23ecc67e4.png)

#### How to fix it
From my perspective there are two different ways to fix the bug.
1. If we click `close` button(NOT `apply` or `ok` button)  after we did some change to the config table, we can withdraw the change we have made. This is what happens for other configs in run/configuration dialog. For example, if we change main class name or configuration name field and we click `close` button to close the dialog, we will find these fields remain unchanged if we reopen the dialog again.
2. After we click `close` button, we know for now the new config takes effect. To fix the bug, we can apply the new config when we submit the job.

Actually I think the former way to fix the bug is much more reasonable, but it might take more efforts to fix the bug in that way. Instead in this PR we adopted the latter way to fix this bug.
