### PR TITLE
Fix VM image selection sychronize issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/RxJavaUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/RxJavaUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.intellij.util;
+
+import rx.Subscription;
+
+public class RxJavaUtils {
+    public static void unsubscribeSubscription(Subscription subscription) {
+        if (subscription != null && !subscription.isUnsubscribed()) {
+            subscription.unsubscribe();
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/wizards/createarmvm/SelectImageStep.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/wizards/createarmvm/SelectImageStep.java
@@ -323,7 +323,7 @@ public class SelectImageStep extends AzureWizardStep<VMWizardModel> implements T
                     if (location == null) {
                         return;
                     }
-                    publisherComboBox.removeAllItems();
+                    clearSelection(publisherComboBox, offerComboBox, skuComboBox, imageLabelList);
                     unsubscribeSubscription(fillPublisherSubscription);
                     fillPublisherSubscription =
                             Observable.fromCallable(() -> azure.virtualMachineImages().publishers().listByRegion(location.name()))
@@ -350,7 +350,7 @@ public class SelectImageStep extends AzureWizardStep<VMWizardModel> implements T
             public void run(@org.jetbrains.annotations.NotNull ProgressIndicator progressIndicator) {
                 progressIndicator.setIndeterminate(true);
                 unsubscribeSubscription(fillOfferSubscription);
-                offerComboBox.removeAllItems();
+                clearSelection(offerComboBox, skuComboBox, imageLabelList);
                 fillOfferSubscription =
                         Observable.fromCallable(() -> ((VirtualMachinePublisher) publisherComboBox.getSelectedItem()).offers().list())
                                   .subscribeOn(Schedulers.io())
@@ -376,7 +376,7 @@ public class SelectImageStep extends AzureWizardStep<VMWizardModel> implements T
                 public void run(@org.jetbrains.annotations.NotNull ProgressIndicator progressIndicator) {
                     progressIndicator.setIndeterminate(true);
                     unsubscribeSubscription(fillSkuSubscription);
-                    skuComboBox.removeAllItems();
+                    clearSelection(skuComboBox, imageLabelList);
                     fillSkuSubscription =
                             Observable.fromCallable(() -> ((VirtualMachineOffer) offerComboBox.getSelectedItem()).skus().list())
                                       .subscribeOn(Schedulers.io())
@@ -407,7 +407,7 @@ public class SelectImageStep extends AzureWizardStep<VMWizardModel> implements T
                 VirtualMachineSku sku = (VirtualMachineSku) skuComboBox.getSelectedItem();
                 if (sku != null) {
                     unsubscribeSubscription(fillImagesSubscription);
-                    imageLabelList.setListData(new Object[]{});
+                    clearSelection(imageLabelList);
                     fillImagesSubscription =
                             Observable.fromCallable(() -> sku.images().list())
                                       .subscribeOn(Schedulers.io())
@@ -420,6 +420,16 @@ public class SelectImageStep extends AzureWizardStep<VMWizardModel> implements T
                 }
             }
         });
+    }
+
+    private void clearSelection(JComponent... components) {
+        for (JComponent component : components) {
+            if (component instanceof JComboBox) {
+                ((JComboBox) component).removeAllItems();
+            } else if (component instanceof JList) {
+                ((JList) component).setListData(new Object[]{});
+            }
+        }
     }
 
     private void disableNext() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/wizards/createarmvm/SelectImageStep.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/wizards/createarmvm/SelectImageStep.java
@@ -237,20 +237,6 @@ public class SelectImageStep extends AzureWizardStep<VMWizardModel> implements T
         knownImageBtn.setSelected(true);
     }
 
-    private void enableControls(boolean customImage) {
-        model.setKnownMachineImage(knownImageBtn.isSelected());
-        knownImageComboBox.setEnabled(!customImage);
-        model.getCurrentNavigationState().NEXT.setEnabled(!customImage || !imageLabelList.isSelectionEmpty());
-        imageLabelList.setEnabled(customImage);
-        publisherComboBox.setEnabled(customImage);
-        offerComboBox.setEnabled(customImage);
-        skuComboBox.setEnabled(customImage);
-        publisherLabel.setEnabled(customImage);
-        offerLabel.setEnabled(customImage);
-        skuLabel.setEnabled(customImage);
-        versionLabel.setEnabled(customImage);
-    }
-
     @Override
     public JComponent prepare(WizardNavigationState wizardNavigationState) {
         rootPanel.revalidate();
@@ -285,6 +271,25 @@ public class SelectImageStep extends AzureWizardStep<VMWizardModel> implements T
             }
         }
         return rootPanel;
+    }
+
+    @Override
+    public Map<String, String> toProperties() {
+        return model.toProperties();
+    }
+
+    private void enableControls(boolean customImage) {
+        model.setKnownMachineImage(knownImageBtn.isSelected());
+        knownImageComboBox.setEnabled(!customImage);
+        model.getCurrentNavigationState().NEXT.setEnabled(!customImage || !imageLabelList.isSelectionEmpty());
+        imageLabelList.setEnabled(customImage);
+        publisherComboBox.setEnabled(customImage);
+        offerComboBox.setEnabled(customImage);
+        skuComboBox.setEnabled(customImage);
+        publisherLabel.setEnabled(customImage);
+        offerLabel.setEnabled(customImage);
+        skuLabel.setEnabled(customImage);
+        versionLabel.setEnabled(customImage);
     }
 
     private void fillRegions() {
@@ -436,10 +441,5 @@ public class SelectImageStep extends AzureWizardStep<VMWizardModel> implements T
             return;
         }
         PluginUtil.displayErrorDialogInAWTAndLog(message("errTtl"), errorMessage, throwable);
-    }
-
-    @Override
-    public Map<String, String> toProperties() {
-        return model.toProperties();
     }
 }


### PR DESCRIPTION
- Fix comboBoc listener will trigger select event twice by `ItemEvent.getStateChange`
- Using subscription to fix image selection sychronize issue
- Load publisher list only if region is selected

For issue https://dev.azure.com/mseng/VSJava/_workitems/edit/1762281/
