### PR TITLE
Run command with common exec

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -88,6 +88,7 @@ configurations {
 apply plugin: 'java'
 
 dependencies {
+    compile group: 'org.apache.commons', name: 'commons-exec', version: '1.3'
     compile 'com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8'
     compile 'commons-io:commons-io:2.7'
     compile group: 'org.apache.commons', name: 'commons-text', version: '1.8'

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/localrun/FunctionRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/localrun/FunctionRunState.java
@@ -160,32 +160,32 @@ public class FunctionRunState extends AzureRunProfileState<FunctionApp> {
             if (funcVersion.compareTo(minimumVersion) < 0) {
                 throw new AzureExecutionException(FUNCTION_CORE_TOOLS_OUT_OF_DATE);
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException e) {
             throw new AzureExecutionException(String.format(FAILED_TO_VALIDATE_FUNCTION_RUNTIME, e.getMessage()));
         }
     }
 
-    private ComparableVersion getFuncVersion() throws IOException, InterruptedException {
+    private ComparableVersion getFuncVersion() throws IOException {
         final File func = new File(functionRunConfiguration.getFuncPath());
-        final String[] funcVersionResult = CommandUtils.executeMultipleLineOutput(
-                String.format("%s -v", func.getName()), func.getParentFile());
-        if (ArrayUtils.isEmpty(funcVersionResult)) {
+        final String funcVersion = CommandUtils.executeCommandAndGetOutput(func.getAbsolutePath(), new String[]{"-v"}, func.getParentFile());
+        if (StringUtils.isEmpty(funcVersion)) {
             return null;
         }
-        return new ComparableVersion(funcVersionResult[0].trim());
+        return new ComparableVersion(funcVersion);
     }
 
     // Get java runtime version following the strategy of function core tools
     // Get java version of JAVA_HOME first, fall back to use PATH if JAVA_HOME not exists
-    private ComparableVersion getJavaVersion() throws IOException, InterruptedException {
+    private ComparableVersion getJavaVersion() throws IOException {
         final String javaHome = System.getenv("JAVA_HOME");
-        final File executeFolder = StringUtils.isEmpty(javaHome) ? null : Paths.get(javaHome, "bin").toFile();
-        final String[] javaVersionResult = CommandUtils.executeMultipleLineOutput(
-                "java -version", executeFolder, Process::getErrorStream); // java -version will write to std error
-        if (ArrayUtils.isEmpty(javaVersionResult)) {
+        final File javaFile = StringUtils.isEmpty(javaHome) ? null : Paths.get(javaHome, "bin", "java").toFile();
+        final File executeFolder = javaFile == null ? null : javaFile.getParentFile();
+        final String command = javaFile == null ? "java" : javaFile.getAbsolutePath();
+        final String javaVersion = CommandUtils.executeCommandAndGetOutput(command, new String[]{"-version"}, executeFolder);
+        if (StringUtils.isEmpty(javaVersion)) {
             return null;
         }
-        final Matcher matcher = JAVA_VERSION_PATTERN.matcher(javaVersionResult[0].trim());
+        final Matcher matcher = JAVA_VERSION_PATTERN.matcher(javaVersion);
         return matcher.find() ? new ComparableVersion(matcher.group(1)) : null;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/CommandUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/CommandUtils.java
@@ -22,10 +22,15 @@
 
 package com.microsoft.intellij.util;
 
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.ExecuteException;
+import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,6 +57,24 @@ public class CommandUtils {
             return new String[0];
         }
         return StringUtils.split(IOUtils.toString(streamFunction.apply(p), "utf8"), "\n");
+    }
+
+    public static String executeCommandAndGetOutput(final String command, final String[] parameters, final File directory) throws IOException {
+        final CommandLine commandLine = new CommandLine(command);
+        commandLine.addArguments(parameters);
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final PumpStreamHandler streamHandler = new PumpStreamHandler(outputStream);
+        final DefaultExecutor executor = new DefaultExecutor();
+        executor.setWorkingDirectory(directory);
+        executor.setStreamHandler(streamHandler);
+        executor.setExitValues(null);
+        try {
+            executor.execute(commandLine);
+            return outputStream.toString();
+        } catch (ExecuteException e) {
+            // swallow execute exception and return empty
+            return StringUtils.EMPTY;
+        }
     }
 
     public static String[] executeMultipleLineOutput(final String cmd, File cwd)


### PR DESCRIPTION
Using common exec and absolute path to run `func -v` and `java -version` as ProcessBuilder will always run program in PATH without `./`, fixes  https://dev.azure.com/mseng/VSJava/_workitems/edit/1762265/