### PR TITLE
Add /usr/local/bin to command path by default in unix

### DIFF
--- a/Utils/azuretools-core/src/com/microsoft/azuretools/utils/CommandUtils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/utils/CommandUtils.java
@@ -83,7 +83,8 @@ public class CommandUtils {
             logger.throwing(CommandUtils.class.getName(), "exec", exception);
             throw exception;
         }
-        return executeCommandAndGetOutput(starter, switcher, commandWithArgs, new File(workingDirectory));
+        final String commandWithPath = isWindows() ? commandWithArgs : String.format("export PATH=$PATH:/usr/local/bin ; %s", commandWithArgs);
+        return executeCommandAndGetOutput(starter, switcher, commandWithPath, new File(workingDirectory));
     }
 
     public static String executeCommandAndGetOutput(final String commandWithoutArgs, final String[] args, final File directory) throws IOException {


### PR DESCRIPTION
Add /usr/local/bin to command path by default in unix, fixes https://dev.azure.com/mseng/VSJava/_workitems/edit/1775299