### PR TITLE
Fix function deployment id storage issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/component/table/AppSettingModel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/component/table/AppSettingModel.java
@@ -43,14 +43,12 @@ public class AppSettingModel implements TableModel {
     private static final String FUNCTIONS_WORKER_RUNTIME_VALUE = "java";
     private static final String AZURE_WEB_JOB_STORAGE_VALUE = "";
 
-    public static final String REQUIRED_APP_SETTINGS_PROMPTION = "%s is a required parameter";
+    public static final String REQUIRED_APP_SETTINGS_PROMOTION = "%s is a required parameter";
 
     private List<Pair<String, String>> appSettings = new ArrayList<>();
     private List<TableModelListener> tableModelListenerList = new ArrayList<>();
 
     public AppSettingModel() {
-        appSettings.add(Pair.of(FUNCTIONS_WORKER_RUNTIME_KEY, FUNCTIONS_WORKER_RUNTIME_VALUE));
-        appSettings.add(Pair.of(AZURE_WEB_JOB_STORAGE_KEY, AZURE_WEB_JOB_STORAGE_VALUE));
     }
 
     @Override
@@ -123,7 +121,7 @@ public class AppSettingModel implements TableModel {
         }
         final Pair<String, String> target = appSettings.get(row);
         if (FUNCTIONS_WORKER_RUNTIME_KEY.equals(target.getKey()) || AZURE_WEB_JOB_STORAGE_KEY.equals(target.getKey())) {
-            throw new IllegalArgumentException(String.format(REQUIRED_APP_SETTINGS_PROMPTION, target.getKey()));
+            throw new IllegalArgumentException(String.format(REQUIRED_APP_SETTINGS_PROMOTION, target.getKey()));
         }
         appSettings.remove(row);
         fireTableChanged();
@@ -161,14 +159,7 @@ public class AppSettingModel implements TableModel {
         tableModelListenerList.remove(tableModelListener);
     }
 
-    public boolean isDefaultAppSettings() {
-        final Map<String, String> appSettingsMap = getAppSettings();
-        return appSettingsMap.size() == 2 &&
-                StringUtils.equals(appSettingsMap.get(FUNCTIONS_WORKER_RUNTIME_KEY), FUNCTIONS_WORKER_RUNTIME_VALUE) &&
-                StringUtils.equals(appSettingsMap.get(AZURE_WEB_JOB_STORAGE_KEY), AZURE_WEB_JOB_STORAGE_VALUE);
-    }
-
-    public void addRequiredAttributes() {
+    public void loadRequiredAttributes() {
         final Map<String, String> appSettingsMap = getAppSettings();
         if (!appSettingsMap.containsKey(FUNCTIONS_WORKER_RUNTIME_KEY)) {
             appSettings.add(Pair.of(FUNCTIONS_WORKER_RUNTIME_KEY, FUNCTIONS_WORKER_RUNTIME_VALUE));

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/component/table/AppSettingsTable.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/component/table/AppSettingsTable.java
@@ -23,10 +23,9 @@
 package com.microsoft.intellij.runner.functions.component.table;
 
 import com.intellij.ui.table.JBTable;
-import org.apache.commons.collections4.MapUtils;
 
-import javax.swing.ListSelectionModel;
-import java.awt.Dimension;
+import javax.swing.*;
+import java.awt.*;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/component/table/AppSettingsTable.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/component/table/AppSettingsTable.java
@@ -47,6 +47,10 @@ public class AppSettingsTable extends JBTable {
         this.setPreferredScrollableViewportSize(null);
     }
 
+    public void loadRequiredSettings() {
+        appSettingModel.loadRequiredAttributes();
+    }
+
     public void loadLocalSetting() {
         final Map<String, String> appSettings = AppSettingsTableUtils.getAppSettingsFromLocalSettingsJson(new File(localSettingPath));
         setAppSettings(appSettings);
@@ -69,16 +73,9 @@ public class AppSettingsTable extends JBTable {
         this.refresh();
     }
 
-    public void setAppSettings(Map<String, String> appSettingMap, boolean clearRequiredAttributes) {
+    public void setAppSettings(Map<String, String> appSettingMap) {
         clear();
         addAppSettings(appSettingMap);
-        if (!clearRequiredAttributes) {
-            appSettingModel.addRequiredAttributes();
-        }
-    }
-
-    public void setAppSettings(Map<String, String> appSettingMap) {
-        setAppSettings(appSettingMap, true);
     }
 
     public void clear() {
@@ -98,8 +95,8 @@ public class AppSettingsTable extends JBTable {
         return Paths.get(localSettingPath);
     }
 
-    public boolean isDefaultAppSettings() {
-        return appSettingModel.isDefaultAppSettings();
+    public boolean isEmpty() {
+        return appSettingModel.getRowCount() == 0;
     }
 
     private void scrollToRow(int target) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/component/table/AppSettingsTable.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/component/table/AppSettingsTable.java
@@ -70,12 +70,16 @@ public class AppSettingsTable extends JBTable {
         this.refresh();
     }
 
-    public void setAppSettings(Map<String, String> appSettingMap) {
+    public void setAppSettings(Map<String, String> appSettingMap, boolean clearRequiredAttributes) {
         clear();
-        if (MapUtils.isNotEmpty(appSettingMap)) {
-            addAppSettings(appSettingMap);
+        addAppSettings(appSettingMap);
+        if (!clearRequiredAttributes) {
             appSettingModel.addRequiredAttributes();
         }
+    }
+
+    public void setAppSettings(Map<String, String> appSettingMap) {
+        setAppSettings(appSettingMap, true);
     }
 
     public void clear() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/deploy/FunctionDeploymentState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/deploy/FunctionDeploymentState.java
@@ -77,6 +77,7 @@ public class FunctionDeploymentState extends AzureRunProfileState<WebAppBase> {
         final FunctionApp functionApp;
         if (deployModel.isNewResource()) {
             functionApp = createFunctionApp(processHandler);
+            functionDeployConfiguration.setFunctionId(functionApp.id());
         } else {
             functionApp = AzureFunctionMvpModel.getInstance()
                                                .getFunctionById(functionDeployConfiguration.getSubscriptionId(), functionDeployConfiguration.getFunctionId());

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/deploy/ui/FunctionDeploymentPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/deploy/ui/FunctionDeploymentPanel.java
@@ -193,7 +193,7 @@ public class FunctionDeploymentPanel extends AzureSettingPanel<FunctionDeployCon
                 this.fillAppSettings(Collections.EMPTY_MAP);
             }
         } else { // For existing Functions
-            if (!AppServiceComboBoxModel.isSameApp(model, appSettingsFunctionApp) || appSettingsTable.isDefaultAppSettings()) {
+            if (!AppServiceComboBoxModel.isSameApp(model, appSettingsFunctionApp) || appSettingsTable.isEmpty()) {
                 // Do not refresh if selected function app is not changed except create run configuration from azure explorer
                 presenter.loadAppSettings(model.getResource());
             }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/deploy/ui/FunctionDeploymentPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/deploy/ui/FunctionDeploymentPanel.java
@@ -94,6 +94,7 @@ public class FunctionDeploymentPanel extends AzureSettingPanel<FunctionDeployCon
 
     @Override
     public void disposeEditor() {
+        presenter.onDetachView();
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/localrun/ui/FunctionRunPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/localrun/ui/FunctionRunPanel.java
@@ -98,8 +98,10 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
     @Override
     protected void resetFromConfig(@NotNull FunctionRunConfiguration configuration) {
         if (MapUtils.isNotEmpty(configuration.getAppSettings())) {
-            appSettingsTable.setAppSettings(configuration.getAppSettings(), false);
+            appSettingsTable.setAppSettings(configuration.getAppSettings());
         }
+        // In case `FUNCTIONS_WORKER_RUNTIME` or `AZURE_WEB_JOB_STORAGE_KEY` was missed in configuration
+        appSettingsTable.loadRequiredSettings();
         if (StringUtils.isNotEmpty(configuration.getFuncPath())) {
             txtFunc.setText(configuration.getFuncPath());
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/localrun/ui/FunctionRunPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/functions/localrun/ui/FunctionRunPanel.java
@@ -93,13 +93,12 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
 
     @Override
     public void disposeEditor() {
-
     }
 
     @Override
     protected void resetFromConfig(@NotNull FunctionRunConfiguration configuration) {
         if (MapUtils.isNotEmpty(configuration.getAppSettings())) {
-            appSettingsTable.setAppSettings(configuration.getAppSettings());
+            appSettingsTable.setAppSettings(configuration.getAppSettings(), false);
         }
         if (StringUtils.isNotEmpty(configuration.getFuncPath())) {
             txtFunc.setText(configuration.getFuncPath());


### PR DESCRIPTION
- Save created function app id to function deployment configuration
- Do not save empty `AZURE_WEB_JOB_STORAGE_KEY` to deployment configuration as they will be created by SDK automatically