### PR TITLE
Task 1792621: [refactor] IOException is not used properly and severely polluted our code

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/ui/SubscriptionsDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/ui/SubscriptionsDialog.java
@@ -28,7 +28,6 @@ import static com.microsoft.azuretools.telemetry.TelemetryConstants.SELECT_SUBSC
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetrywrapper.EventType;
 import com.microsoft.azuretools.telemetrywrapper.EventUtil;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
@@ -168,31 +167,21 @@ public class SubscriptionsDialog extends AzureTitleAreaDialogWrapper {
     }
 
     private void setSubscriptionDetails() {
-        try {
-            sdl = subscriptionManager.getSubscriptionDetails();
-            for (SubscriptionDetail sd : sdl) {
-                TableItem item = new TableItem(table, SWT.NULL);
-                item.setText(new String[] {sd.getSubscriptionName(), sd.getSubscriptionId()});
-                item.setChecked(sd.isSelected());
-            }
-        } catch (IOException ex) {
-            ex.printStackTrace();
-            LOG.log(new Status(IStatus.ERROR, Activator.PLUGIN_ID, "setSubscriptionDetails@SubscriptionDialog", ex));
+        sdl = subscriptionManager.getSubscriptionDetails();
+        for (SubscriptionDetail sd : sdl) {
+            TableItem item = new TableItem(table, SWT.NULL);
+            item.setText(new String[] {sd.getSubscriptionName(), sd.getSubscriptionId()});
+            item.setChecked(sd.isSelected());
         }
     }
 
     private void refreshSubscriptions() {
-        try {
-            System.out.println("refreshSubscriptions");
-            table.removeAll();
-            subscriptionManager.cleanSubscriptions();
-            refreshSubscriptionsAsync();
-            setSubscriptionDetails();
-            subscriptionManager.setSubscriptionDetails(sdl);
-        } catch (IOException ex) {
-            ex.printStackTrace();
-            LOG.log(new Status(IStatus.ERROR, Activator.PLUGIN_ID, "refreshSubscriptions@SubscriptionDialog", ex));
-        }
+        System.out.println("refreshSubscriptions");
+        table.removeAll();
+        subscriptionManager.cleanSubscriptions();
+        refreshSubscriptionsAsync();
+        setSubscriptionDetails();
+        subscriptionManager.setSubscriptionDetails(sdl);
     }
 
     /**

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/CreateFunctionAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/actions/CreateFunctionAction.java
@@ -39,13 +39,7 @@ import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.psi.JavaDirectoryService;
-import com.intellij.psi.PsiDirectory;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiFileFactory;
-import com.intellij.psi.PsiNameHelper;
-import com.intellij.psi.PsiPackage;
+import com.intellij.psi.*;
 import com.intellij.psi.util.ClassUtil;
 import com.intellij.util.IncorrectOperationException;
 import com.microsoft.azure.common.exceptions.AzureExecutionException;
@@ -55,11 +49,7 @@ import com.microsoft.azure.management.eventhub.EventHubNamespace;
 import com.microsoft.azure.management.eventhub.EventHubNamespaceAuthorizationRule;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
-import com.microsoft.azuretools.telemetrywrapper.ErrorType;
-import com.microsoft.azuretools.telemetrywrapper.EventType;
-import com.microsoft.azuretools.telemetrywrapper.EventUtil;
-import com.microsoft.azuretools.telemetrywrapper.Operation;
-import com.microsoft.azuretools.telemetrywrapper.TelemetryManager;
+import com.microsoft.azuretools.telemetrywrapper.*;
 import com.microsoft.intellij.forms.function.CreateFunctionForm;
 import com.microsoft.intellij.runner.functions.AzureFunctionSupportConfigurationType;
 import com.microsoft.intellij.util.AzureFunctionsUtils;
@@ -70,10 +60,7 @@ import org.jetbrains.jps.model.java.JavaModuleSourceRootTypes;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.CREATE_FUNCTION_TRIGGER;
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.FUNCTION;
@@ -220,14 +207,10 @@ public class CreateFunctionAction extends CreateElementActionBase {
     }
 
     private String getEventHubNamespaceConnectionString(EventHubNamespace eventHubNamespace) {
-        try {
-            Azure azure = AuthMethodManager.getInstance().getAzureClient(eventHubNamespace.id().split("/")[2]);
-            EventHubNamespaceAuthorizationRule eventHubNamespaceAuthorizationRule = azure.eventHubNamespaces().
-                    authorizationRules().getByName(eventHubNamespace.resourceGroupName(), eventHubNamespace.name(),
-                    "RootManageSharedAccessKey");
-            return eventHubNamespaceAuthorizationRule.getKeys().primaryConnectionString();
-        } catch (IOException e) {
-            return null;
-        }
+        Azure azure = AuthMethodManager.getInstance().getAzureClient(eventHubNamespace.id().split("/")[2]);
+        EventHubNamespaceAuthorizationRule eventHubNamespaceAuthorizationRule = azure.eventHubNamespaces().
+            authorizationRules().getByName(eventHubNamespace.resourceGroupName(), eventHubNamespace.name(),
+            "RootManageSharedAccessKey");
+        return eventHubNamespaceAuthorizationRule.getKeys().primaryConnectionString();
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/CreateRedisCacheForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/CreateRedisCacheForm.java
@@ -154,24 +154,20 @@ public class CreateRedisCacheForm extends AzureDialogWrapper {
             return new ValidationInfo(INVALID_REDIS_CACHE_NAME, txtRedisName);
         }
 
-        try {
-            if (newResGrp) {
-                for (String resGrp : sortedGroups) {
-                    if (resGrp.equals(selectedResGrpValue)) {
-                        return new ValidationInfo(String.format(NEW_RES_GRP_ERROR_FORMAT, selectedResGrpValue), txtNewResGrp);
-                    }
-                }
-                if (!Utils.isResGrpNameValid(selectedResGrpValue)) {
-                    return new ValidationInfo(RES_GRP_NAME_RULE, txtNewResGrp);
+        if (newResGrp) {
+            for (final String resGrp : sortedGroups) {
+                if (resGrp.equals(selectedResGrpValue)) {
+                    return new ValidationInfo(String.format(NEW_RES_GRP_ERROR_FORMAT, selectedResGrpValue), txtNewResGrp);
                 }
             }
-            for (RedisCache existingRedisCache : azureManager.getAzure(currentSub.getSubscriptionId()).redisCaches().list()) {
-                if (existingRedisCache.name().equals(redisCacheNameValue)) {
-                    return new ValidationInfo(String.format(VALIDATION_FORMAT, redisCacheNameValue), txtRedisName);
-                }
+            if (!Utils.isResGrpNameValid(selectedResGrpValue)) {
+                return new ValidationInfo(RES_GRP_NAME_RULE, txtNewResGrp);
             }
-        } catch (IOException e) {
-            e.printStackTrace();
+        }
+        for (final RedisCache existingRedisCache : azureManager.getAzure(currentSub.getSubscriptionId()).redisCaches().list()) {
+            if (existingRedisCache.name().equals(redisCacheNameValue)) {
+                return new ValidationInfo(String.format(VALIDATION_FORMAT, redisCacheNameValue), txtRedisName);
+            }
         }
 
         return null;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/function/CreateFunctionForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/function/CreateFunctionForm.java
@@ -54,7 +54,6 @@ import rx.schedulers.Schedulers;
 
 import javax.swing.*;
 import javax.swing.event.PopupMenuEvent;
-import java.io.IOException;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -351,22 +350,18 @@ public class CreateFunctionForm extends DialogWrapper implements TelemetryProper
     private List<EventHubNamespace> eventHubNamespaces = null;
 
     private List<EventHubNamespace> getEventHubNameSpaces() {
-        try {
-            if (eventHubNamespaces == null) {
-                eventHubNamespaces = new ArrayList<>();
-                List<Subscription> subs = AzureMvpModel.getInstance().getSelectedSubscriptions();
-                for (Subscription subscriptionId : subs) {
-                    Azure azure = AuthMethodManager.getInstance().getAzureClient(subscriptionId.subscriptionId());
-                    PagedList<EventHubNamespace> pagedList = azure.eventHubNamespaces().list();
-                    pagedList.loadAll();
-                    eventHubNamespaces.addAll(pagedList);
-                    eventHubNamespaces.sort(Comparator.comparing(HasName::name));
-                }
+        if (eventHubNamespaces == null) {
+            eventHubNamespaces = new ArrayList<>();
+            final List<Subscription> subs = AzureMvpModel.getInstance().getSelectedSubscriptions();
+            for (final Subscription subscriptionId : subs) {
+                final Azure azure = AuthMethodManager.getInstance().getAzureClient(subscriptionId.subscriptionId());
+                final PagedList<EventHubNamespace> pagedList = azure.eventHubNamespaces().list();
+                pagedList.loadAll();
+                eventHubNamespaces.addAll(pagedList);
+                eventHubNamespaces.sort(Comparator.comparing(HasName::name));
             }
-            return eventHubNamespaces;
-        } catch (IOException e) {
-            return new ArrayList<>();
         }
+        return eventHubNamespaces;
     }
 
     private void fillTimerSchedule() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/AzureLoginHelper.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/AzureLoginHelper.java
@@ -27,7 +27,6 @@ import com.microsoft.azuretools.authmanage.models.SubscriptionDetail;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
 import org.apache.commons.collections.CollectionUtils;
 
-import java.io.IOException;
 import java.util.List;
 
 public class AzureLoginHelper {
@@ -42,20 +41,15 @@ public class AzureLoginHelper {
         if (!AuthMethodManager.getInstance().isSignedIn()) {
             throw new AzureExecutionException(NEED_SIGN_IN);
         }
-        try {
-            final AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
-            final List<SubscriptionDetail> subscriptions =
-                    azureManager.getSubscriptionManager().getSubscriptionDetails();
-            if (CollectionUtils.isEmpty(subscriptions)) {
-                throw new AzureExecutionException(NO_SUBSCRIPTION);
-            }
-            final List<SubscriptionDetail> selectedSubscriptions =
-                    azureManager.getSubscriptionManager().getSelectedSubscriptionDetails();
-            if (CollectionUtils.isEmpty(selectedSubscriptions)) {
-                throw new AzureExecutionException(MUST_SELECT_SUBSCRIPTION);
-            }
-        } catch (IOException e) {
-            throw new AzureExecutionException(e.getMessage(), e);
+        final AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
+        final List<SubscriptionDetail> subscriptions = azureManager.getSubscriptionManager().getSubscriptionDetails();
+        if (CollectionUtils.isEmpty(subscriptions)) {
+            throw new AzureExecutionException(NO_SUBSCRIPTION);
+        }
+        final List<SubscriptionDetail> selectedSubscriptions =
+            azureManager.getSubscriptionManager().getSelectedSubscriptionDetails();
+        if (CollectionUtils.isEmpty(selectedSubscriptions)) {
+            throw new AzureExecutionException(MUST_SELECT_SUBSCRIPTION);
         }
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/ValidationUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/ValidationUtils.java
@@ -30,7 +30,6 @@ import com.microsoft.rest.RestException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -85,15 +84,11 @@ public class ValidationUtils {
         if (!isValidAppServiceName(appServiceName)) {
             cacheAndThrow(appServiceNameValidationCache, cacheKey, message("appService.subscription.validate.invalidName"));
         }
-        try {
-            final Azure azure = AuthMethodManager.getInstance().getAzureManager().getAzure(subscriptionId);
-            final ResourceNameAvailabilityInner result = azure.appServices().inner()
-                    .checkNameAvailability(appServiceName, CheckNameResourceTypes.MICROSOFT_WEBSITES);
-            if (!result.nameAvailable()) {
-                cacheAndThrow(appServiceNameValidationCache, cacheKey, result.message());
-            }
-        } catch (IOException e) {
-            // swallow exception when get azure client
+        final Azure azure = AuthMethodManager.getInstance().getAzureManager().getAzure(subscriptionId);
+        final ResourceNameAvailabilityInner result = azure.appServices().inner()
+                .checkNameAvailability(appServiceName, CheckNameResourceTypes.MICROSOFT_WEBSITES);
+        if (!result.nameAvailable()) {
+            cacheAndThrow(appServiceNameValidationCache, cacheKey, result.message());
         }
         appServiceNameValidationCache.put(cacheKey, null);
     }
@@ -116,8 +111,6 @@ public class ValidationUtils {
             }
         } catch (RestException e) {
             throw new IllegalArgumentException(e.getMessage());
-        } catch (IOException e) {
-            // swallow exception when get azure client
         }
         resourceGroupValidationCache.put(subscriptionId, null);
     }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/Node.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/Node.java
@@ -22,11 +22,9 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
-import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpView;
@@ -42,7 +40,6 @@ import javax.swing.*;
 import javax.swing.tree.TreePath;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -138,11 +135,13 @@ public class Node implements MvpView, BasicTelemetryProperty {
     }
 
     public boolean isDescendant(Node node) {
-        if (isDirectChild(node))
+        if (isDirectChild(node)) {
             return true;
-        for (Node child : childNodes) {
-            if (child.isDescendant(node))
+        }
+        for (final Node child : childNodes) {
+            if (child.isDescendant(node)) {
                 return true;
+            }
         }
 
         return false;
@@ -150,11 +149,13 @@ public class Node implements MvpView, BasicTelemetryProperty {
 
     // Walk up the tree till we find a parent node who's type
     // is equal to "clazz".
-    public <T extends Node> T findParentByType(Class<T> clazz) {
-        if (parent == null)
+    public <T extends Node> @Nullable T findParentByType(Class<T> clazz) {
+        if (parent == null) {
             return null;
-        if (parent.getClass().equals(clazz))
+        }
+        if (parent.getClass().equals(clazz)) {
             return (T) parent;
+        }
         return parent.findParentByType(clazz);
     }
 
@@ -255,18 +256,8 @@ public class Node implements MvpView, BasicTelemetryProperty {
                     Class<? extends NodeActionListener> listenerClass = entry.getValue();
                     NodeActionListener actionListener = createNodeActionListener(listenerClass);
                     addAction(entry.getKey(), actionListener);
-                } catch (InstantiationException e) {
-                    DefaultLoader.getUIHelper().showException(e.getMessage(), e,
-                            "MS Services - Error", true, false);
-                } catch (IllegalAccessException e) {
-                    DefaultLoader.getUIHelper().showException(e.getMessage(), e,
-                            "MS Services - Error", true, false);
-                } catch (NoSuchMethodException e) {
-                    DefaultLoader.getUIHelper().showException(e.getMessage(), e,
-                            "MS Services - Error", true, false);
-                } catch (InvocationTargetException e) {
-                    DefaultLoader.getUIHelper().showException(e.getMessage(), e,
-                            "MS Services - Error", true, false);
+                } catch (final InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+                    DefaultLoader.getUIHelper().showException(e.getMessage(), e, "MS Services - Error", true, false);
                 }
             }
         }
@@ -297,18 +288,8 @@ public class Node implements MvpView, BasicTelemetryProperty {
                         addAction(nameAnnotation.value(), createNodeActionListener(actionListener));
                     }
                 }
-            } catch (InstantiationException e) {
-                DefaultLoader.getUIHelper().showException(e.getMessage(), e,
-                        "MS Services - Error", true, false);
-            } catch (IllegalAccessException e) {
-                DefaultLoader.getUIHelper().showException(e.getMessage(), e,
-                        "MS Services - Error", true, false);
-            } catch (NoSuchMethodException e) {
-                DefaultLoader.getUIHelper().showException(e.getMessage(), e,
-                        "MS Services - Error", true, false);
-            } catch (InvocationTargetException e) {
-                DefaultLoader.getUIHelper().showException(e.getMessage(), e,
-                        "MS Services - Error", true, false);
+            } catch (final InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                DefaultLoader.getUIHelper().showException(e.getMessage(), e, "MS Services - Error", true, false);
             }
         }
         return null;
@@ -328,12 +309,7 @@ public class Node implements MvpView, BasicTelemetryProperty {
     }
 
     public NodeAction getNodeActionByName(final String name) {
-        return Iterators.tryFind(nodeActions.iterator(), new Predicate<NodeAction>() {
-            @Override
-            public boolean apply(NodeAction nodeAction) {
-                return name.compareTo(nodeAction.getName()) == 0;
-            }
-        }).orNull();
+        return Iterators.tryFind(nodeActions.iterator(), nodeAction -> name.compareTo(nodeAction.getName()) == 0).orNull();
     }
 
     public boolean hasNodeActions() {
@@ -400,7 +376,8 @@ public class Node implements MvpView, BasicTelemetryProperty {
         Node.node2Actions = node2Actions;
     }
 
-    public void removeNode(String sid, String id, Node node) { }
+    public void removeNode(String sid, String id, Node node) {
+    }
 
     public Node createNode(Node parent, String sid, NodeContent content) {
         return new Node(content.getId(), content.getName());
@@ -412,23 +389,19 @@ public class Node implements MvpView, BasicTelemetryProperty {
         return TelemetryConstants.ACTION;
     }
 
-    public void openResourcesInPortal(String subscriptionId, String resourceRelativePath) throws AzureCmdException {
-        try {
-            final AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
-            // not signed in
-            if (azureManager == null) {
-                return;
-            }
-            final String portalUrl = azureManager.getPortalUrl();
-            final String tenantId = azureManager.getTenantIdBySubscription(subscriptionId);
-            String url = portalUrl
-                    + REST_SEGMENT_JOB_MANAGEMENT_TENANTID
-                    + tenantId
-                    + REST_SEGMENT_JOB_MANAGEMENT_RESOURCE
-                    + resourceRelativePath;
-            DefaultLoader.getIdeHelper().openLinkInBrowser(url);
-        } catch (IOException e) {
-            throw new AzureCmdException(OPEN_RESOURCES_IN_PORTAL_FAILED, e);
+    public void openResourcesInPortal(String subscriptionId, String resourceRelativePath) {
+        final AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
+        // not signed in
+        if (azureManager == null) {
+            return;
         }
+        final String portalUrl = azureManager.getPortalUrl();
+        final String tenantId = azureManager.getTenantIdBySubscription(subscriptionId);
+        final String url = portalUrl
+            + REST_SEGMENT_JOB_MANAGEMENT_TENANTID
+            + tenantId
+            + REST_SEGMENT_JOB_MANAGEMENT_RESOURCE
+            + resourceRelativePath;
+        DefaultLoader.getIdeHelper().openLinkInBrowser(url);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/ResourceManagementModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/ResourceManagementModule.java
@@ -27,12 +27,14 @@ import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.core.mvp.model.ResourceEx;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetrywrapper.EventUtil;
-import com.microsoft.azuretools.utils.*;
+import com.microsoft.azuretools.utils.AzureUIRefreshCore;
+import com.microsoft.azuretools.utils.AzureUIRefreshEvent;
+import com.microsoft.azuretools.utils.AzureUIRefreshListener;
+import com.microsoft.azuretools.utils.CanceledByUserException;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureRefreshableNode;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 
-import java.io.IOException;
 import java.util.List;
 
 public class ResourceManagementModule extends AzureRefreshableNode implements ResourceManagementModuleView {
@@ -54,8 +56,6 @@ public class ResourceManagementModule extends AzureRefreshableNode implements Re
     protected void refreshItems() throws AzureCmdException {
         try {
             rmModulePresenter.onModuleRefresh();
-        } catch (final IOException e) {
-            throw new RuntimeException(e);
         } catch (final CanceledByUserException e) {
             DefaultLoader.getUIHelper().showWarningNotification("Refreshing cancelled", "You canceled refreshing resource groups.");
         }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/ResourceManagementModulePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/ResourceManagementModulePresenter.java
@@ -23,32 +23,21 @@
 package com.microsoft.tooling.msservices.serviceexplorer.azure.arm;
 
 import com.microsoft.azure.management.Azure;
-import com.microsoft.azure.management.resources.Deployment;
-import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.core.mvp.model.AzureMvpModel;
-import com.microsoft.azuretools.core.mvp.model.ResourceEx;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
 import com.microsoft.azuretools.utils.CanceledByUserException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import rx.Observable;
-import rx.Observable.OnSubscribe;
-import rx.schedulers.Schedulers;
 
 public class ResourceManagementModulePresenter<V extends ResourceManagementModuleView> extends MvpPresenter<V> {
 
-    public void onModuleRefresh() throws IOException, CanceledByUserException {
+    public void onModuleRefresh() throws CanceledByUserException {
         final ResourceManagementModuleView view = getMvpView();
         if (view != null) {
             view.renderChildren(AzureMvpModel.getInstance().getResourceGroups(true));
         }
     }
 
-    public void onDeleteResourceGroup(String sid, String rgName) throws IOException {
+    public void onDeleteResourceGroup(String sid, String rgName) {
         Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
         azure.resourceGroups().deleteByName(rgName);
     }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/ResourceManagementNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/ResourceManagementNode.java
@@ -28,16 +28,13 @@ import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.core.mvp.model.ResourceEx;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetrywrapper.EventUtil;
-import com.microsoft.azuretools.utils.AzureUIRefreshCore;
-import com.microsoft.azuretools.utils.AzureUIRefreshEvent;
-import com.microsoft.azuretools.utils.AzureUIRefreshListener;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.arm.deployments.DeploymentNode;
-import java.io.IOException;
+
 import java.util.List;
 
 public class ResourceManagementNode extends RefreshableNode implements ResourceManagementNodeView {
@@ -63,11 +60,7 @@ public class ResourceManagementNode extends RefreshableNode implements ResourceM
 
     @Override
     protected void refreshItems() throws AzureCmdException {
-        try {
-            rmNodePresenter.onModuleRefresh(sid, rgName);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        rmNodePresenter.onModuleRefresh(sid, rgName);
     }
 
     @Override

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionModule.java
@@ -33,7 +33,6 @@ import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureRefreshableNode;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 
-import java.io.IOException;
 import java.util.List;
 
 public class FunctionModule extends AzureRefreshableNode implements FunctionModuleView {
@@ -57,7 +56,7 @@ public class FunctionModule extends AzureRefreshableNode implements FunctionModu
         try {
             functionModulePresenter.onDeleteFunctionApp(sid, id);
             removeDirectChildNode(node);
-        } catch (IOException | CloudException e) {
+        } catch (CloudException e) {
             DefaultLoader.getUIHelper().showException(String.format(FAILED_TO_DELETE_FUNCTION_APP, node.getName()),
                     e, ERROR_DELETING_FUNCTION_APP, false, true);
             functionModulePresenter.onModuleRefresh();

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionModulePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionModulePresenter.java
@@ -25,8 +25,6 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.function;
 import com.microsoft.azuretools.core.mvp.model.function.AzureFunctionMvpModel;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
 
-import java.io.IOException;
-
 public class FunctionModulePresenter<V extends FunctionModuleView> extends MvpPresenter<V> {
 
     public void onModuleRefresh() {
@@ -36,7 +34,7 @@ public class FunctionModulePresenter<V extends FunctionModuleView> extends MvpPr
         }
     }
 
-    public void onDeleteFunctionApp(String sid, String id) throws IOException {
+    public void onDeleteFunctionApp(String sid, String id) {
         AzureFunctionMvpModel.getInstance().deleteFunction(sid, id);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionNode.java
@@ -27,7 +27,7 @@ import com.google.gson.JsonObject;
 import com.microsoft.azure.management.appservice.FunctionApp;
 import com.microsoft.azure.management.appservice.FunctionEnvelope;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
-import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
@@ -51,7 +51,6 @@ import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.*;
@@ -96,11 +95,7 @@ public class FunctionNode extends WebAppBaseNode implements FunctionNodeView {
 
     @Override
     protected void refreshItems() {
-        try {
-            functionNodePresenter.onRefreshFunctionNode(this.subscriptionId, this.functionAppId);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, String.format(FAILED_TO_LOAD_TRIGGERS, functionAppName), e);
-        }
+        functionNodePresenter.onRefreshFunctionNode(this.subscriptionId, this.functionAppId);
     }
 
     @Override
@@ -126,20 +121,19 @@ public class FunctionNode extends WebAppBaseNode implements FunctionNodeView {
         addAction(ACTION_RESTART, new WrappedTelemetryNodeActionListener(FUNCTION, RESTART_FUNCTION_APP,
                 createBackgroundActionListener("Restarting", () -> restartFunctionApp())));
         addAction(ACTION_DELETE, new DeleteFunctionAppAction());
-        addAction("Open in portal", new WrappedTelemetryNodeActionListener(FUNCTION, OPEN_INBROWSER_FUNCTION_APP,
-                new NodeActionListener() {
-                    @Override
-                    protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
-                        openResourcesInPortal(subscriptionId, functionAppId);
-                    }
-                }));
-        addAction(ACTION_SHOW_PROPERTY, new WrappedTelemetryNodeActionListener(FUNCTION, SHOWPROP_FUNCTION_APP,
-                new NodeActionListener() {
-                    @Override
-                    protected void actionPerformed(NodeActionEvent e) {
-                        DefaultLoader.getUIHelper().openFunctionAppPropertyView(FunctionNode.this);
-                    }
-                }));
+        addAction("Open in portal", new WrappedTelemetryNodeActionListener(FUNCTION, OPEN_INBROWSER_FUNCTION_APP, new NodeActionListener() {
+            @Override
+            protected void actionPerformed(NodeActionEvent e) {
+                openResourcesInPortal(subscriptionId, functionAppId);
+            }
+        }));
+        addAction(ACTION_SHOW_PROPERTY, new WrappedTelemetryNodeActionListener(FUNCTION, SHOWPROP_FUNCTION_APP, new NodeActionListener() {
+            @Override
+            protected void actionPerformed(NodeActionEvent e) {
+                DefaultLoader.getUIHelper()
+                             .openFunctionAppPropertyView(FunctionNode.this);
+            }
+        }));
         super.loadActions();
     }
 
@@ -164,27 +158,15 @@ public class FunctionNode extends WebAppBaseNode implements FunctionNodeView {
     }
 
     public void startFunctionApp() {
-        try {
-            functionNodePresenter.onStartFunctionApp(this.subscriptionId, this.functionAppId);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, String.format(FAILED_TO_START_FUNCTION_APP, functionAppName), e);
-        }
+        functionNodePresenter.onStartFunctionApp(this.subscriptionId, this.functionAppId);
     }
 
     public void restartFunctionApp() {
-        try {
-            functionNodePresenter.onRestartFunctionApp(this.subscriptionId, this.functionAppId);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, String.format(FAILED_TO_RESTART_FUNCTION_APP, functionAppName), e);
-        }
+        functionNodePresenter.onRestartFunctionApp(this.subscriptionId, this.functionAppId);
     }
 
     public void stopFunctionApp() {
-        try {
-            functionNodePresenter.onStopFunctionApp(this.subscriptionId, this.functionAppId);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, String.format(FAILED_TO_STOP_FUNCTION_APP, functionAppName), e);
-        }
+        functionNodePresenter.onStopFunctionApp(this.subscriptionId, this.functionAppId);
     }
 
     // work around for API getMasterKey failed

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionNode.java
@@ -27,7 +27,6 @@ import com.google.gson.JsonObject;
 import com.microsoft.azure.management.appservice.FunctionApp;
 import com.microsoft.azure.management.appservice.FunctionEnvelope;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
-import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
 import com.microsoft.tooling.msservices.components.DefaultLoader;

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionNodePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionNodePresenter.java
@@ -27,32 +27,30 @@ import com.microsoft.azuretools.core.mvp.model.function.AzureFunctionMvpModel;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBaseState;
 
-import java.io.IOException;
-
 public class FunctionNodePresenter<V extends FunctionNodeView> extends MvpPresenter<V> {
-    public void onStartFunctionApp(String subscriptionId, String appId) throws IOException {
+    public void onStartFunctionApp(String subscriptionId, String appId) {
         AzureFunctionMvpModel.getInstance().startFunction(subscriptionId, appId);
         renderFunctionStatus(subscriptionId, appId);
     }
 
-    public void onRestartFunctionApp(String subscriptionId, String appId) throws IOException {
+    public void onRestartFunctionApp(String subscriptionId, String appId) {
         AzureFunctionMvpModel.getInstance().restartFunction(subscriptionId, appId);
         renderFunctionStatus(subscriptionId, appId);
     }
 
-    public void onStopFunctionApp(String subscriptionId, String appId) throws IOException {
+    public void onStopFunctionApp(String subscriptionId, String appId) {
         AzureFunctionMvpModel.getInstance().stopFunction(subscriptionId, appId);
         renderFunctionStatus(subscriptionId, appId);
     }
 
-    public void onRefreshFunctionNode(String subscriptionId, String appId) throws IOException {
+    public void onRefreshFunctionNode(String subscriptionId, String appId) {
         final FunctionNodeView view = getMvpView();
         if (view != null) {
             view.renderSubModules(AzureFunctionMvpModel.getInstance().listFunctionEnvelopeInFunctionApp(subscriptionId, appId));
         }
     }
 
-    private void renderFunctionStatus(String subscriptionId, String appId) throws IOException {
+    private void renderFunctionStatus(String subscriptionId, String appId) {
         final FunctionNodeView view = getMvpView();
         if (view != null) {
             final FunctionApp target = AzureFunctionMvpModel.getInstance().getFunctionById(subscriptionId, appId);

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisCacheModulePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisCacheModulePresenter.java
@@ -29,7 +29,6 @@ import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
 import com.microsoft.azuretools.core.mvp.ui.base.NodeContent;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -45,20 +44,15 @@ public class RedisCacheModulePresenter<V extends RedisCacheModule> extends MvpPr
      * Called from view when the view needs refresh.
      */
     public void onModuleRefresh() {
-        HashMap<String, ArrayList<NodeContent>> nodeMap = new HashMap<String, ArrayList<NodeContent>>();
-        try {
-            HashMap<String, RedisCaches> redisCachesMap = azureRedisMvpModel.getRedisCaches();
-            for (String sid : redisCachesMap.keySet()) {
-                ArrayList<NodeContent> nodeContentList = new ArrayList<NodeContent>();
-                for (RedisCache redisCache : redisCachesMap.get(sid).list()) {
-                    nodeContentList
-                            .add(new NodeContent(redisCache.id(), redisCache.name(), redisCache.provisioningState()));
-                }
-                nodeMap.put(sid, nodeContentList);
+        final HashMap<String, ArrayList<NodeContent>> nodeMap = new HashMap<>();
+        final HashMap<String, RedisCaches> redisCachesMap = azureRedisMvpModel.getRedisCaches();
+        for (final String sid : redisCachesMap.keySet()) {
+            final ArrayList<NodeContent> nodeContentList = new ArrayList<>();
+            for (final RedisCache redisCache : redisCachesMap.get(sid).list()) {
+                nodeContentList
+                    .add(new NodeContent(redisCache.id(), redisCache.name(), redisCache.provisioningState()));
             }
-        } catch (IOException e) {
-            getMvpView().onErrorWithException(CANNOT_GET_REDIS_ID, e);
-            return;
+            nodeMap.put(sid, nodeContentList);
         }
         getMvpView().showNode(nodeMap);
     }
@@ -82,12 +76,7 @@ public class RedisCacheModulePresenter<V extends RedisCacheModule> extends MvpPr
             getMvpView().onError(CANNOT_GET_REDIS_ID);
             return;
         }
-        try {
-            azureRedisMvpModel.deleteRedisCache(sid, id);
-        } catch (IOException e) {
-            getMvpView().onErrorWithException(CANNOT_DELETE_REDIS, e);
-            return;
-        }
+        azureRedisMvpModel.deleteRedisCache(sid, id);
         getMvpView().removeDirectChildNode(node);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudAppNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudAppNode.java
@@ -25,7 +25,6 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.springcloud;
 import com.microsoft.azure.management.appplatform.v2019_05_01_preview.DeploymentResourceStatus;
 import com.microsoft.azure.management.appplatform.v2019_05_01_preview.implementation.AppResourceInner;
 import com.microsoft.azure.management.appplatform.v2019_05_01_preview.implementation.DeploymentResourceInner;
-import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.core.mvp.model.springcloud.SpringCloudIdHelper;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.*;
@@ -33,9 +32,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPro
 import io.reactivex.rxjava3.disposables.Disposable;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.*;
@@ -131,13 +128,12 @@ public class SpringCloudAppNode extends Node implements SpringCloudAppNodeView {
 
         addAction(ACTION_DELETE, new DeleteSpringCloudAppAction());
 
-        addAction(ACTION_OPEN_IN_PORTAL, new WrappedTelemetryNodeActionListener(SPRING_CLOUD, OPEN_IN_PORTAL_SPRING_CLOUD_APP,
-            new NodeActionListener() {
-                @Override
-                protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
-                    openResourcesInPortal(getSubscriptionId(), getAppId());
-                }
-            }));
+        addAction(ACTION_OPEN_IN_PORTAL, new WrappedTelemetryNodeActionListener(SPRING_CLOUD, OPEN_IN_PORTAL_SPRING_CLOUD_APP, new NodeActionListener() {
+            @Override
+            protected void actionPerformed(NodeActionEvent e) {
+                openResourcesInPortal(getSubscriptionId(), getAppId());
+            }
+        }));
         addAction(ACTION_OPEN_IN_BROWSER, new WrappedTelemetryNodeActionListener(SPRING_CLOUD, OPEN_IN_BROWSER_SPRING_CLOUD_APP, new NodeActionListener() {
             @Override
             protected void actionPerformed(NodeActionEvent e) {
@@ -150,19 +146,15 @@ public class SpringCloudAppNode extends Node implements SpringCloudAppNodeView {
                 }
             }
         }));
-        addAction(ACTION_SHOW_PROPERTY, new WrappedTelemetryNodeActionListener(SPRING_CLOUD, SHOWPROP_SPRING_CLOUD_APP,
-            new NodeActionListener() {
-                @Override
-                protected void actionPerformed(NodeActionEvent e) {
-                    DefaultLoader.getUIHelper().openSpringCloudAppPropertyView(
-                           SpringCloudAppNode.this);
-                    // add this statement for false updating notice to update Property view
-                    // immediately
-                    SpringCloudStateManager.INSTANCE.notifySpringAppUpdate(clusterId,
-                                                                          app, deploy);
-
-                }
-            }));
+        addAction(ACTION_SHOW_PROPERTY, new WrappedTelemetryNodeActionListener(SPRING_CLOUD, SHOWPROP_SPRING_CLOUD_APP, new NodeActionListener() {
+            @Override
+            protected void actionPerformed(NodeActionEvent e) {
+                DefaultLoader.getUIHelper().openSpringCloudAppPropertyView(SpringCloudAppNode.this);
+                // add this statement for false updating notice to update Property view
+                // immediately
+                SpringCloudStateManager.INSTANCE.notifySpringAppUpdate(clusterId, app, deploy);
+            }
+        }));
         super.loadActions();
     }
 
@@ -187,27 +179,15 @@ public class SpringCloudAppNode extends Node implements SpringCloudAppNodeView {
     }
 
     private void startSpringCloudApp() {
-        try {
-            springCloudAppNodePresenter.onStartSpringCloudApp(this.app.id(), this.app.properties().activeDeploymentName(), status);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, String.format(FAILED_TO_START_APP, this.app.name()), e);
-        }
+        springCloudAppNodePresenter.onStartSpringCloudApp(this.app.id(), this.app.properties().activeDeploymentName(), status);
     }
 
     private void restartSpringCloudApp() {
-        try {
-            springCloudAppNodePresenter.onReStartSpringCloudApp(this.app.id(), this.app.properties().activeDeploymentName(), status);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, String.format(FAILED_TO_RESTART_APP, this.app.name()), e);
-        }
+        springCloudAppNodePresenter.onReStartSpringCloudApp(this.app.id(), this.app.properties().activeDeploymentName(), status);
     }
 
     private void stopSpringCloudApp() {
-        try {
-            springCloudAppNodePresenter.onStopSpringCloudApp(this.app.id(), this.app.properties().activeDeploymentName(), status);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, String.format(FAILED_TO_STOP_APP, this.app.name()), e);
-        }
+        springCloudAppNodePresenter.onStopSpringCloudApp(this.app.id(), this.app.properties().activeDeploymentName(), status);
     }
 
     private void syncActionState() {
@@ -250,12 +230,7 @@ public class SpringCloudAppNode extends Node implements SpringCloudAppNodeView {
 
         @Override
         protected void azureNodeAction(NodeActionEvent event) {
-            try {
-                springCloudAppNodePresenter.onDeleteApp(id);
-            } catch (IOException e) {
-                DefaultLoader.getUIHelper().showException(String.format(FAILED_TO_DELETE_APP, SpringCloudAppNode.this.getName()),
-                                                          e, ERROR_DELETING_APP, false, true);
-            }
+            springCloudAppNodePresenter.onDeleteApp(id);
         }
 
         @Override

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudAppNodePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudAppNodePresenter.java
@@ -32,7 +32,6 @@ import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -44,27 +43,27 @@ public class SpringCloudAppNodePresenter<V extends SpringCloudAppNodeView> exten
     private static final Logger LOGGER = Logger.getLogger(SpringCloudAppNodePresenter.class.getName());
     private static final String FAILED_TO_STOP_APP = "Failed to refresh Spring Cloud App: %s";
 
-    public void onStartSpringCloudApp(String appId, String activeDeploymentName, DeploymentResourceStatus originalStatus) throws IOException {
+    public void onStartSpringCloudApp(String appId, String activeDeploymentName, DeploymentResourceStatus originalStatus) {
         AzureSpringCloudMvpModel.startApp(appId, activeDeploymentName).await();
         waitUntilStatusChanged(appId, originalStatus);
     }
 
-    public void onStopSpringCloudApp(String appId, String activeDeploymentName, DeploymentResourceStatus originalStatus) throws IOException {
+    public void onStopSpringCloudApp(String appId, String activeDeploymentName, DeploymentResourceStatus originalStatus) {
         AzureSpringCloudMvpModel.stopApp(appId, activeDeploymentName).await();
         waitUntilStatusChanged(appId, originalStatus);
     }
 
-    public void onReStartSpringCloudApp(String appId, String activeDeploymentName, DeploymentResourceStatus originalStatus) throws IOException {
+    public void onReStartSpringCloudApp(String appId, String activeDeploymentName, DeploymentResourceStatus originalStatus) {
         AzureSpringCloudMvpModel.restartApp(appId, activeDeploymentName).await();
         waitUntilStatusChanged(appId, originalStatus);
     }
 
-    public void onDeleteApp(final String appId) throws IOException {
+    public void onDeleteApp(final String appId) {
         AzureSpringCloudMvpModel.deleteApp(appId).await();
         waitUntilStatusChanged(appId, null);
     }
 
-    public static void awaitAndMonitoringStatus(String appId, DeploymentResourceStatus originalStatus) throws IOException, InterruptedException {
+    public static void awaitAndMonitoringStatus(String appId, DeploymentResourceStatus originalStatus) {
         String clusterId = getParentSegment(appId);
         ExecutorService executor = Executors.newSingleThreadExecutor();
         Future future = executor.submit(() -> {
@@ -85,7 +84,7 @@ public class SpringCloudAppNodePresenter<V extends SpringCloudAppNodeView> exten
                     status = deployment.properties().status();
                     SpringCloudStateManager.INSTANCE.notifySpringAppUpdate(clusterId, app, deployment);
                     Thread.sleep(1000 * 5);
-                } catch (IOException | InterruptedException e) {
+                } catch (InterruptedException e) {
                     SneakyThrowUtils.sneakyThrow(e);
                 }
 
@@ -100,11 +99,7 @@ public class SpringCloudAppNodePresenter<V extends SpringCloudAppNodeView> exten
     }
 
     private void waitUntilStatusChanged(String appId, DeploymentResourceStatus originalStatus) {
-        try {
-            awaitAndMonitoringStatus(appId, originalStatus);
-        } catch (IOException | InterruptedException e) {
-            LOGGER.log(Level.SEVERE, String.format(FAILED_TO_STOP_APP, SpringCloudIdHelper.getAppName(appId)), e);
-        }
+        awaitAndMonitoringStatus(appId, originalStatus);
     }
 
     private static String getParentSegment(String id) {

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudModulePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudModulePresenter.java
@@ -24,9 +24,6 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.springcloud;
 
 import com.microsoft.azuretools.core.mvp.model.springcloud.AzureSpringCloudMvpModel;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
-import com.microsoft.tooling.msservices.components.DefaultLoader;
-
-import java.io.IOException;
 
 public class SpringCloudModulePresenter<V extends SpringCloudModuleView> extends MvpPresenter<V> {
     private static final String FAILED_TO_LOAD_CLUSTERS = "Failed to load Spring Cloud Clusters.";
@@ -35,11 +32,7 @@ public class SpringCloudModulePresenter<V extends SpringCloudModuleView> extends
     public void onSpringCloudRefresh() {
         final SpringCloudModuleView view = getMvpView();
         if (view != null) {
-            try {
-                view.renderChildren(AzureSpringCloudMvpModel.listAllSpringCloudClusters());
-            } catch (final IOException e) {
-                DefaultLoader.getUIHelper().showException(FAILED_TO_LOAD_CLUSTERS, e, ERROR_LOAD_CLUSTER, false, true);
-            }
+            view.renderChildren(AzureSpringCloudMvpModel.listAllSpringCloudClusters());
         }
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudNode.java
@@ -30,16 +30,13 @@ import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetry.TelemetryProperties;
-import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.*;
 import io.reactivex.rxjava3.disposables.Disposable;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.OPEN_IN_PORTAL_SPRING_CLOUD_APP;
@@ -95,24 +92,17 @@ public class SpringCloudNode extends RefreshableNode implements TelemetryPropert
     @Override
     protected void loadActions() {
         super.loadActions();
-        addAction(ACTION_OPEN_IN_PORTAL, new WrappedTelemetryNodeActionListener(SPRING_CLOUD, OPEN_IN_PORTAL_SPRING_CLOUD_APP,
-            new NodeActionListener() {
-                @Override
-                protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
-                    openResourcesInPortal(subscriptionId, clusterId);
-                }
-            }));
+        addAction(ACTION_OPEN_IN_PORTAL, new WrappedTelemetryNodeActionListener(SPRING_CLOUD, OPEN_IN_PORTAL_SPRING_CLOUD_APP, new NodeActionListener() {
+            @Override
+            protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
+                openResourcesInPortal(subscriptionId, clusterId);
+            }
+        }));
     }
 
     @Override
     protected void refreshItems() {
-        try {
-            springCloudNodePresenter.onRefreshSpringCloudServiceNode(this.subscriptionId, this.clusterId);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, String.format(FAILED_TO_LOAD_APPS, this.clusterName), e);
-            DefaultLoader.getUIHelper().showException(String.format(FAILED_TO_LOAD_APPS, this.clusterName),
-                                                      e, ERROR_LOAD_APP, false, true);
-        }
+        springCloudNodePresenter.onRefreshSpringCloudServiceNode(this.subscriptionId, this.clusterId);
     }
 
     @Override

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudNodePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudNodePresenter.java
@@ -29,14 +29,12 @@ import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
 import org.apache.commons.lang3.StringUtils;
 import rx.Observable;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class SpringCloudNodePresenter<V extends SpringCloudNodeView> extends MvpPresenter<V> {
-    public void onRefreshSpringCloudServiceNode(final String subscriptionId, final String clusterId)
-            throws IOException {
+    public void onRefreshSpringCloudServiceNode(final String subscriptionId, final String clusterId) {
         final SpringCloudNodeView view = getMvpView();
         if (view != null) {
             final List<AppResourceInner> appList = AzureSpringCloudMvpModel.listAppsByClusterId(clusterId);

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppModule.java
@@ -22,8 +22,6 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
 
-import java.io.IOException;
-
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.resources.fluentcore.arm.ResourceId;
@@ -68,7 +66,7 @@ public class WebAppModule extends AzureRefreshableNode implements WebAppModuleVi
         try {
             webAppModulePresenter.onDeleteWebApp(sid, id);
             removeDirectChildNode(node);
-        } catch (IOException | CloudException e) {
+        } catch (CloudException e) {
             DefaultLoader.getUIHelper().showException("An error occurred while attempting to delete the Web App ",
                     e, "Azure Services Explorer - Error Deleting Web App for Containers", false, true);
         }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppModulePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppModulePresenter.java
@@ -22,8 +22,6 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
 
-import java.io.IOException;
-
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
 
@@ -38,7 +36,7 @@ public class WebAppModulePresenter<V extends WebAppModuleView> extends MvpPresen
         }
     }
 
-    public void onDeleteWebApp(String sid, String id) throws IOException {
+    public void onDeleteWebApp(String sid, String id) {
         AzureWebAppMvpModel.getInstance().deleteWebApp(sid, id);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppNode.java
@@ -37,7 +37,6 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebApp
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotModule;
 import org.apache.commons.lang.StringUtils;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -124,30 +123,15 @@ public class WebAppNode extends WebAppBaseNode implements WebAppNodeView {
     }
 
     public void startWebApp() {
-        try {
-            webAppNodePresenter.onStartWebApp(this.subscriptionId, this.webapp.id());
-        } catch (IOException e) {
-            e.printStackTrace();
-            // TODO: Error handling
-        }
+        webAppNodePresenter.onStartWebApp(this.subscriptionId, this.webapp.id());
     }
 
     public void restartWebApp() {
-        try {
-            webAppNodePresenter.onRestartWebApp(this.subscriptionId, this.webapp.id());
-        } catch (IOException e) {
-            e.printStackTrace();
-            // TODO: Error handling
-        }
+        webAppNodePresenter.onRestartWebApp(this.subscriptionId, this.webapp.id());
     }
 
     public void stopWebApp() {
-        try {
-            webAppNodePresenter.onStopWebApp(this.subscriptionId, this.webapp.id());
-        } catch (IOException e) {
-            e.printStackTrace();
-            // TODO: Error handling
-        }
+        webAppNodePresenter.onStopWebApp(this.subscriptionId, this.webapp.id());
     }
 
     @Override

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppNodePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppNodePresenter.java
@@ -25,10 +25,9 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBaseState;
-import java.io.IOException;
 
 public class WebAppNodePresenter<V extends WebAppNodeView> extends MvpPresenter<V> {
-    public void onStartWebApp(String subscriptionId, String webAppId) throws IOException {
+    public void onStartWebApp(String subscriptionId, String webAppId) {
         AzureWebAppMvpModel.getInstance().startWebApp(subscriptionId, webAppId);
         final WebAppNodeView view = getMvpView();
         if (view == null) {
@@ -37,7 +36,7 @@ public class WebAppNodePresenter<V extends WebAppNodeView> extends MvpPresenter<
         view.renderNode(WebAppBaseState.RUNNING);
     }
 
-    public void onRestartWebApp(String subscriptionId, String webAppId) throws IOException {
+    public void onRestartWebApp(String subscriptionId, String webAppId) {
         AzureWebAppMvpModel.getInstance().restartWebApp(subscriptionId, webAppId);
         final WebAppNodeView view = getMvpView();
         if (view == null) {
@@ -46,7 +45,7 @@ public class WebAppNodePresenter<V extends WebAppNodeView> extends MvpPresenter<
         view.renderNode(WebAppBaseState.RUNNING);
     }
 
-    public void onStopWebApp(String subscriptionId, String webAppId) throws IOException {
+    public void onStopWebApp(String subscriptionId, String webAppId) {
         AzureWebAppMvpModel.getInstance().stopWebApp(subscriptionId, webAppId);
         final WebAppNodeView view = getMvpView();
         if (view == null) {

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyViewPresenter.java
@@ -22,22 +22,20 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import com.microsoft.azure.management.appservice.DeploymentSlot;
 import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
+import java.util.Map;
+import java.util.Set;
+
 public class WebAppPropertyViewPresenter extends WebAppBasePropertyViewPresenter {
     @Override
     protected void updateAppSettings(@NotNull final String sid, @NotNull final String webAppId,
                                      @Nullable final String name, final Map toUpdate,
-                                     final Set toRemove) throws Exception {
+                                     final Set toRemove) {
         AzureWebAppMvpModel.getInstance().updateWebAppSettings(sid, webAppId, toUpdate, toRemove);
     }
 
@@ -50,7 +48,7 @@ public class WebAppPropertyViewPresenter extends WebAppBasePropertyViewPresenter
 
     @Override
     protected WebAppBase getWebAppBase(@NotNull final String sid, @NotNull final String webAppId,
-                                       @Nullable final String name) throws Exception {
+                                       @Nullable final String name) {
         return AzureWebAppMvpModel.getInstance().getWebAppById(sid, webAppId);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotModule.java
@@ -26,7 +26,6 @@ import com.microsoft.azure.management.appservice.DeploymentSlot;
 import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
-import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureRefreshableNode;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppModule;
@@ -52,22 +51,13 @@ public class DeploymentSlotModule extends AzureRefreshableNode implements Deploy
 
     @Override
     public void removeNode(final String sid, final String name, Node node) {
-        try {
-            presenter.onDeleteDeploymentSlot(sid, this.webapp.id(), name);
-            removeDirectChildNode(node);
-        } catch (Exception e) {
-            DefaultLoader.getUIHelper().showException("An error occurred while attempting to delete the Deployment Slot",
-                                                      e, "Azure Services Explorer - Error Deleting Deployment Slot", false, true);
-        }
+        presenter.onDeleteDeploymentSlot(sid, this.webapp.id(), name);
+        removeDirectChildNode(node);
     }
 
     @Override
     protected void refreshItems() throws AzureCmdException {
-        try {
-            presenter.onRefreshDeploymentSlotModule(this.subscriptionId, this.webapp.id());
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
+        presenter.onRefreshDeploymentSlotModule(this.subscriptionId, this.webapp.id());
     }
 
     @Override

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotModulePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotModulePresenter.java
@@ -24,10 +24,9 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deployment
 
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
-import java.io.IOException;
 
 public class DeploymentSlotModulePresenter<V extends DeploymentSlotModuleView> extends MvpPresenter<V> {
-    public void onRefreshDeploymentSlotModule(final String subscriptionId, final String webAppId) throws IOException {
+    public void onRefreshDeploymentSlotModule(final String subscriptionId, final String webAppId) {
         final DeploymentSlotModuleView view = getMvpView();
         if (view != null) {
             view.renderDeploymentSlots(AzureWebAppMvpModel.getInstance().getDeploymentSlots(subscriptionId, webAppId));
@@ -35,7 +34,7 @@ public class DeploymentSlotModulePresenter<V extends DeploymentSlotModuleView> e
     }
 
     public void onDeleteDeploymentSlot(final String subscriptionId, final String webAppId,
-                                       final String slotName) throws IOException {
+                                       final String slotName) {
         AzureWebAppMvpModel.getInstance().deleteDeploymentSlotNode(subscriptionId, webAppId, slotName);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNode.java
@@ -84,8 +84,7 @@ public class DeploymentSlotNode extends WebAppBaseNode implements DeploymentSlot
             createBackgroundActionListener("Restarting Deployment Slot", () -> restart())));
         addAction(ACTION_SWAP_WITH_PRODUCTION, new WrappedTelemetryNodeActionListener(WEBAPP, SWAP_WEBAPP_SLOT,
             createBackgroundActionListener("Swapping with Production", () -> swapWithProduction())));
-        addAction(ACTION_OPEN_IN_BROWSER, new WrappedTelemetryNodeActionListener(WEBAPP, OPERN_WEBAPP_SLOT_BROWSER,
-            new NodeActionListener() {
+        addAction(ACTION_OPEN_IN_BROWSER, new WrappedTelemetryNodeActionListener(WEBAPP, OPERN_WEBAPP_SLOT_BROWSER, new NodeActionListener() {
             @Override
             protected void actionPerformed(NodeActionEvent e) {
                 DefaultLoader.getUIHelper().openInBrowser("http://" + hostName);

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNode.java
@@ -22,27 +22,18 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot;
 
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.DELETE_WEBAPP_SLOT;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.OPERN_WEBAPP_SLOT_BROWSER;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.RESTART_WEBAPP_SLOT;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.SHOW_WEBAPP_SLOT_PROP;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.START_WEBAPP_SLOT;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.STOP_WEBAPP_SLOT;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.SWAP_WEBAPP_SLOT;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP;
-
-import com.microsoft.tooling.msservices.serviceexplorer.WrappedTelemetryNodeActionListener;
-import java.io.IOException;
-import java.util.List;
-
-import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeAction;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
+import com.microsoft.tooling.msservices.serviceexplorer.WrappedTelemetryNodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBaseNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBaseState;
+
+import java.util.List;
+
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.*;
 
 public class DeploymentSlotNode extends WebAppBaseNode implements DeploymentSlotNodeView {
     private static final String ACTION_SWAP_WITH_PRODUCTION = "Swap with production";
@@ -101,14 +92,13 @@ public class DeploymentSlotNode extends WebAppBaseNode implements DeploymentSlot
             }
         }));
         addAction(ACTION_DELETE, new DeleteDeploymentSlotAction());
-        addAction(ACTION_SHOW_PROPERTY, new WrappedTelemetryNodeActionListener(WEBAPP, SHOW_WEBAPP_SLOT_PROP,
-            new NodeActionListener() {
-                @Override
-                protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
-                    DefaultLoader.getUIHelper().openDeploymentSlotPropertyView(DeploymentSlotNode.this);
-                }
-            }));
-
+        addAction(ACTION_SHOW_PROPERTY, new WrappedTelemetryNodeActionListener(WEBAPP, SHOW_WEBAPP_SLOT_PROP, new NodeActionListener() {
+            @Override
+            protected void actionPerformed(NodeActionEvent e) {
+                DefaultLoader.getUIHelper().openDeploymentSlotPropertyView(
+                    DeploymentSlotNode.this);
+            }
+        }));
         super.loadActions();
     }
 
@@ -120,49 +110,24 @@ public class DeploymentSlotNode extends WebAppBaseNode implements DeploymentSlot
     }
 
     private void start() {
-        try {
-            presenter.onStartDeploymentSlot(this.subscriptionId, this.webAppId, this.slotName);
-        } catch (IOException e) {
-            e.printStackTrace();
-            // TODO: Error handling
-        }
+        presenter.onStartDeploymentSlot(this.subscriptionId, this.webAppId, this.slotName);
     }
 
     private void stop() {
-        try {
-            presenter.onStopDeploymentSlot(this.subscriptionId, this.webAppId, this.slotName);
-        } catch (IOException e) {
-            e.printStackTrace();
-            // TODO: Error handling
-        }
+        presenter.onStopDeploymentSlot(this.subscriptionId, this.webAppId, this.slotName);
     }
 
     private void restart() {
-        try {
-            presenter.onRestartDeploymentSlot(this.subscriptionId, this.webAppId, this.slotName);
-        } catch (IOException e) {
-            e.printStackTrace();
-            // TODO: Error handling
-        }
+        presenter.onRestartDeploymentSlot(this.subscriptionId, this.webAppId, this.slotName);
     }
 
     private void swapWithProduction() {
-        try {
-            presenter.onSwapWithProduction(this.subscriptionId, this.webAppId, this.slotName);
-        } catch (IOException e) {
-            e.printStackTrace();
-            // TODO: Error handling
-        }
+        presenter.onSwapWithProduction(this.subscriptionId, this.webAppId, this.slotName);
     }
 
     @Override
     protected void refreshItems() {
-        try {
-            presenter.onRefreshNode(this.subscriptionId, this.webAppId, this.slotName);
-        } catch (Exception e) {
-            e.printStackTrace();
-            // TODO: Error handling
-        }
+        presenter.onRefreshNode(this.subscriptionId, this.webAppId, this.slotName);
     }
 
     private class DeleteDeploymentSlotAction extends AzureNodeActionPromptListener {

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNodePresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNodePresenter.java
@@ -22,8 +22,6 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot;
 
-import java.io.IOException;
-
 import com.microsoft.azure.management.appservice.DeploymentSlot;
 import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
@@ -32,7 +30,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebApp
 
 public class DeploymentSlotNodePresenter<V extends DeploymentSlotNodeView> extends MvpPresenter<V> {
     public void onStartDeploymentSlot(final String subscriptionId, final String webAppId,
-                                      final String slotName) throws IOException {
+                                      final String slotName) {
         AzureWebAppMvpModel.getInstance().startDeploymentSlot(subscriptionId, webAppId, slotName);
         final DeploymentSlotNodeView view = getMvpView();
         if (!isViewDetached()) {
@@ -41,7 +39,7 @@ public class DeploymentSlotNodePresenter<V extends DeploymentSlotNodeView> exten
     }
 
     public void onStopDeploymentSlot(final String subscriptionId, final String webAppId,
-                                     final String slotName) throws IOException {
+                                     final String slotName) {
         AzureWebAppMvpModel.getInstance().stopDeploymentSlot(subscriptionId, webAppId, slotName);
         final DeploymentSlotNodeView view = getMvpView();
         if (!isViewDetached()) {
@@ -50,7 +48,7 @@ public class DeploymentSlotNodePresenter<V extends DeploymentSlotNodeView> exten
     }
 
     public void onRestartDeploymentSlot(final String subscriptionId, final String webAppId,
-                                        final String slotName) throws IOException {
+                                        final String slotName) {
         AzureWebAppMvpModel.getInstance().restartDeploymentSlot(subscriptionId, webAppId, slotName);
         final DeploymentSlotNodeView view = getMvpView();
         if (!isViewDetached()) {
@@ -59,7 +57,7 @@ public class DeploymentSlotNodePresenter<V extends DeploymentSlotNodeView> exten
     }
 
     public void onRefreshNode(final String subscriptionId, final String webAppId,
-                              final String slotName) throws Exception {
+                              final String slotName) {
         final WebApp app = AzureWebAppMvpModel.getInstance().getWebAppById(subscriptionId, webAppId);
         final DeploymentSlot slot = app.deploymentSlots().getByName(slotName);
         final DeploymentSlotNodeView view = getMvpView();
@@ -69,7 +67,7 @@ public class DeploymentSlotNodePresenter<V extends DeploymentSlotNodeView> exten
     }
 
     public void onSwapWithProduction(final String subscriptionId, final String webAppId,
-                                     final String slotName) throws IOException {
+                                     final String slotName) {
         AzureWebAppMvpModel.getInstance().swapSlotWithProduction(subscriptionId, webAppId, slotName);
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
@@ -22,36 +22,34 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import com.microsoft.azure.management.appservice.DeploymentSlot;
 import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
+import java.util.Map;
+import java.util.Set;
+
 public class DeploymentSlotPropertyViewPresenter extends WebAppBasePropertyViewPresenter {
     @Override
     protected void updateAppSettings(@NotNull final String sid, @NotNull final String webAppId,
                                      @Nullable final String name, final Map toUpdate,
-                                     final Set toRemove) throws Exception {
+                                     final Set toRemove) {
         AzureWebAppMvpModel.getInstance().updateDeploymentSlotAppSettings(sid, webAppId, name, toUpdate, toRemove);
     }
 
     @Override
     protected boolean getPublishingProfile(@NotNull final String subscriptionId, @NotNull final String webAppId,
                                            @Nullable final String name,
-                                           @NotNull final String filePath) throws Exception {
+                                           @NotNull final String filePath) {
         return AzureWebAppMvpModel.getInstance()
             .getSlotPublishingProfileXmlWithSecrets(subscriptionId, webAppId, name, filePath);
     }
 
     @Override
     protected WebAppBase getWebAppBase(@NotNull final String sid, @NotNull final String webAppId,
-                                       @Nullable final String name) throws Exception {
+                                       @Nullable final String name) {
         return AzureWebAppMvpModel.getInstance().getWebAppById(sid, webAppId).deploymentSlots().getByName(name);
     }
 }

--- a/Utils/azure-explorer-common/test/java/com/microsoft/tooling/IntegrationTestBase.java
+++ b/Utils/azure-explorer-common/test/java/com/microsoft/tooling/IntegrationTestBase.java
@@ -23,8 +23,6 @@
 package com.microsoft.tooling;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Rule;
-import org.junit.rules.TestName;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -36,13 +34,11 @@ import com.microsoft.azure.credentials.ApplicationTokenCredentials;
 import com.microsoft.azure.serializer.AzureJacksonAdapter;
 import com.microsoft.rest.LogLevel;
 import com.microsoft.rest.RestClient;
-
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,6 +46,9 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
 public abstract class IntegrationTestBase {
     private static final String GLOBAL_ENDPOINT = "https://management.azure.com";
@@ -130,7 +129,7 @@ public abstract class IntegrationTestBase {
             return;
         }
         wireMock.resetMappings();
-        restClient=null;
+        restClient = null;
         testRecord = null;
         currentTestName = null;
     }
@@ -197,24 +196,24 @@ public abstract class IntegrationTestBase {
 
         UrlPattern urlPattern = urlEqualTo(recordUrl);
         String method = networkCallRecord.Method;
-        MappingBuilder mBuilder;
+        MappingBuilder methodBuilder;
         if (method.equals("GET")) {
-            mBuilder = get(urlPattern);
+            methodBuilder = get(urlPattern);
         } else if (method.equals("POST")) {
-            mBuilder = post(urlPattern);
+            methodBuilder = post(urlPattern);
         } else if (method.equals("PUT")) {
-            mBuilder = put(urlPattern);
+            methodBuilder = put(urlPattern);
         } else if (method.equals("DELETE")) {
-            mBuilder = delete(urlPattern);
+            methodBuilder = delete(urlPattern);
         } else if (method.equals("PATCH")) {
-            mBuilder = patch(urlPattern);
+            methodBuilder = patch(urlPattern);
         } else if (method.equals("HEAD")) {
-            mBuilder = head(urlPattern);
+            methodBuilder = head(urlPattern);
         } else {
             throw new Exception("Invalid HTTP method.");
         }
 
-        ResponseDefinitionBuilder rBuilder = aResponse()
+        ResponseDefinitionBuilder responseBuilder = aResponse()
                 .withStatus(Integer.parseInt(networkCallRecord.Response.get("StatusCode")));
         for (Entry<String, String> header : networkCallRecord.Response.entrySet()) {
             if (!header.getKey().equals("StatusCode") && !header.getKey().equals("Body")
@@ -225,7 +224,7 @@ public abstract class IntegrationTestBase {
                         rawHeader = rawHeader.replaceAll(rule.getKey(), rule.getValue());
                     }
                 }
-                rBuilder.withHeader(header.getKey(), rawHeader);
+                responseBuilder.withHeader(header.getKey(), rawHeader);
             }
         }
 
@@ -236,12 +235,12 @@ public abstract class IntegrationTestBase {
                     rawBody = rawBody.replaceAll(rule.getKey(), rule.getValue());
                 }
             }
-            rBuilder.withBody(rawBody);
-            rBuilder.withHeader("Content-Length", String.valueOf(rawBody.getBytes("UTF-8").length));
+            responseBuilder.withBody(rawBody);
+            responseBuilder.withHeader("Content-Length", String.valueOf(rawBody.getBytes("UTF-8").length));
         }
 
-        mBuilder.willReturn(rBuilder);
-        wireMock.stubFor(mBuilder);
+        methodBuilder.willReturn(responseBuilder);
+        wireMock.stubFor(methodBuilder);
     }
 
     protected void addTextReplacementRule(String regex, String replacement) {

--- a/Utils/azuretools-core/src/com/microsoft/azure/toolkit/lib/common/exception/AzureToolkitException.java
+++ b/Utils/azuretools-core/src/com/microsoft/azure/toolkit/lib/common/exception/AzureToolkitException.java
@@ -20,24 +20,28 @@
  * SOFTWARE.
  */
 
-package com.microsoft.tooling.msservices.serviceexplorer.azure.arm;
+package com.microsoft.azure.toolkit.lib.common.exception;
 
-import com.microsoft.azure.management.Azure;
-import com.microsoft.azuretools.authmanage.AuthMethodManager;
-import com.microsoft.azuretools.core.mvp.model.AzureMvpModel;
-import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
+import lombok.Getter;
 
-public class ResourceManagementNodePresenter<V extends ResourceManagementNodeView> extends MvpPresenter<V> {
+@Getter
+public class AzureToolkitException extends Exception {
+    private final String action;
 
-    public void onModuleRefresh(String sid, String rgName) {
-        final ResourceManagementNodeView view = getMvpView();
-        if (view != null) {
-            view.renderChildren(AzureMvpModel.getInstance().getDeploymentByRgName(sid, rgName));
-        }
+    public AzureToolkitException(String error) {
+        this(error, null, null);
     }
 
-    public void onDeleteDeployment(String sid, String deploymentId) {
-        final Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
-        azure.deployments().deleteById(deploymentId);
+    public AzureToolkitException(String error, Throwable cause) {
+        this(error, cause, null);
+    }
+
+    public AzureToolkitException(String error, String action) {
+        this(error, null, action);
+    }
+
+    public AzureToolkitException(String error, Throwable cause, String action) {
+        super(error, cause);
+        this.action = action;
     }
 }

--- a/Utils/azuretools-core/src/com/microsoft/azure/toolkit/lib/common/exception/AzureToolkitRuntimeException.java
+++ b/Utils/azuretools-core/src/com/microsoft/azure/toolkit/lib/common/exception/AzureToolkitRuntimeException.java
@@ -20,24 +20,28 @@
  * SOFTWARE.
  */
 
-package com.microsoft.tooling.msservices.serviceexplorer.azure.arm;
+package com.microsoft.azure.toolkit.lib.common.exception;
 
-import com.microsoft.azure.management.Azure;
-import com.microsoft.azuretools.authmanage.AuthMethodManager;
-import com.microsoft.azuretools.core.mvp.model.AzureMvpModel;
-import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter;
+import lombok.Getter;
 
-public class ResourceManagementNodePresenter<V extends ResourceManagementNodeView> extends MvpPresenter<V> {
+@Getter
+public class AzureToolkitRuntimeException extends RuntimeException {
+    private final String action;
 
-    public void onModuleRefresh(String sid, String rgName) {
-        final ResourceManagementNodeView view = getMvpView();
-        if (view != null) {
-            view.renderChildren(AzureMvpModel.getInstance().getDeploymentByRgName(sid, rgName));
-        }
+    public AzureToolkitRuntimeException(String error) {
+        this(error, null, null);
     }
 
-    public void onDeleteDeployment(String sid, String deploymentId) {
-        final Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
-        azure.deployments().deleteById(deploymentId);
+    public AzureToolkitRuntimeException(String error, Throwable cause) {
+        this(error, cause, null);
+    }
+
+    public AzureToolkitRuntimeException(String error, String action) {
+        this(error, null, action);
+    }
+
+    public AzureToolkitRuntimeException(String error, Throwable cause, String action) {
+        super(error, cause);
+        this.action = action;
     }
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AuthMethodManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AuthMethodManager.java
@@ -62,9 +62,10 @@ public class AuthMethodManager {
 
     private AuthMethodManager(AuthMethodDetails authMethodDetails) {
         this.authMethodDetails = authMethodDetails;
+        final AzureManager manager = getAzureManager();
         // initialize subscription manager when restore authentication
-        if (this.authMethodDetails.getAuthMethod() != null) {
-            Objects.requireNonNull(getAzureManager()).getSubscriptionManager().updateSubscriptionDetailsIfNull();
+        if (this.authMethodDetails.getAuthMethod() != null && Objects.nonNull(manager)) {
+            manager.getSubscriptionManager().updateSubscriptionDetailsIfNull();
         }
     }
 
@@ -158,8 +159,8 @@ public class AuthMethodManager {
         try {
             persistAuthMethodDetails();
         } catch (final IOException e) {
-            final String error = "failed to persist auth method settings while updating";
-            final String action = "retry later";
+            final String error = "Failed to persist auth method settings while updating";
+            final String action = "Retry later";
             throw new AzureToolkitRuntimeException(error, e, action);
         }
     }
@@ -193,8 +194,8 @@ public class AuthMethodManager {
         try {
             persistAuthMethodDetails();
         } catch (final IOException e) {
-            final String error = "failed to persist local auth method settings while cleaning";
-            final String action = "retry later";
+            final String error = "Failed to persist local auth method settings while cleaning";
+            final String action = "Retry later";
             throw new AzureToolkitRuntimeException(error, e, action);
         }
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AuthMethodManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AuthMethodManager.java
@@ -25,8 +25,10 @@ package com.microsoft.azuretools.authmanage;
 
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.appplatform.v2019_05_01_preview.implementation.AppPlatformManager;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azuretools.adauth.JsonHelper;
 import com.microsoft.azuretools.authmanage.models.AuthMethodDetails;
+import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
 import com.microsoft.azuretools.sdkmanage.ServicePrincipalAzureManager;
@@ -38,17 +40,11 @@ import com.microsoft.azuretools.utils.AzureUIRefreshEvent;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Logger;
 
 import static com.microsoft.azuretools.Constants.FILE_NAME_AUTH_METHOD_DETAILS;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.ACCOUNT;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.AZURE_ENVIRONMENT;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.RESIGNIN;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.SIGNIN_METHOD;
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.*;
 
 public class AuthMethodManager {
     private static final Logger LOGGER = Logger.getLogger(AuthMethodManager.class.getName());
@@ -68,11 +64,7 @@ public class AuthMethodManager {
         this.authMethodDetails = authMethodDetails;
         // initialize subscription manager when restore authentication
         if (this.authMethodDetails.getAuthMethod() != null) {
-            try {
-                getAzureManager().getSubscriptionManager().updateSubscriptionDetailsIfNull();
-            } catch (IOException e) {
-                // swallow exception
-            }
+            Objects.requireNonNull(getAzureManager()).getSubscriptionManager().updateSubscriptionDetailsIfNull();
         }
     }
 
@@ -80,22 +72,28 @@ public class AuthMethodManager {
         return LazyHolder.INSTANCE;
     }
 
-    public Azure getAzureClient(String sid) throws IOException {
-        if (getAzureManager() == null) {
-            throw new IOException(CANNOT_GET_AZURE_MANAGER);
+    @NotNull
+    public Azure getAzureClient(String sid) {
+        final AzureManager manager = getAzureManager();
+        if (manager != null) {
+            final Azure azure = manager.getAzure(sid);
+            if (azure != null) {
+                return azure;
+            }
         }
-        Azure azure = getAzureManager().getAzure(sid);
-        if (azure == null) {
-            throw new IOException(String.format(CANNOT_GET_AZURE_BY_SID, sid));
-        }
-        return azure;
+        final String error = "Failed to initialize request";
+        final String action = "Confirm you have already signed in with subscription: " + sid;
+        throw new AzureToolkitRuntimeException(error, action);
     }
 
-    public AppPlatformManager getAzureSpringCloudClient(String sid) throws IOException {
-        if (getAzureManager() == null) {
-            throw new IOException(CANNOT_GET_AZURE_MANAGER);
+    public AppPlatformManager getAzureSpringCloudClient(String sid) {
+        final AzureManager manager = getAzureManager();
+        if (manager != null) {
+            return getAzureManager().getAzureSpringCloudClient(sid);
         }
-        return getAzureManager().getAzureSpringCloudClient(sid);
+        final String error = "Failed to initialize request";
+        final String action = "Confirm you have already signed in with subscription: " + sid;
+        throw new AzureToolkitRuntimeException(error, action);
     }
 
     public void addSignInEventListener(Runnable l) {
@@ -133,21 +131,17 @@ public class AuthMethodManager {
     }
 
     @Nullable
-    public AzureManager getAzureManager() throws IOException {
+    public AzureManager getAzureManager() {
         return getAzureManager(getAuthMethod());
     }
 
-    public void signOut() throws IOException {
+    public void signOut() {
         cleanAll();
         notifySignOutEventListener();
     }
 
     public boolean isSignedIn() {
-        try {
-            return getAzureManager() != null;
-        } catch (IOException e) {
-            return false;
-        }
+        return azureManager != null;
     }
 
     public AuthMethod getAuthMethod() {
@@ -158,13 +152,19 @@ public class AuthMethodManager {
         return this.authMethodDetails;
     }
 
-    public synchronized void setAuthMethodDetails(AuthMethodDetails authMethodDetails) throws IOException {
+    public synchronized void setAuthMethodDetails(AuthMethodDetails authMethodDetails) {
         cleanAll();
         this.authMethodDetails = authMethodDetails;
-        saveSettings();
+        try {
+            persistAuthMethodDetails();
+        } catch (final IOException e) {
+            final String error = "failed to persist auth method settings while updating";
+            final String action = "retry later";
+            throw new AzureToolkitRuntimeException(error, e, action);
+        }
     }
 
-    private synchronized AzureManager getAzureManager(final AuthMethod authMethod) throws IOException {
+    private synchronized @Nullable AzureManager getAzureManager(final AuthMethod authMethod) {
         if (authMethod == null) {
             return null;
         }
@@ -179,7 +179,7 @@ public class AuthMethodManager {
         return azureManager;
     }
 
-    private synchronized void cleanAll() throws IOException {
+    private synchronized void cleanAll() {
         if (azureManager != null) {
             azureManager.drop();
             azureManager.getSubscriptionManager().cleanSubscriptions();
@@ -190,10 +190,16 @@ public class AuthMethodManager {
         authMethodDetails.setAzureEnv(null);
         authMethodDetails.setAuthMethod(null);
         authMethodDetails.setCredFilePath(null);
-        saveSettings();
+        try {
+            persistAuthMethodDetails();
+        } catch (final IOException e) {
+            final String error = "failed to persist local auth method settings while cleaning";
+            final String action = "retry later";
+            throw new AzureToolkitRuntimeException(error, e, action);
+        }
     }
 
-    private void saveSettings() throws IOException {
+    private void persistAuthMethodDetails() throws IOException {
         System.out.println("saving authMethodDetails...");
         String sd = JsonHelper.serialize(authMethodDetails);
         FileStorage fs = new FileStorage(FILE_NAME_AUTH_METHOD_DETAILS, CommonSettings.getSettingsBaseDir());

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/SubscriptionManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/SubscriptionManager.java
@@ -30,12 +30,7 @@ import com.microsoft.azuretools.utils.AzureUIRefreshCore;
 import com.microsoft.azuretools.utils.AzureUIRefreshEvent;
 import com.microsoft.azuretools.utils.Pair;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -58,25 +53,25 @@ public class SubscriptionManager {
         this.azureManager = azureManager;
     }
 
-    public synchronized Map<String, SubscriptionDetail> getSubscriptionIdToSubscriptionDetailsMap() throws IOException {
+    public synchronized Map<String, SubscriptionDetail> getSubscriptionIdToSubscriptionDetailsMap() {
         System.out.println(Thread.currentThread().getId() + " SubscriptionManager.getSubscriptionIdToSubscriptionDetailsMap()");
         updateSubscriptionDetailsIfNull();
         return subscriptionIdToSubscriptionDetailMap;
     }
 
-    public synchronized Map<String, Subscription> getSubscriptionIdToSubscriptionMap() throws IOException {
+    public synchronized Map<String, Subscription> getSubscriptionIdToSubscriptionMap() {
         System.out.println(Thread.currentThread().getId() + " SubscriptionManager.getSubscriptionIdToSubscriptionMap()");
         updateSubscriptionDetailsIfNull();
         return subscriptionIdToSubscriptionMap;
     }
 
-    public synchronized List<SubscriptionDetail> getSubscriptionDetails() throws IOException {
+    public synchronized List<SubscriptionDetail> getSubscriptionDetails() {
         System.out.println(Thread.currentThread().getId() + " SubscriptionManager.getSubscriptionDetails()");
         updateSubscriptionDetailsIfNull();
         return subscriptionDetails;
     }
 
-    public synchronized List<SubscriptionDetail> getSelectedSubscriptionDetails() throws IOException {
+    public synchronized List<SubscriptionDetail> getSelectedSubscriptionDetails() {
         System.out.println(Thread.currentThread().getId() + " SubscriptionManager.getSelectedSubscriptionDetails()");
         updateSubscriptionDetailsIfNull();
 
@@ -85,14 +80,14 @@ public class SubscriptionManager {
                 .collect(Collectors.toList());
     }
 
-    public void updateSubscriptionDetailsIfNull() throws IOException {
+    public void updateSubscriptionDetailsIfNull() {
         if (subscriptionDetails == null) {
             List<SubscriptionDetail> sdl = updateAccountSubscriptionList();
             doSetSubscriptionDetails(sdl);
         }
     }
 
-    protected List<SubscriptionDetail> updateAccountSubscriptionList() throws IOException {
+    protected List<SubscriptionDetail> updateAccountSubscriptionList() {
         System.out.println(Thread.currentThread().getId() + " SubscriptionManager.updateAccountSubscriptionList()");
 
         if (azureManager == null) {
@@ -115,7 +110,7 @@ public class SubscriptionManager {
         return sdl;
     }
 
-    private synchronized void doSetSubscriptionDetails(List<SubscriptionDetail> subscriptionDetails) throws IOException {
+    private synchronized void doSetSubscriptionDetails(List<SubscriptionDetail> subscriptionDetails) {
         System.out.println(Thread.currentThread().getId() + " SubscriptionManager.doSetSubscriptionDetails()");
         this.subscriptionDetails = subscriptionDetails;
         updateMapAccordingToList(); // WORKAROUND: Update SubscriptionId->SubscriptionDetail Map
@@ -123,7 +118,7 @@ public class SubscriptionManager {
     }
 
     // WORKAROUND: private helper to construct SubscriptionId->SubscriptionDetail map
-    private void updateMapAccordingToList() throws IOException {
+    private void updateMapAccordingToList() {
         Map<String, SubscriptionDetail> sid2sd = new ConcurrentHashMap<>();
         for (SubscriptionDetail sd : this.subscriptionDetails) {
             sid2sd.put(sd.getSubscriptionId(),
@@ -136,7 +131,7 @@ public class SubscriptionManager {
         this.subscriptionIdToSubscriptionDetailMap = sid2sd;
     }
 
-    public void setSubscriptionDetails(List<SubscriptionDetail> subscriptionDetails) throws IOException {
+    public void setSubscriptionDetails(List<SubscriptionDetail> subscriptionDetails) {
         System.out.println("SubscriptionManager.setSubscriptionDetails() " + Thread.currentThread().getId());
         doSetSubscriptionDetails(subscriptionDetails);
         notifyAllListeners();
@@ -171,7 +166,7 @@ public class SubscriptionManager {
         return sidToTid.keySet();
     }
 
-    public void cleanSubscriptions() throws IOException {
+    public void cleanSubscriptions() {
         System.out.println(Thread.currentThread().getId() + " SubscriptionManager.cleanSubscriptions()");
         synchronized (this) {
             if (subscriptionDetails != null) {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/SubscriptionManagerPersist.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/SubscriptionManagerPersist.java
@@ -50,8 +50,8 @@ public class SubscriptionManagerPersist extends SubscriptionManager {
             try {
                 saveSubscriptions(subscriptionDetails, subscriptionsDetailsFileName);
             } catch (final IOException e) {
-                final String error = "failed to update local subscriptions cache while updating";
-                final String action = "retry later";
+                final String error = "Failed to update local subscriptions cache while updating";
+                final String action = "Retry later";
                 throw new AzureToolkitRuntimeException(error, e, action);
             }
         }
@@ -114,7 +114,7 @@ public class SubscriptionManagerPersist extends SubscriptionManager {
             try {
                 fs.cleanFile();
             } catch (final IOException e) {
-                final String error = "failed to clear local cached subscriptions";
+                final String error = "Failed to clear local cached subscriptions";
                 throw new AzureToolkitRuntimeException(error, e);
             }
         }
@@ -135,8 +135,8 @@ public class SubscriptionManagerPersist extends SubscriptionManager {
             final SubscriptionDetail[] sda = JsonHelper.deserialize(SubscriptionDetail[].class, json);
             return new ArrayList<>(Arrays.asList(sda));
         } catch (final IOException e) {
-            final String error = "failed to load local cached subscriptions";
-            final String action = "retry later or logout to clear local cached subscriptions";
+            final String error = "Failed to load local cached subscriptions";
+            final String action = "Retry later or logout to clear local cached subscriptions";
             throw new AzureToolkitRuntimeException(error, e);
         }
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/SubscriptionManagerPersist.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/SubscriptionManagerPersist.java
@@ -24,19 +24,18 @@ package com.microsoft.azuretools.authmanage;
 
 import com.microsoft.azure.management.resources.Subscription;
 import com.microsoft.azure.management.resources.Tenant;
-import com.microsoft.azuretools.adauth.AuthException;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azuretools.adauth.JsonHelper;
 import com.microsoft.azuretools.authmanage.models.SubscriptionDetail;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
 import com.microsoft.azuretools.utils.Pair;
+import lombok.extern.java.Log;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+@Log
 public class SubscriptionManagerPersist extends SubscriptionManager {
 
     public SubscriptionManagerPersist(AzureManager azureManager) {
@@ -44,17 +43,23 @@ public class SubscriptionManagerPersist extends SubscriptionManager {
     }
 
     @Override
-    public void setSubscriptionDetails(List<SubscriptionDetail> subscriptionDetails) throws AuthException, IOException {
+    public void setSubscriptionDetails(List<SubscriptionDetail> subscriptionDetails) {
         System.out.println(Thread.currentThread().getId() + " SubscriptionManagerPersist.setSubscriptionDetails()");
         synchronized (this) {
-            String subscriptionsDetailsFileName = azureManager.getSettings().getSubscriptionsDetailsFileName();
-            saveSubscriptions(subscriptionDetails, subscriptionsDetailsFileName);
+            final String subscriptionsDetailsFileName = azureManager.getSettings().getSubscriptionsDetailsFileName();
+            try {
+                saveSubscriptions(subscriptionDetails, subscriptionsDetailsFileName);
+            } catch (final IOException e) {
+                final String error = "failed to update local subscriptions cache while updating";
+                final String action = "retry later";
+                throw new AzureToolkitRuntimeException(error, e, action);
+            }
         }
         super.setSubscriptionDetails(subscriptionDetails);
     }
 
     @Override
-    protected List<SubscriptionDetail> updateAccountSubscriptionList() throws IOException {
+    protected List<SubscriptionDetail> updateAccountSubscriptionList() {
         System.out.println(Thread.currentThread().getId()
                 + "SubscriptionManagerPersist.updateAccountSubscriptionList()");
         List<SubscriptionDetail> sdl = null;
@@ -63,7 +68,7 @@ public class SubscriptionManagerPersist extends SubscriptionManager {
             sdl = loadSubscriptions(subscriptionsDetailsFileName);
         }
 
-        if (sdl == null) {
+        if (sdl.isEmpty()) {
             return super.updateAccountSubscriptionList();
         }
 
@@ -90,37 +95,50 @@ public class SubscriptionManagerPersist extends SubscriptionManager {
     }
 
     @Override
-    public synchronized void cleanSubscriptions() throws IOException {
+    public synchronized void cleanSubscriptions() {
         System.out.println(Thread.currentThread().getId() + " SubscriptionManagerPersist.cleanSubscriptions()");
         String subscriptionsDetailsFileName = azureManager.getSettings().getSubscriptionsDetailsFileName();
         deleteSubscriptions(subscriptionsDetailsFileName);
         super.cleanSubscriptions();
     }
 
-    public static synchronized void deleteSubscriptions(String subscriptionsDetailsFileName) throws IOException {
+    public static synchronized void deleteSubscriptions(String subscriptionsDetailsFileName) {
         System.out.println("cleaning " + subscriptionsDetailsFileName + " file");
-        FileStorage fs = new FileStorage(subscriptionsDetailsFileName, CommonSettings.getSettingsBaseDir());
-        fs.cleanFile();
+        FileStorage fs = null;
+        try {
+            fs = new FileStorage(subscriptionsDetailsFileName, CommonSettings.getSettingsBaseDir());
+        } catch (final IOException e) {
+            log.warning(subscriptionsDetailsFileName + " is not found when try to clean subscriptions");
+        }
+        if (Objects.nonNull(fs)) {
+            try {
+                fs.cleanFile();
+            } catch (final IOException e) {
+                final String error = "failed to clear local cached subscriptions";
+                throw new AzureToolkitRuntimeException(error, e);
+            }
+        }
     }
 
-    private static List<SubscriptionDetail> loadSubscriptions(String subscriptionsDetailsFileName) throws IOException {
+    private static List<SubscriptionDetail> loadSubscriptions(String subscriptionsDetailsFileName) {
         System.out.println("SubscriptionManagerPersist.loadSubscriptions()");
 
         //subscriptionDetails.clear();
-        FileStorage subscriptionsDetailsFileStorage = new FileStorage(subscriptionsDetailsFileName,
-                CommonSettings.getSettingsBaseDir());
-        byte[] data = subscriptionsDetailsFileStorage.read();
-        String json = new String(data, StandardCharsets.UTF_8);
-        if (json.isEmpty()) {
-            System.out.println(subscriptionsDetailsFileName + " file is empty");
-            return null;
+        try {
+            final FileStorage file = new FileStorage(subscriptionsDetailsFileName, CommonSettings.getSettingsBaseDir());
+            final byte[] data = file.read();
+            final String json = new String(data, StandardCharsets.UTF_8);
+            if (json.isEmpty()) {
+                System.out.println(subscriptionsDetailsFileName + " file is empty");
+                return Collections.emptyList();
+            }
+            final SubscriptionDetail[] sda = JsonHelper.deserialize(SubscriptionDetail[].class, json);
+            return new ArrayList<>(Arrays.asList(sda));
+        } catch (final IOException e) {
+            final String error = "failed to load local cached subscriptions";
+            final String action = "retry later or logout to clear local cached subscriptions";
+            throw new AzureToolkitRuntimeException(error, e);
         }
-        SubscriptionDetail[] sda = JsonHelper.deserialize(SubscriptionDetail[].class, json);
-        List<SubscriptionDetail> sdl = new ArrayList<>();
-        for (SubscriptionDetail sd : sda) {
-            sdl.add(sd);
-        }
-        return sdl;
     }
 
     private static void saveSubscriptions(List<SubscriptionDetail> sdl, String subscriptionsDetailsFileName)

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/azurecommons/helpers/RedisCacheUtil.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/azurecommons/helpers/RedisCacheUtil.java
@@ -85,7 +85,8 @@ public final class RedisCacheUtil {
         return skus;
     }
 
-    public static void doValidate(SubscriptionDetail currentSub, String dnsNameValue, String selectedRegionValue, String selectedResGrpValue, String selectedPriceTierValue) throws InvalidFormDataException {
+    public static void doValidate(SubscriptionDetail currentSub, String dnsNameValue,
+            String selectedRegionValue, String selectedResGrpValue, String selectedPriceTierValue) throws InvalidFormDataException {
         if (currentSub == null) {
             throw new InvalidFormDataException(REQUIRE_SUBSCRIPTION);
         }
@@ -122,15 +123,15 @@ public final class RedisCacheUtil {
                     selectedRegionValue,
                     selectedResGrpValue
                     );
-            if(noSSLPort) {
-                if(newResGrp && canCreateNewResGrp(azure, selectedResGrpValue)) {
+            if (noSSLPort) {
+                if (newResGrp && canCreateNewResGrp(azure, selectedResGrpValue)) {
                     //e.g. BASIC0NewNoSSL
                     return creator.CreatorMap().get(skus.get(selectedPriceTierValue) + "NewNoSSL");
                 } else {
                     return creator.CreatorMap().get(skus.get(selectedPriceTierValue) + "ExistingNoSSL");
                 }
             } else {
-                if(newResGrp && canCreateNewResGrp(azure, selectedResGrpValue)) {
+                if (newResGrp && canCreateNewResGrp(azure, selectedResGrpValue)) {
                     //e.g. BASIC0NewNoSSL
                     return creator.CreatorMap().get(skus.get(selectedPriceTierValue) + "New");
                 } else {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/azurecommons/helpers/RedisCacheUtil.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/azurecommons/helpers/RedisCacheUtil.java
@@ -22,9 +22,6 @@
 
 package com.microsoft.azuretools.azurecommons.helpers;
 
-import java.io.IOException;
-import java.util.LinkedHashMap;
-
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.redis.RedisCache;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
@@ -32,6 +29,8 @@ import com.microsoft.azuretools.authmanage.models.SubscriptionDetail;
 import com.microsoft.azuretools.azurecommons.exceptions.InvalidFormDataException;
 import com.microsoft.azuretools.azurecommons.rediscacheprocessors.ProcessingStrategy;
 import com.microsoft.azuretools.azurecommons.rediscacheprocessors.RedisCacheCreator;
+
+import java.util.LinkedHashMap;
 
 public final class RedisCacheUtil {
 
@@ -57,7 +56,8 @@ public final class RedisCacheUtil {
 
     //Alert Messages
     private static final String REQUIRE_SUBSCRIPTION = "Select one subscription for Redis cache creation.";
-    private static final String INVALID_REDIS_CACHE_NAME = "Invalid Redis Cache name. The name can only contain letters, numbers and hyphens. The first and last characters must each be a letter or a number. Consecutive hyphens are not allowed.";
+    private static final String INVALID_REDIS_CACHE_NAME = "Invalid Redis Cache name. The name can only contain letters, numbers and hyphens. "
+            + "The first and last characters must each be a letter or a number. Consecutive hyphens are not allowed.";
     private static final String REQUIRE_LOCATION = "Location cannot be null or empty.";
     private static final String REQUIRE_RESOURCE_GROUP = "Resource group cannot be null or empty.";
     private static final String REQUIRE_PRICE_TIER = "Pricing tier cannot be null or empty.";
@@ -101,15 +101,11 @@ public final class RedisCacheUtil {
         if (selectedPriceTierValue == null || selectedPriceTierValue.isEmpty()) {
             throw new InvalidFormDataException(REQUIRE_PRICE_TIER);
         }
-        try {
-            Azure azure = AuthMethodManager.getInstance().getAzureClient(currentSub.getSubscriptionId());
-            for (RedisCache existingRedisCache : azure.redisCaches().list()) {
-                if (existingRedisCache.name().equals(dnsNameValue)) {
-                    throw new InvalidFormDataException("The name " + dnsNameValue + " is not available");
-                }
+        final Azure azure = AuthMethodManager.getInstance().getAzureClient(currentSub.getSubscriptionId());
+        for (final RedisCache existingRedisCache : azure.redisCaches().list()) {
+            if (existingRedisCache.name().equals(dnsNameValue)) {
+                throw new InvalidFormDataException("The name " + dnsNameValue + " is not available");
             }
-        } catch (IOException e) {
-            e.printStackTrace();
         }
     }
 

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerRegistryMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerRegistryMvpModel.java
@@ -82,15 +82,11 @@ public class ContainerRegistryMvpModel {
             return subscriptionIdToRegistryMap.get(sid);
         }
         List<ResourceEx<Registry>> registryList = new ArrayList<>();
-        try {
-            Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
-            for (Registry registry: azure.containerRegistries().list()) {
-                registryList.add(new ResourceEx<>(registry, sid));
-            }
-            subscriptionIdToRegistryMap.put(sid, registryList);
-        } catch (IOException e) {
-            e.printStackTrace();
+        Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
+        for (Registry registry: azure.containerRegistries().list()) {
+            registryList.add(new ResourceEx<>(registry, sid));
         }
+        subscriptionIdToRegistryMap.put(sid, registryList);
         return registryList;
     }
 
@@ -134,7 +130,7 @@ public class ContainerRegistryMvpModel {
     /**
      * Set AdminUser enabled status of container registry.
      */
-    public Registry setAdminUserEnabled(String sid, String id, boolean enabled) throws IOException {
+    public Registry setAdminUserEnabled(String sid, String id, boolean enabled) {
         Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
         Registries registries = azure.containerRegistries();
         if (registries != null) {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerRegistryMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/container/ContainerRegistryMvpModel.java
@@ -35,7 +35,6 @@ import com.microsoft.azuretools.core.mvp.model.AzureMvpModel;
 import com.microsoft.azuretools.core.mvp.model.ResourceEx;
 import com.microsoft.azuretools.core.mvp.model.webapp.PrivateRegistryImageSetting;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/function/AzureFunctionMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/function/AzureFunctionMvpModel.java
@@ -24,17 +24,9 @@ package com.microsoft.azuretools.core.mvp.model.function;
 
 import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.Azure;
-import com.microsoft.azure.management.appservice.AppServicePlan;
-import com.microsoft.azure.management.appservice.ApplicationLogsConfig;
-import com.microsoft.azure.management.appservice.FunctionApp;
-import com.microsoft.azure.management.appservice.FunctionApps;
-import com.microsoft.azure.management.appservice.FunctionEnvelope;
-import com.microsoft.azure.management.appservice.LogLevel;
-import com.microsoft.azure.management.appservice.PricingTier;
-import com.microsoft.azure.management.appservice.SkuName;
-import com.microsoft.azure.management.appservice.WebAppBase;
-import com.microsoft.azure.management.appservice.WebAppDiagnosticLogs;
+import com.microsoft.azure.management.appservice.*;
 import com.microsoft.azure.management.resources.Subscription;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.core.mvp.model.AzureMvpModel;
@@ -43,12 +35,7 @@ import com.microsoft.azuretools.core.mvp.model.webapp.AppServiceUtils;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -66,40 +53,42 @@ public class AzureFunctionMvpModel {
         return SingletonHolder.INSTANCE;
     }
 
-    public FunctionApp getFunctionById(String sid, String id) throws IOException {
-        FunctionApp app = getFunctionAppsClient(sid).getById(id);
-        if (app == null) {
-            throw new IOException(CANNOT_GET_FUNCTION_APP_WITH_ID + id); // TODO: specify the type of exception.
+    @NotNull
+    public FunctionApp getFunctionById(String sid, String id) throws AzureToolkitRuntimeException {
+        final FunctionApp app = getFunctionAppsClient(sid).getById(id);
+        if (Objects.isNull(app)) {
+            final String error = String.format("cannot find FunctionApp[%s] in subscription[%s]", id, sid);
+            final String action = String.format("confirm if the FunctionApp[id=%s] still exists", id);
+            throw new AzureToolkitRuntimeException(error, action);
         }
         return app;
     }
 
-    public FunctionApp getFunctionByName(String sid, String resourceGroup, String name) throws IOException {
+    public FunctionApp getFunctionByName(String sid, String resourceGroup, String name) {
         return getFunctionAppsClient(sid).getByResourceGroup(resourceGroup, name);
     }
 
-    public void deleteFunction(String sid, String appId) throws IOException {
+    public void deleteFunction(String sid, String appId) {
         getFunctionAppsClient(sid).deleteById(appId);
         subscriptionIdToFunctionApps.remove(sid);
     }
 
-    public void restartFunction(String sid, String appId) throws IOException {
+    public void restartFunction(String sid, String appId) {
         getFunctionAppsClient(sid).getById(appId).restart();
     }
 
-    public void startFunction(String sid, String appId) throws IOException {
+    public void startFunction(String sid, String appId) {
         getFunctionAppsClient(sid).getById(appId).start();
     }
 
-    public void stopFunction(String sid, String appId) throws IOException {
+    public void stopFunction(String sid, String appId) {
         getFunctionAppsClient(sid).getById(appId).stop();
     }
 
     /**
      * List app service plan by subscription id and resource group name.
      */
-    public List<AppServicePlan> listAppServicePlanBySubscriptionIdAndResourceGroupName(String sid, String group)
-            throws IOException {
+    public List<AppServicePlan> listAppServicePlanBySubscriptionIdAndResourceGroupName(String sid, String group) {
         List<AppServicePlan> appServicePlans = new ArrayList<>();
 
         Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
@@ -111,7 +100,7 @@ public class AzureFunctionMvpModel {
     /**
      * List app service plan by subscription id.
      */
-    public List<AppServicePlan> listAppServicePlanBySubscriptionId(String sid) throws IOException {
+    public List<AppServicePlan> listAppServicePlanBySubscriptionId(String sid) {
         return AuthMethodManager.getInstance().getAzureClient(sid).appServices().appServicePlans().list(true);
     }
 
@@ -129,33 +118,28 @@ public class AzureFunctionMvpModel {
         }
         Observable.from(subs).flatMap((sd) ->
                 Observable.create((subscriber) -> {
-                    try {
-                        List<ResourceEx<FunctionApp>> functionList = listFunctionsInSubscription(sd.subscriptionId(), forceReload);
-                        synchronized (functions) {
-                            functions.addAll(functionList);
-                        }
-                    } catch (IOException e) {
-                        // swallow exception and skip error subscription
+                    List<ResourceEx<FunctionApp>> functionList = listFunctionsInSubscription(sd.subscriptionId(), forceReload);
+                    synchronized (functions) {
+                        functions.addAll(functionList);
                     }
                     subscriber.onCompleted();
                 }).subscribeOn(Schedulers.io()), subs.size()).subscribeOn(Schedulers.io()).toBlocking().subscribe();
         return functions;
     }
 
-    public List<FunctionEnvelope> listFunctionEnvelopeInFunctionApp(String sid, String id) throws IOException {
+    public List<FunctionEnvelope> listFunctionEnvelopeInFunctionApp(String sid, String id) {
         FunctionApp app = getFunctionById(sid, id);
         PagedList<FunctionEnvelope> functions = app.manager().functionApps().listFunctions(app.resourceGroupName(), app.name());
         functions.loadAll();
         return new ArrayList<>(functions);
     }
 
-    public boolean getPublishingProfileXmlWithSecrets(String sid, String functionAppId, String filePath) throws IOException {
+    public boolean getPublishingProfileXmlWithSecrets(String sid, String functionAppId, String filePath) {
         final FunctionApp app = getFunctionById(sid, functionAppId);
         return AppServiceUtils.getPublishingProfileXmlWithSecrets(app, filePath);
     }
 
-    public void updateWebAppSettings(String sid, String functionAppId, Map<String, String> toUpdate, Set<String> toRemove)
-            throws IOException {
+    public void updateWebAppSettings(String sid, String functionAppId, Map<String, String> toUpdate, Set<String> toRemove) {
         final FunctionApp app = getFunctionById(sid, functionAppId);
         WebAppBase.Update<FunctionApp> update = app.update().withAppSettings(toUpdate);
         for (String key : toRemove) {
@@ -201,8 +185,7 @@ public class AzureFunctionMvpModel {
      * List all Function Apps by subscription id.
      */
     @NotNull
-    private List<ResourceEx<FunctionApp>> listFunctionsInSubscription(final String subscriptionId, final boolean forceReload)
-            throws IOException {
+    private List<ResourceEx<FunctionApp>> listFunctionsInSubscription(final String subscriptionId, final boolean forceReload) {
         if (!forceReload && subscriptionIdToFunctionApps.get(subscriptionId) != null) {
             return subscriptionIdToFunctionApps.get(subscriptionId);
         }
@@ -218,7 +201,7 @@ public class AzureFunctionMvpModel {
         return functions;
     }
 
-    private static FunctionApps getFunctionAppsClient(String sid) throws IOException {
+    private static FunctionApps getFunctionAppsClient(String sid) {
         return AuthMethodManager.getInstance().getAzureClient(sid).appServices().functionApps();
     }
 

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/function/AzureFunctionMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/function/AzureFunctionMvpModel.java
@@ -57,8 +57,8 @@ public class AzureFunctionMvpModel {
     public FunctionApp getFunctionById(String sid, String id) throws AzureToolkitRuntimeException {
         final FunctionApp app = getFunctionAppsClient(sid).getById(id);
         if (Objects.isNull(app)) {
-            final String error = String.format("cannot find FunctionApp[%s] in subscription[%s]", id, sid);
-            final String action = String.format("confirm if the FunctionApp[id=%s] still exists", id);
+            final String error = String.format("Cannot find FunctionApp[%s] in subscription[%s]", id, sid);
+            final String action = String.format("Confirm if the FunctionApp[id=%s] still exists", id);
             throw new AzureToolkitRuntimeException(error, action);
         }
         return app;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/function/FunctionAppWrapper.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/function/FunctionAppWrapper.java
@@ -22,18 +22,13 @@
 
 package com.microsoft.azuretools.core.mvp.model.function;
 
-import com.microsoft.azure.management.appservice.FunctionApp;
-import com.microsoft.azure.management.appservice.FunctionDeploymentSlots;
-import com.microsoft.azure.management.appservice.NameValuePair;
-import com.microsoft.azure.management.appservice.SupportedTlsVersions;
-import com.microsoft.azure.management.appservice.WebAppBase;
+import com.microsoft.azure.management.appservice.*;
 import com.microsoft.azure.management.appservice.implementation.SiteInner;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azuretools.core.mvp.model.webapp.WebAppBaseWrapper;
 import rx.Completable;
 import rx.Observable;
 
-import java.io.IOException;
 import java.util.Map;
 
 public class FunctionAppWrapper extends WebAppBaseWrapper implements FunctionApp {
@@ -143,11 +138,7 @@ public class FunctionAppWrapper extends WebAppBaseWrapper implements FunctionApp
         if (functionApp == null) {
             synchronized (this) {
                 if (functionApp == null) {
-                    try {
-                        functionApp = AzureFunctionMvpModel.getInstance().getFunctionById(getSubscriptionId(), inner().id());
-                    } catch (IOException e) {
-                        throw new RuntimeException("Failed to get function instance");
-                    }
+                    functionApp = AzureFunctionMvpModel.getInstance().getFunctionById(getSubscriptionId(), inner().id());
                 }
             }
         }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/rediscache/AzureRedisMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/rediscache/AzureRedisMvpModel.java
@@ -27,7 +27,6 @@ import com.microsoft.azure.management.redis.RedisCache;
 import com.microsoft.azure.management.redis.RedisCaches;
 import com.microsoft.azure.management.resources.Subscription;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
-import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.core.mvp.model.AzureMvpModel;
 
 import java.util.HashMap;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/rediscache/AzureRedisMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/rediscache/AzureRedisMvpModel.java
@@ -27,17 +27,18 @@ import com.microsoft.azure.management.redis.RedisCache;
 import com.microsoft.azure.management.redis.RedisCaches;
 import com.microsoft.azure.management.resources.Subscription;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.core.mvp.model.AzureMvpModel;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 
 public class AzureRedisMvpModel {
 
-    private AzureRedisMvpModel() {}
+    private AzureRedisMvpModel() {
+    }
 
-    private static final class  AzureMvpModelHolder {
+    private static final class AzureMvpModelHolder {
         private static final AzureRedisMvpModel INSTANCE = new AzureRedisMvpModel();
     }
 
@@ -48,9 +49,8 @@ public class AzureRedisMvpModel {
     /**
      * Get all redis caches.
      * @return A map containing RedisCaches with subscription id as the key
-     * @throws IOException getAzureManager Exception
      */
-    public HashMap<String, RedisCaches> getRedisCaches() throws IOException {
+    public HashMap<String, RedisCaches> getRedisCaches() {
         HashMap<String, RedisCaches> redisCacheMaps = new HashMap<>();
         List<Subscription> subscriptions = AzureMvpModel.getInstance().getSelectedSubscriptions();
         for (Subscription subscription : subscriptions) {
@@ -68,9 +68,8 @@ public class AzureRedisMvpModel {
      * @param sid Subscription Id
      * @param id Redis cache's id
      * @return Redis Cache Object
-     * @throws IOException getAzureManager Exception
      */
-    public RedisCache getRedisCache(String sid, String id) throws IOException {
+    public RedisCache getRedisCache(String sid, String id) {
         Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
         RedisCaches redisCaches = azure.redisCaches();
         if (redisCaches == null) {
@@ -83,9 +82,8 @@ public class AzureRedisMvpModel {
      * Delete a redis cache.
      * @param sid Subscription Id
      * @param id Redis cache's id
-     * @throws IOException getAzureManager Exception
      */
-    public void deleteRedisCache(String sid, String id) throws IOException {
+    public void deleteRedisCache(String sid, String id) {
         Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
         RedisCaches redisCaches = azure.redisCaches();
         if (redisCaches == null) {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AppServiceUtils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AppServiceUtils.java
@@ -25,28 +25,34 @@ package com.microsoft.azuretools.core.mvp.model.webapp;
 import com.microsoft.azure.management.appservice.CsmPublishingProfileOptions;
 import com.microsoft.azure.management.appservice.PublishingProfileFormat;
 import com.microsoft.azure.management.appservice.WebAppBase;
+import lombok.extern.java.Log;
 import org.apache.commons.io.IOUtils;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.nio.file.Paths;
 
+@Log
 public class AppServiceUtils {
-    public static boolean getPublishingProfileXmlWithSecrets(WebAppBase webAppBase, String filePath) throws IOException {
+    public static boolean getPublishingProfileXmlWithSecrets(WebAppBase webAppBase, String filePath) {
         final File file = new File(Paths.get(filePath, String.format("%s_%s.PublishSettings",
-                webAppBase.name(), System.currentTimeMillis())).toString());
-        file.createNewFile();
-        try (InputStream inputStream = webAppBase.manager().inner().webApps()
-                .listPublishingProfileXmlWithSecrets(webAppBase.resourceGroupName(), webAppBase.name(),
-                        new CsmPublishingProfileOptions().withFormat(PublishingProfileFormat.FTP));
-             OutputStream outputStream = new FileOutputStream(file);
+                                                                     webAppBase.name(), System.currentTimeMillis()))
+                                        .toString());
+        try {
+            file.createNewFile();
+        } catch (final IOException e) {
+            log.warning("failed to create publishing profile xml file");
+            return false;
+        }
+        try (final InputStream inputStream = webAppBase.manager().inner().webApps()
+                                                       .listPublishingProfileXmlWithSecrets(webAppBase.resourceGroupName(),
+                                                                                      webAppBase.name(),
+                                                                                      new CsmPublishingProfileOptions().withFormat(
+                                                                                          PublishingProfileFormat.FTP));
+             final OutputStream outputStream = new FileOutputStream(file)
         ) {
             IOUtils.copy(inputStream, outputStream);
             return true;
-        } catch (IOException e) {
+        } catch (final IOException e) {
             e.printStackTrace();
             return false;
         }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -23,51 +23,36 @@
 package com.microsoft.azuretools.core.mvp.model.webapp;
 
 import com.microsoft.azure.management.Azure;
-import com.microsoft.azure.management.appservice.AppServicePlan;
-import com.microsoft.azure.management.appservice.CsmPublishingProfileOptions;
-import com.microsoft.azure.management.appservice.DeploymentSlot;
-import com.microsoft.azure.management.appservice.OperatingSystem;
-import com.microsoft.azure.management.appservice.PricingTier;
-import com.microsoft.azure.management.appservice.PublishingProfileFormat;
-import com.microsoft.azure.management.appservice.RuntimeStack;
-import com.microsoft.azure.management.appservice.SkuName;
-import com.microsoft.azure.management.appservice.WebApp;
-import com.microsoft.azure.management.appservice.WebAppBase;
-import com.microsoft.azure.management.appservice.WebAppDiagnosticLogs;
-import com.microsoft.azure.management.appservice.WebContainer;
+import com.microsoft.azure.management.appservice.*;
 import com.microsoft.azure.management.appservice.implementation.GeoRegionInner;
 import com.microsoft.azure.management.appservice.implementation.SiteInner;
 import com.microsoft.azure.management.resources.Subscription;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.core.mvp.model.AzureMvpModel;
 import com.microsoft.azuretools.core.mvp.model.ResourceEx;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
 import com.microsoft.azuretools.utils.WebAppUtils;
 import lombok.SneakyThrows;
+import lombok.extern.java.Log;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
+import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+@Log
 public class AzureWebAppMvpModel {
 
     private static final Logger logger = Logger.getLogger(AzureWebAppMvpModel.class.getName());
@@ -75,8 +60,10 @@ public class AzureWebAppMvpModel {
     public static final String CANNOT_GET_WEB_APP_WITH_ID = "Cannot get Web App with ID: ";
     private final Map<String, List<ResourceEx<WebApp>>> subscriptionIdToWebApps;
 
-    private static final List<WebAppUtils.WebContainerMod> JAVA_8_JAR_CONTAINERS = Collections.singletonList(WebAppUtils.WebContainerMod.Java_SE_8);
-    private static final List<WebAppUtils.WebContainerMod> JAVA_11_JAR_CONTAINERS = Collections.singletonList(WebAppUtils.WebContainerMod.Java_SE_11);
+    private static final List<WebAppUtils.WebContainerMod> JAVA_8_JAR_CONTAINERS =
+        Collections.singletonList(WebAppUtils.WebContainerMod.Java_SE_8);
+    private static final List<WebAppUtils.WebContainerMod> JAVA_11_JAR_CONTAINERS = Collections.singletonList(
+        WebAppUtils.WebContainerMod.Java_SE_11);
 
     private AzureWebAppMvpModel() {
         subscriptionIdToWebApps = new ConcurrentHashMap<>();
@@ -87,19 +74,30 @@ public class AzureWebAppMvpModel {
     }
 
     /**
-     * get the web app by ID.
+     * get the web app by ID
      */
-    public WebApp getWebAppById(String sid, String id) throws IOException {
-        Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
-        WebApp app = azure.webApps().getById(id);
-        if (app == null) {
-            throw new IOException(CANNOT_GET_WEB_APP_WITH_ID + id); // TODO: specify the type of exception.
+    @NotNull
+    public WebApp getWebAppById(String sid, String id) throws AzureToolkitRuntimeException {
+        final WebApp webapp = this.getNullableWebAppById(sid, id);
+        if (Objects.isNull(webapp)) {
+            final String error = String.format("cannot find WebApp[%s] in subscription[%s]", id, sid);
+            final String action = String.format("confirm if the WebApp[id=%s] still exists", id);
+            throw new AzureToolkitRuntimeException(error, action);
         }
-        return app;
+        return webapp;
     }
 
-    public WebApp getWebAppByName(String sid, String resourceGroup, String appName) throws IOException {
-        Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
+    /**
+     * get the web app by ID.
+     */
+    @Nullable
+    public WebApp getNullableWebAppById(String sid, String id) {
+        final Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
+        return azure.webApps().getById(id);
+    }
+
+    public WebApp getWebAppByName(String sid, String resourceGroup, String appName) {
+        final Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
         return azure.webApps().getByResourceGroup(resourceGroup, appName);
     }
 
@@ -120,7 +118,7 @@ public class AzureWebAppMvpModel {
     /**
      * API to create a new Deployment Slot by setting model.
      */
-    public DeploymentSlot createDeploymentSlot(@NotNull WebAppSettingModel model) throws Exception {
+    public DeploymentSlot createDeploymentSlot(@NotNull WebAppSettingModel model) {
         final WebApp app = getWebAppById(model.getSubscriptionId(), model.getWebAppId());
         final String name = model.getNewSlotName();
         final String configurationSource = model.getNewSlotConfigurationSource();
@@ -131,11 +129,11 @@ public class AzureWebAppMvpModel {
         }
 
         final DeploymentSlot configurationSourceSlot = app.deploymentSlots()
-            .list()
-            .stream()
-            .filter(s -> configurationSource.equals(s.name()))
-            .findAny()
-            .orElse(null);
+                                                          .list()
+                                                          .stream()
+                                                          .filter(s -> configurationSource.equals(s.name()))
+                                                          .findAny()
+                                                          .orElse(null);
 
         if (configurationSourceSlot != null) {
             return definedSlot.withConfigurationFromDeploymentSlot(configurationSourceSlot).create();
@@ -145,14 +143,14 @@ public class AzureWebAppMvpModel {
     }
 
     /**
-    * API to create Web App on Windows .
-    *
-    * @param model parameters
-    * @return instance of created WebApp
-    * @throws Exception exception
-    */
+     * API to create Web App on Windows .
+     *
+     * @param model parameters
+     * @return instance of created WebApp
+     * @throws Exception exception
+     */
     public WebApp createWebAppOnWindows(@NotNull WebAppSettingModel model) throws Exception {
-        Azure azure = AuthMethodManager.getInstance().getAzureClient(model.getSubscriptionId());
+        final Azure azure = AuthMethodManager.getInstance().getAzureClient(model.getSubscriptionId());
 
         WebApp.DefinitionStages.WithCreate withCreate;
         if (model.isCreatingAppServicePlan()) {
@@ -162,42 +160,45 @@ public class AzureWebAppMvpModel {
         }
         withCreate = applyDiagnosticConfig(withCreate, model);
         return withCreate
-                .withJavaVersion(model.getJdkVersion())
-                .withWebContainer(WebContainer.fromString(model.getWebContainer()))
-                .create();
+            .withJavaVersion(model.getJdkVersion())
+            .withWebContainer(WebContainer.fromString(model.getWebContainer()))
+            .create();
     }
 
     /**
      * API to create Web App on Linux.
      */
     public WebApp createWebAppOnLinux(@NotNull WebAppSettingModel model) throws Exception {
-        Azure azure = AuthMethodManager.getInstance().getAzureClient(model.getSubscriptionId());
+        final Azure azure = AuthMethodManager.getInstance().getAzureClient(model.getSubscriptionId());
 
-        WebApp.DefinitionStages.WithDockerContainerImage withDockerContainerImage;
+        final WebApp.DefinitionStages.WithDockerContainerImage withDockerContainerImage;
         if (model.isCreatingAppServicePlan()) {
             withDockerContainerImage = withCreateNewLinuxServicePlan(azure, model);
         } else {
             withDockerContainerImage = withExistingLinuxServicePlan(azure, model);
         }
-        WebApp.DefinitionStages.WithCreate withCreate = withDockerContainerImage.withBuiltInImage(model.getLinuxRuntime());
+        final WebApp.DefinitionStages.WithCreate withCreate =
+            withDockerContainerImage.withBuiltInImage(model.getLinuxRuntime());
         return applyDiagnosticConfig(withCreate, model).create();
     }
 
-    private WebApp.DefinitionStages.WithCreate applyDiagnosticConfig(WebApp.DefinitionStages.WithCreate withCreate, WebAppSettingModel settingModel) {
-        final WebAppDiagnosticLogs.DefinitionStages.Blank diagnosticLogs = withCreate.defineDiagnosticLogsConfiguration();
+    private WebApp.DefinitionStages.WithCreate applyDiagnosticConfig(WebApp.DefinitionStages.WithCreate withCreate,
+                                                                     WebAppSettingModel settingModel) {
+        final WebAppDiagnosticLogs.DefinitionStages.Blank diagnosticLogs =
+            withCreate.defineDiagnosticLogsConfiguration();
         WebAppDiagnosticLogs.DefinitionStages.WithAttach withAttach = null;
         if (settingModel.isEnableApplicationLog()) {
             withAttach = diagnosticLogs.withApplicationLogging()
-                    .withLogLevel(settingModel.getApplicationLogLevel())
-                    .withApplicationLogsStoredOnFileSystem();
+                                       .withLogLevel(settingModel.getApplicationLogLevel())
+                                       .withApplicationLogsStoredOnFileSystem();
         }
         if (settingModel.isEnableWebServerLogging()) {
             withAttach = diagnosticLogs.withWebServerLogging()
-                    .withWebServerLogsStoredOnFileSystem()
-                    .withWebServerFileSystemQuotaInMB(settingModel.getWebServerLogQuota())
-                    .withLogRetentionDays(settingModel.getWebServerRetentionPeriod())
-                    .withDetailedErrorMessages(settingModel.isEnableDetailedErrorMessage())
-                    .withFailedRequestTracing(settingModel.isEnableFailedRequestTracing());
+                                       .withWebServerLogsStoredOnFileSystem()
+                                       .withWebServerFileSystemQuotaInMB(settingModel.getWebServerLogQuota())
+                                       .withLogRetentionDays(settingModel.getWebServerRetentionPeriod())
+                                       .withDetailedErrorMessages(settingModel.isEnableDetailedErrorMessage())
+                                       .withFailedRequestTracing(settingModel.isEnableFailedRequestTracing());
         }
         return withAttach == null ? withCreate : (WebApp.DefinitionStages.WithCreate) withAttach.attach();
     }
@@ -244,7 +245,7 @@ public class AzureWebAppMvpModel {
     }
 
     private WebApp.DefinitionStages.WithCreate withCreateNewWindowsServicePlan(
-            @NotNull Azure azure, @NotNull WebAppSettingModel model) throws Exception {
+        @NotNull Azure azure, @NotNull WebAppSettingModel model) throws Exception {
 
         final AppServicePlan.DefinitionStages.WithCreate withCreate = prepareWithCreate(azure, model);
         final WebApp.DefinitionStages.WithNewAppServicePlan withNewAppServicePlan = prepareServicePlan(azure, model);
@@ -260,10 +261,10 @@ public class AzureWebAppMvpModel {
     }
 
     private WebApp.DefinitionStages.WithCreate withExistingWindowsServicePlan(
-            @NotNull Azure azure, @NotNull WebAppSettingModel model) {
+        @NotNull Azure azure, @NotNull WebAppSettingModel model) {
 
-        AppServicePlan servicePlan = azure.appServices().appServicePlans().getById(model.getAppServicePlanId());
-        WebApp.DefinitionStages.ExistingWindowsPlanWithGroup withGroup = azure
+        final AppServicePlan servicePlan = azure.appServices().appServicePlans().getById(model.getAppServicePlanId());
+        final WebApp.DefinitionStages.ExistingWindowsPlanWithGroup withGroup = azure
             .webApps()
             .define(model.getWebAppName())
             .withExistingWindowsPlan(servicePlan);
@@ -277,8 +278,8 @@ public class AzureWebAppMvpModel {
     private WebApp.DefinitionStages.WithDockerContainerImage withExistingLinuxServicePlan(
         @NotNull Azure azure, @NotNull WebAppSettingModel model) {
 
-        AppServicePlan servicePlan = azure.appServices().appServicePlans().getById(model.getAppServicePlanId());
-        WebApp.DefinitionStages.ExistingLinuxPlanWithGroup withGroup = azure
+        final AppServicePlan servicePlan = azure.appServices().appServicePlans().getById(model.getAppServicePlanId());
+        final WebApp.DefinitionStages.ExistingLinuxPlanWithGroup withGroup = azure
             .webApps()
             .define(model.getWebAppName())
             .withExistingLinuxPlan(servicePlan);
@@ -293,7 +294,7 @@ public class AzureWebAppMvpModel {
         // TODO
     }
 
-    public void deleteWebApp(String sid, String appId) throws IOException {
+    public void deleteWebApp(String sid, String appId) {
         AuthMethodManager.getInstance().getAzureClient(sid).webApps().deleteById(appId);
         subscriptionIdToWebApps.remove(sid);
     }
@@ -305,67 +306,66 @@ public class AzureWebAppMvpModel {
      * @return instance of created WebApp
      * @throws IOException IOExceptions
      */
-    public WebApp createWebAppWithPrivateRegistryImage(@NotNull WebAppOnLinuxDeployModel model)
-            throws IOException {
-        PrivateRegistryImageSetting pr = model.getPrivateRegistryImageSetting();
-        WebApp app;
-        Azure azure = AuthMethodManager.getInstance().getAzureClient(model.getSubscriptionId());
-        PricingTier pricingTier = new PricingTier(model.getPricingSkuTier(), model.getPricingSkuSize());
+    public WebApp createWebAppWithPrivateRegistryImage(@NotNull WebAppOnLinuxDeployModel model) {
+        final PrivateRegistryImageSetting pr = model.getPrivateRegistryImageSetting();
+        final WebApp app;
+        final Azure azure = AuthMethodManager.getInstance().getAzureClient(model.getSubscriptionId());
+        final PricingTier pricingTier = new PricingTier(model.getPricingSkuTier(), model.getPricingSkuSize());
 
-        WebApp.DefinitionStages.Blank webAppDefinition = azure.webApps().define(model.getWebAppName());
+        final WebApp.DefinitionStages.Blank webAppDefinition = azure.webApps().define(model.getWebAppName());
         if (model.isCreatingNewAppServicePlan()) {
             // new asp
-            AppServicePlan.DefinitionStages.WithCreate asp;
+            final AppServicePlan.DefinitionStages.WithCreate asp;
             if (model.isCreatingNewResourceGroup()) {
                 // new rg
                 asp = azure.appServices().appServicePlans()
-                        .define(model.getAppServicePlanName())
-                        .withRegion(Region.findByLabelOrName(model.getLocationName()))
-                        .withNewResourceGroup(model.getResourceGroupName())
-                        .withPricingTier(pricingTier)
-                        .withOperatingSystem(OperatingSystem.LINUX);
+                           .define(model.getAppServicePlanName())
+                           .withRegion(Region.findByLabelOrName(model.getLocationName()))
+                           .withNewResourceGroup(model.getResourceGroupName())
+                           .withPricingTier(pricingTier)
+                           .withOperatingSystem(OperatingSystem.LINUX);
                 app = webAppDefinition
-                        .withRegion(Region.findByLabelOrName(model.getLocationName()))
-                        .withNewResourceGroup(model.getResourceGroupName())
-                        .withNewLinuxPlan(asp)
-                        .withPrivateRegistryImage(pr.getImageTagWithServerUrl(), pr.getServerUrl())
-                        .withCredentials(pr.getUsername(), pr.getPassword())
-                        .withStartUpCommand(pr.getStartupFile()).create();
+                    .withRegion(Region.findByLabelOrName(model.getLocationName()))
+                    .withNewResourceGroup(model.getResourceGroupName())
+                    .withNewLinuxPlan(asp)
+                    .withPrivateRegistryImage(pr.getImageTagWithServerUrl(), pr.getServerUrl())
+                    .withCredentials(pr.getUsername(), pr.getPassword())
+                    .withStartUpCommand(pr.getStartupFile()).create();
             } else {
                 // old rg
                 asp = azure.appServices().appServicePlans()
-                        .define(model.getAppServicePlanName())
-                        .withRegion(Region.findByLabelOrName(model.getLocationName()))
-                        .withExistingResourceGroup(model.getResourceGroupName())
-                        .withPricingTier(pricingTier)
-                        .withOperatingSystem(OperatingSystem.LINUX);
+                           .define(model.getAppServicePlanName())
+                           .withRegion(Region.findByLabelOrName(model.getLocationName()))
+                           .withExistingResourceGroup(model.getResourceGroupName())
+                           .withPricingTier(pricingTier)
+                           .withOperatingSystem(OperatingSystem.LINUX);
                 app = webAppDefinition
-                        .withRegion(Region.findByLabelOrName(model.getLocationName()))
-                        .withExistingResourceGroup(model.getResourceGroupName())
-                        .withNewLinuxPlan(asp)
-                        .withPrivateRegistryImage(pr.getImageTagWithServerUrl(), pr.getServerUrl())
-                        .withCredentials(pr.getUsername(), pr.getPassword())
-                        .withStartUpCommand(pr.getStartupFile()).create();
+                    .withRegion(Region.findByLabelOrName(model.getLocationName()))
+                    .withExistingResourceGroup(model.getResourceGroupName())
+                    .withNewLinuxPlan(asp)
+                    .withPrivateRegistryImage(pr.getImageTagWithServerUrl(), pr.getServerUrl())
+                    .withCredentials(pr.getUsername(), pr.getPassword())
+                    .withStartUpCommand(pr.getStartupFile()).create();
             }
         } else {
             // old asp
-            AppServicePlan asp = azure.appServices().appServicePlans().getById(model.getAppServicePlanId());
+            final AppServicePlan asp = azure.appServices().appServicePlans().getById(model.getAppServicePlanId());
             if (model.isCreatingNewResourceGroup()) {
                 // new rg
                 app = webAppDefinition
-                        .withExistingLinuxPlan(asp)
-                        .withNewResourceGroup(model.getResourceGroupName())
-                        .withPrivateRegistryImage(pr.getImageTagWithServerUrl(), pr.getServerUrl())
-                        .withCredentials(pr.getUsername(), pr.getPassword())
-                        .withStartUpCommand(pr.getStartupFile()).create();
+                    .withExistingLinuxPlan(asp)
+                    .withNewResourceGroup(model.getResourceGroupName())
+                    .withPrivateRegistryImage(pr.getImageTagWithServerUrl(), pr.getServerUrl())
+                    .withCredentials(pr.getUsername(), pr.getPassword())
+                    .withStartUpCommand(pr.getStartupFile()).create();
             } else {
                 // old rg
                 app = webAppDefinition
-                        .withExistingLinuxPlan(asp)
-                        .withExistingResourceGroup(model.getResourceGroupName())
-                        .withPrivateRegistryImage(pr.getImageTagWithServerUrl(), pr.getServerUrl())
-                        .withCredentials(pr.getUsername(), pr.getPassword())
-                        .withStartUpCommand(pr.getStartupFile()).create();
+                    .withExistingLinuxPlan(asp)
+                    .withExistingResourceGroup(model.getResourceGroupName())
+                    .withPrivateRegistryImage(pr.getImageTagWithServerUrl(), pr.getServerUrl())
+                    .withCredentials(pr.getUsername(), pr.getPassword())
+                    .withStartUpCommand(pr.getStartupFile()).create();
             }
         }
         return app;
@@ -380,14 +380,14 @@ public class AzureWebAppMvpModel {
      * @param imageSetting new container settings
      * @return instance of the updated Web App on Linux
      */
-    public WebApp updateWebAppOnDocker(String sid, String webAppId, ImageSetting imageSetting) throws Exception {
-        WebApp app = getWebAppById(sid, webAppId);
+    public WebApp updateWebAppOnDocker(String sid, String webAppId, ImageSetting imageSetting) {
+        final WebApp app = getWebAppById(sid, webAppId);
         clearTags(app);
         if (imageSetting instanceof PrivateRegistryImageSetting) {
-            PrivateRegistryImageSetting pr = (PrivateRegistryImageSetting) imageSetting;
+            final PrivateRegistryImageSetting pr = (PrivateRegistryImageSetting) imageSetting;
             app.update().withPrivateRegistryImage(pr.getImageTagWithServerUrl(), pr.getServerUrl())
-                    .withCredentials(pr.getUsername(), pr.getPassword())
-                    .withStartUpCommand(pr.getStartupFile()).apply();
+               .withCredentials(pr.getUsername(), pr.getPassword())
+               .withStartUpCommand(pr.getStartupFile()).apply();
         } else {
             // TODO: other types of ImageSetting, e.g. Docker Hub
         }
@@ -406,13 +406,12 @@ public class AzureWebAppMvpModel {
      * @param toRemove entries to remove
      * @throws Exception exception
      */
-    public void updateWebAppSettings(String sid, String webAppId, Map<String, String> toUpdate, Set<String> toRemove)
-            throws Exception {
-        WebApp app = getWebAppById(sid, webAppId);
+    public void updateWebAppSettings(String sid, String webAppId, Map<String, String> toUpdate, Set<String> toRemove) {
+        final WebApp app = getWebAppById(sid, webAppId);
         clearTags(app);
         com.microsoft.azure.management.appservice.WebAppBase.Update<WebApp> update = app.update()
-                .withAppSettings(toUpdate);
-        for (String key : toRemove) {
+                                                                                        .withAppSettings(toUpdate);
+        for (final String key : toRemove) {
             update = update.withoutAppSetting(key);
         }
         update.apply();
@@ -423,60 +422,61 @@ public class AzureWebAppMvpModel {
      */
     public void updateDeploymentSlotAppSettings(final String subsciptionId, final String webAppId,
                                                 final String slotName, final Map<String, String> toUpdate,
-                                                final Set<String> toRemove) throws Exception {
+                                                final Set<String> toRemove) {
         final DeploymentSlot slot = getWebAppById(subsciptionId, webAppId).deploymentSlots().getByName(slotName);
         clearTags(slot);
         com.microsoft.azure.management.appservice.WebAppBase.Update<DeploymentSlot> update = slot.update()
-            .withAppSettings(toUpdate);
-        for (String key : toRemove) {
+                                                                                                 .withAppSettings(
+                                                                                                     toUpdate);
+        for (final String key : toRemove) {
             update = update.withoutAppSetting(key);
         }
         update.apply();
     }
 
-    public void deleteWebAppOnLinux(String sid, String appid) throws IOException {
+    public void deleteWebAppOnLinux(String sid, String appid) {
         deleteWebApp(sid, appid);
     }
 
-    public void restartWebApp(String sid, String appid) throws IOException {
+    public void restartWebApp(String sid, String appid) {
         AuthMethodManager.getInstance().getAzureClient(sid).webApps().getById(appid).restart();
     }
 
-    public void startWebApp(String sid, String appid) throws IOException {
+    public void startWebApp(String sid, String appid) {
         AuthMethodManager.getInstance().getAzureClient(sid).webApps().getById(appid).start();
     }
 
-    public void stopWebApp(String sid, String appid) throws IOException {
+    public void stopWebApp(String sid, String appid) {
         AuthMethodManager.getInstance().getAzureClient(sid).webApps().getById(appid).stop();
     }
 
     public void startDeploymentSlot(final String subscriptionId, final String appId,
-                                    final String slotName) throws IOException {
+                                    final String slotName) {
         final WebApp app = AuthMethodManager.getInstance().getAzureClient(subscriptionId).webApps().getById(appId);
         app.deploymentSlots().getByName(slotName).start();
     }
 
     public void stopDeploymentSlot(final String subscriptionId, final String appId,
-                                   final String slotName) throws IOException {
+                                   final String slotName) {
         final WebApp app = AuthMethodManager.getInstance().getAzureClient(subscriptionId).webApps().getById(appId);
         app.deploymentSlots().getByName(slotName).stop();
     }
 
     public void restartDeploymentSlot(final String subscriptionId, final String appId,
-                                      final String slotName) throws IOException {
+                                      final String slotName) {
         final WebApp app = AuthMethodManager.getInstance().getAzureClient(subscriptionId).webApps().getById(appId);
         app.deploymentSlots().getByName(slotName).restart();
     }
 
     public void swapSlotWithProduction(final String subscriptionId, final String appId,
-                                       final String slotName) throws IOException {
+                                       final String slotName) {
         final WebApp app = AuthMethodManager.getInstance().getAzureClient(subscriptionId).webApps().getById(appId);
         final DeploymentSlot slot = app.deploymentSlots().getByName(slotName);
         slot.swap("production");
     }
 
     public void deleteDeploymentSlotNode(final String subscriptionId, final String appId,
-                                         final String slotName) throws IOException {
+                                         final String slotName) {
         final WebApp app = AuthMethodManager.getInstance().getAzureClient(subscriptionId).webApps().getById(appId);
         app.deploymentSlots().deleteByName(slotName);
     }
@@ -484,30 +484,28 @@ public class AzureWebAppMvpModel {
     /**
      * Get all the deployment slots of a web app by the subscription id and web app id.
      */
-    public List<DeploymentSlot> getDeploymentSlots(final String subscriptionId, final String appId) throws IOException {
+    public @Nullable List<DeploymentSlot> getDeploymentSlots(final String subscriptionId, final String appId) {
         final AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
         if (azureManager == null) {
             return null;
         }
-        final List<DeploymentSlot> deploymentSlots = new ArrayList<>();
         final WebApp webApp = AuthMethodManager.getInstance().getAzureClient(subscriptionId).webApps().getById(appId);
         if (webApp == null) {
             return null;
         }
-        deploymentSlots.addAll(webApp.deploymentSlots().list());
-        return deploymentSlots;
+        return new ArrayList<>(webApp.deploymentSlots().list());
     }
 
     /**
      * List app service plan by subscription id and resource group name.
      */
     public List<AppServicePlan> listAppServicePlanBySubscriptionIdAndResourceGroupName(String sid, String group) {
-        List<AppServicePlan> appServicePlans = new ArrayList<>();
+        final List<AppServicePlan> appServicePlans = new ArrayList<>();
 
         try {
-            Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
+            final Azure azure = AuthMethodManager.getInstance().getAzureClient(sid);
             appServicePlans.addAll(azure.appServices().appServicePlans().listByResourceGroup(group));
-        } catch (Exception e) {
+        } catch (final Exception e) {
             e.printStackTrace();
         }
         return appServicePlans;
@@ -516,7 +514,7 @@ public class AzureWebAppMvpModel {
     /**
      * List app service plan by subscription id.
      */
-    public List<AppServicePlan> listAppServicePlanBySubscriptionId(String sid) throws IOException {
+    public List<AppServicePlan> listAppServicePlanBySubscriptionId(String sid) {
         return AuthMethodManager.getInstance().getAzureClient(sid).appServices().appServicePlans().list(true);
     }
 
@@ -560,18 +558,23 @@ public class AzureWebAppMvpModel {
      */
     public List<ResourceEx<WebApp>> listAllWebApps(final boolean force) {
         final List<ResourceEx<WebApp>> webApps = new ArrayList<>();
-        List<Subscription> subs = AzureMvpModel.getInstance().getSelectedSubscriptions();
+        final List<Subscription> subs = AzureMvpModel.getInstance().getSelectedSubscriptions();
         if (subs.size() == 0) {
             return webApps;
         }
-        Observable.from(subs).flatMap((sd) ->
-            Observable.create((subscriber) -> {
-                List<ResourceEx<WebApp>> webAppList = listWebApps(sd.subscriptionId(), force);
-                synchronized (webApps) {
-                    webApps.addAll(webAppList);
-                }
-                subscriber.onCompleted();
-            }).subscribeOn(Schedulers.io()), subs.size()).subscribeOn(Schedulers.io()).toBlocking().subscribe();
+        Observable.from(subs)
+                  .flatMap((sd) ->
+                               Observable.create((subscriber) -> {
+                                   final List<ResourceEx<WebApp>> webAppList = listWebApps(sd.subscriptionId(),
+                                                                                           force);
+                                   synchronized (webApps) {
+                                       webApps.addAll(webAppList);
+                                   }
+                                   subscriber.onCompleted();
+                               }).subscribeOn(Schedulers.io()), subs.size())
+                  .subscribeOn(Schedulers.io())
+                  .toBlocking()
+                  .subscribe();
         return webApps;
     }
 
@@ -605,7 +608,8 @@ public class AzureWebAppMvpModel {
             return subscriptionIdToWebApps.get(subscriptionId);
         }
         final Azure azure = AuthMethodManager.getInstance().getAzureClient(subscriptionId);
-        final Predicate<SiteInner> filter = inner -> inner.kind() == null || !Arrays.asList(inner.kind().split(",")).contains("functionapp");
+        final Predicate<SiteInner> filter = inner -> inner.kind() == null || !Arrays.asList(inner.kind().split(","))
+                                                                                    .contains("functionapp");
         final List<ResourceEx<WebApp>> webapps = azure.appServices().webApps()
                                                       .inner().list().stream().filter(filter)
                                                       .map(inner -> new WebAppWrapper(subscriptionId, inner))
@@ -636,17 +640,17 @@ public class AzureWebAppMvpModel {
      */
     public static List<WebAppUtils.WebContainerMod> listWebContainersForWarFile() {
         return Arrays.asList(
-                WebAppUtils.WebContainerMod.Newest_Jetty_91,
-                WebAppUtils.WebContainerMod.Newest_Jetty_93,
-                WebAppUtils.WebContainerMod.Newest_Tomcat_70,
-                WebAppUtils.WebContainerMod.Newest_Tomcat_80,
-                WebAppUtils.WebContainerMod.Newest_Tomcat_85,
-                WebAppUtils.WebContainerMod.Newest_Tomcat_90
-        );
+            WebAppUtils.WebContainerMod.Newest_Jetty_91,
+            WebAppUtils.WebContainerMod.Newest_Jetty_93,
+            WebAppUtils.WebContainerMod.Newest_Tomcat_70,
+            WebAppUtils.WebContainerMod.Newest_Tomcat_80,
+            WebAppUtils.WebContainerMod.Newest_Tomcat_85,
+            WebAppUtils.WebContainerMod.Newest_Tomcat_90
+                            );
     }
 
     public List<WebAppUtils.WebContainerMod> listWebContainers() {
-        List<WebAppUtils.WebContainerMod> webContainers = new ArrayList<>();
+        final List<WebAppUtils.WebContainerMod> webContainers = new ArrayList<>();
         Collections.addAll(webContainers, WebAppUtils.WebContainerMod.values());
         return webContainers;
     }
@@ -655,7 +659,7 @@ public class AzureWebAppMvpModel {
      * List available Third Party JDKs.
      */
     public List<JdkModel> listJdks() {
-        List<JdkModel> jdkModels = new ArrayList<>();
+        final List<JdkModel> jdkModels = new ArrayList<>();
         Collections.addAll(jdkModels, JdkModel.values());
         return jdkModels;
     }
@@ -671,6 +675,7 @@ public class AzureWebAppMvpModel {
 
     /**
      * List all the Web Apps on Linux in selected subscriptions.
+     *
      * @param force flag indicating whether force to fetch most updated data from server
      * @return list of Web App on Linux
      */
@@ -693,28 +698,40 @@ public class AzureWebAppMvpModel {
      * @throws Exception exception
      */
     public boolean getPublishingProfileXmlWithSecrets(String sid, String webAppId, String filePath) throws Exception {
-        WebApp app = getWebAppById(sid, webAppId);
+        final WebApp app = getWebAppById(sid, webAppId);
         return AppServiceUtils.getPublishingProfileXmlWithSecrets(app, filePath);
     }
 
     /**
      * Download publish profile of deployment slot.
      */
-    public boolean getSlotPublishingProfileXmlWithSecrets(final String sid, final String webAppId, final String slotName,
-                                                          final String filePath) throws Exception {
+    public boolean getSlotPublishingProfileXmlWithSecrets(final String sid,
+                                                          final String webAppId,
+                                                          final String slotName,
+                                                          final String filePath) {
         final WebApp app = getWebAppById(sid, webAppId);
         final DeploymentSlot slot = app.deploymentSlots().getByName(slotName);
-        final File file = new File(Paths.get(filePath, slotName + "_" + System.currentTimeMillis() + ".PublishSettings")
-            .toString());
-        file.createNewFile();
+        final String fileName = slotName + "_" + System.currentTimeMillis() + ".PublishSettings";
+        final Path path = Paths.get(filePath, fileName);
+        final File file = new File(path.toString());
+        try {
+            file.createNewFile();
+        } catch (final IOException e) {
+            log.warning("failed to create publishing profile xml file");
+            return false;
+        }
         try (final InputStream inputStream = slot.manager().inner().webApps()
-            .listPublishingProfileXmlWithSecretsSlot(slot.resourceGroupName(), app.name(), slotName,
-                    new CsmPublishingProfileOptions().withFormat(PublishingProfileFormat.FTP));
-             OutputStream outputStream = new FileOutputStream(file);
+                                                 .listPublishingProfileXmlWithSecretsSlot(slot.resourceGroupName(),
+                                                                                          app.name(),
+                                                                                          slotName,
+                                                                                          new CsmPublishingProfileOptions()
+                                                                                              .withFormat(
+                                                                                                  PublishingProfileFormat.FTP));
+             final OutputStream outputStream = new FileOutputStream(file)
         ) {
             IOUtils.copy(inputStream, outputStream);
             return true;
-        } catch (IOException e) {
+        } catch (final IOException e) {
             e.printStackTrace();
             return false;
         }
@@ -724,7 +741,7 @@ public class AzureWebAppMvpModel {
     public static boolean isHttpLogEnabled(WebAppBase webAppBase) {
         final WebAppDiagnosticLogs config = webAppBase.diagnosticLogsConfig();
         return config != null && config.inner() != null && config.inner().httpLogs() != null &&
-                config.inner().httpLogs().fileSystem() != null && config.inner().httpLogs().fileSystem().enabled();
+            config.inner().httpLogs().fileSystem() != null && config.inner().httpLogs().fileSystem().enabled();
     }
 
     public static void enableHttpLog(WebAppBase.Update webApp) {
@@ -741,10 +758,13 @@ public class AzureWebAppMvpModel {
         }
         final SkuName skuName = SkuName.fromString(pricingTier.toSkuDescription().tier());
         final List<GeoRegionInner> geoRegionInnerList = AuthMethodManager.getInstance()
-                .getAzureClient(subscriptionId).appServices().inner().listGeoRegions(skuName, false, false, false);
+                                                                         .getAzureClient(subscriptionId)
+                                                                         .appServices()
+                                                                         .inner()
+                                                                         .listGeoRegions(skuName, false, false, false);
         return geoRegionInnerList.stream()
-                .map(regionInner -> Region.fromName(regionInner.displayName()))
-                .collect(Collectors.toList());
+                                 .map(regionInner -> Region.fromName(regionInner.displayName()))
+                                 .collect(Collectors.toList());
     }
 
     /**

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -80,8 +80,8 @@ public class AzureWebAppMvpModel {
     public WebApp getWebAppById(String sid, String id) throws AzureToolkitRuntimeException {
         final WebApp webapp = this.getNullableWebAppById(sid, id);
         if (Objects.isNull(webapp)) {
-            final String error = String.format("cannot find WebApp[%s] in subscription[%s]", id, sid);
-            final String action = String.format("confirm if the WebApp[id=%s] still exists", id);
+            final String error = String.format("Cannot find WebApp[%s] in subscription[%s]", id, sid);
+            final String action = String.format("Confirm if the WebApp[id=%s] still exists", id);
             throw new AzureToolkitRuntimeException(error, action);
         }
         return webapp;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/WebAppWrapper.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/webapp/WebAppWrapper.java
@@ -32,7 +32,6 @@ import rx.Completable;
 import rx.Observable;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 
 public class WebAppWrapper extends WebAppBaseWrapper implements WebApp {
@@ -122,14 +121,10 @@ public class WebAppWrapper extends WebAppBaseWrapper implements WebApp {
     }
 
     private WebApp getWebApp() {
-        try {
-            if (this.webapp == null) {
-                final AzureWebAppMvpModel instance = AzureWebAppMvpModel.getInstance();
-                this.webapp = instance.getWebAppById(getSubscriptionId(), inner().id());
-            }
-            return this.webapp;
-        } catch (final IOException e) {
-            throw new RuntimeException("Failed to get webapp instance");
+        final AzureWebAppMvpModel instance = AzureWebAppMvpModel.getInstance();
+        if (this.webapp == null) {
+            this.webapp = instance.getWebAppById(getSubscriptionId(), inner().id());
         }
+        return this.webapp;
     }
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/AccessTokenAzureManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/AccessTokenAzureManager.java
@@ -52,7 +52,7 @@ public class AccessTokenAzureManager extends AzureManagerBase {
     }
 
     @Override
-    public String getCurrentUserId() throws IOException {
+    public String getCurrentUserId() {
         return delegateADAuthManager.getAccountEmail();
     }
 
@@ -66,7 +66,7 @@ public class AccessTokenAzureManager extends AzureManagerBase {
     }
 
     @Override
-    public void drop() throws IOException {
+    public void drop() {
         super.drop();
         delegateADAuthManager.signOut();
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/AzureCliAzureManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/AzureCliAzureManager.java
@@ -34,9 +34,9 @@ import com.microsoft.azuretools.authmanage.AzureManagerFactory;
 import com.microsoft.azuretools.authmanage.CommonSettings;
 import com.microsoft.azuretools.authmanage.Environment;
 import com.microsoft.azuretools.authmanage.models.AuthMethodDetails;
-import com.microsoft.azuretools.exception.AzureRuntimeException;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.enums.ErrorEnum;
+import com.microsoft.azuretools.exception.AzureRuntimeException;
 import com.microsoft.azuretools.utils.CommandUtils;
 import com.microsoft.azuretools.utils.Pair;
 import org.apache.commons.lang.ObjectUtils;
@@ -107,7 +107,7 @@ public class AzureCliAzureManager extends AzureManagerBase {
     }
 
     @Override
-    public void drop() throws IOException {
+    public void drop() {
         this.currentClientId = null;
         this.currentTenantId = null;
         this.tenantTokens.clear();
@@ -142,11 +142,7 @@ public class AzureCliAzureManager extends AzureManagerBase {
             authResult.setAzureEnv(credentials.environment().toString());
             return authResult;
         } catch (final IOException e) {
-            try {
-                drop();
-            } catch (final IOException ignore) {
-                // swallow exception while clean up
-            }
+            drop();
             throw new AzureExecutionException(FAILED_TO_AUTH_WITH_AZURE_CLI, e);
         }
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/AzureManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/AzureManager.java
@@ -37,31 +37,31 @@ import java.io.IOException;
 import java.util.List;
 
 public interface AzureManager {
-    Azure getAzure(String sid) throws IOException;
+    Azure getAzure(String sid);
 
-    AppPlatformManager getAzureSpringCloudClient(String sid) throws IOException;
+    AppPlatformManager getAzureSpringCloudClient(String sid);
 
-    InsightsManager getInsightsManager(String sid) throws IOException;
+    InsightsManager getInsightsManager(String sid);
 
-    List<Subscription> getSubscriptions() throws IOException;
+    List<Subscription> getSubscriptions();
 
-    List<Pair<Subscription, Tenant>> getSubscriptionsWithTenant() throws IOException;
+    List<Pair<Subscription, Tenant>> getSubscriptionsWithTenant();
 
     Settings getSettings();
 
     SubscriptionManager getSubscriptionManager();
 
-    void drop() throws IOException;
+    void drop();
 
-    String getCurrentUserId() throws IOException;
+    String getCurrentUserId();
 
     String getAccessToken(String tid, String resource, PromptBehavior promptBehavior) throws IOException;
 
-    String getManagementURI() throws IOException;
+    String getManagementURI();
 
     String getStorageEndpointSuffix();
 
-    String getTenantIdBySubscription(String subscriptionId) throws IOException;
+    String getTenantIdBySubscription(String subscriptionId);
 
     String getScmSuffix();
 

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/AzureManagerBase.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/AzureManagerBase.java
@@ -34,6 +34,7 @@ import com.microsoft.azure.management.resources.Tenant;
 import com.microsoft.azure.toolkit.lib.common.rest.RestExceptionHandlerInterceptor;
 import com.microsoft.azuretools.adauth.AuthException;
 import com.microsoft.azuretools.authmanage.*;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.enums.ErrorEnum;
 import com.microsoft.azuretools.exception.AzureRuntimeException;
 import com.microsoft.azuretools.telemetry.TelemetryInterceptor;
@@ -41,7 +42,6 @@ import com.microsoft.azuretools.utils.AzureRegisterProviderNamespaces;
 import com.microsoft.azuretools.utils.Pair;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -106,7 +106,7 @@ public abstract class AzureManagerBase implements AzureManager {
     }
 
     @Override
-    public String getTenantIdBySubscription(String subscriptionId) throws IOException {
+    public String getTenantIdBySubscription(String subscriptionId) {
         final Pair<Subscription, Tenant> subscriptionTenantPair = getSubscriptionsWithTenant().stream()
                 .filter(pair -> pair != null && pair.first() != null && pair.second() != null)
                 .filter(pair -> StringUtils.equals(pair.first().subscriptionId(), subscriptionId))
@@ -120,12 +120,12 @@ public abstract class AzureManagerBase implements AzureManager {
     }
 
     @Override
-    public List<Subscription> getSubscriptions() throws IOException {
+    public List<Subscription> getSubscriptions() {
         return getSubscriptionsWithTenant().stream().map(Pair::first).collect(Collectors.toList());
     }
 
     @Override
-    public List<Pair<Subscription, Tenant>> getSubscriptionsWithTenant() throws IOException {
+    public List<Pair<Subscription, Tenant>> getSubscriptionsWithTenant() {
         final List<Pair<Subscription, Tenant>> subscriptions = new LinkedList<>();
         final Azure.Authenticated authentication = authTenant(getCurrentTenantId());
         // could be multi tenant - return all subscriptions for the current account
@@ -154,7 +154,7 @@ public abstract class AzureManagerBase implements AzureManager {
     }
 
     @Override
-    public Azure getAzure(String sid) throws IOException {
+    public @Nullable Azure getAzure(String sid) {
         if (!isSignedIn()) {
             return null;
         }
@@ -170,30 +170,26 @@ public abstract class AzureManagerBase implements AzureManager {
     }
 
     @Override
-    public AppPlatformManager getAzureSpringCloudClient(String sid) throws IOException {
+    public @Nullable AppPlatformManager getAzureSpringCloudClient(String sid) {
         if (!isSignedIn()) {
             return null;
         }
         return sidToAzureSpringCloudManagerMap.computeIfAbsent(sid, s -> {
-            String tid = this.subscriptionManager.getSubscriptionTenant(sid);
+            final String tid = this.subscriptionManager.getSubscriptionTenant(sid);
             return authSpringCloud(sid, tid);
         });
     }
 
     @Override
-    public InsightsManager getInsightsManager(String sid) throws IOException {
+    public @Nullable InsightsManager getInsightsManager(String sid) {
         if (!isSignedIn()) {
             return null;
         }
         return sidToInsightsManagerMap.computeIfAbsent(sid, s -> {
-            try {
-                // Register insights namespace first
-                final Azure azure = getAzure(sid);
-                azure.providers().register(MICROSOFT_INSIGHTS_NAMESPACE);
-            } catch (IOException e) {
-                // swallow exception while get azure client
-            }
-            String tid = this.subscriptionManager.getSubscriptionTenant(sid);
+            // Register insights namespace first
+            final Azure azure = getAzure(sid);
+            azure.providers().register(MICROSOFT_INSIGHTS_NAMESPACE);
+            final String tid = this.subscriptionManager.getSubscriptionTenant(sid);
             return authApplicationInsights(sid, tid);
         });
     }
@@ -212,7 +208,7 @@ public abstract class AzureManagerBase implements AzureManager {
     }
 
     @Override
-    public String getManagementURI() throws IOException {
+    public @Nullable String getManagementURI() {
         if (!isSignedIn()) {
             return null;
         }
@@ -233,12 +229,12 @@ public abstract class AzureManagerBase implements AzureManager {
     }
 
     @Override
-    public void drop() throws IOException {
+    public void drop() {
         LOGGER.log(Level.INFO, "ServicePrincipalAzureManager.drop()");
         this.subscriptionManager.cleanSubscriptions();
     }
 
-    protected abstract String getCurrentTenantId() throws IOException;
+    protected abstract String getCurrentTenantId();
 
     protected boolean isSignedIn() {
         return false;

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/ServicePrincipalAzureManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/ServicePrincipalAzureManager.java
@@ -59,8 +59,8 @@ public class ServicePrincipalAzureManager extends AzureManagerBase {
         settings.setSubscriptionsDetailsFileName(FILE_NAME_SUBSCRIPTIONS_DETAILS_SP);
     }
 
-    public static void cleanPersist() throws IOException {
-        String subscriptionsDetailsFileName = settings.getSubscriptionsDetailsFileName();
+    public static void cleanPersist() {
+        final String subscriptionsDetailsFileName = settings.getSubscriptionsDetailsFileName();
         SubscriptionManagerPersist.deleteSubscriptions(subscriptionsDetailsFileName);
     }
 
@@ -82,12 +82,12 @@ public class ServicePrincipalAzureManager extends AzureManagerBase {
     }
 
     @Override
-    public String getCurrentUserId() throws IOException {
+    public String getCurrentUserId() {
         return this.credentials.clientId();
     }
 
     @Override
-    protected String getCurrentTenantId() throws IOException {
+    protected String getCurrentTenantId() {
         return this.defaultTenantId;
     }
 
@@ -101,7 +101,7 @@ public class ServicePrincipalAzureManager extends AzureManagerBase {
     }
 
     @Override
-    public String getManagementURI() throws IOException {
+    public String getManagementURI() {
         // default to global cloud
         return this.credentials.environment() == null ?
                 AzureEnvironment.AZURE.resourceManagerEndpoint() : this.credentials.environment().resourceManagerEndpoint();

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/EventUtil.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/EventUtil.java
@@ -28,7 +28,6 @@ import com.microsoft.azuretools.sdkmanage.AzureManager;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -191,13 +190,9 @@ public class EventUtil {
 
     // Will collect error stack traces only if user signed in with Azure account
     public static boolean isAbleToCollectErrorStacks() {
-        try {
-            final AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
-            return azureManager != null && azureManager.getEnvironment() != null &&
-                    ObjectUtils.equals(azureManager.getEnvironment().getAzureEnvironment(), Environment.GLOBAL.getAzureEnvironment());
-        } catch (IOException e) {
-            return false;
-        }
+        final AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
+        return azureManager != null && azureManager.getEnvironment() != null &&
+            ObjectUtils.equals(azureManager.getEnvironment().getAzureEnvironment(), Environment.GLOBAL.getAzureEnvironment());
     }
 
     private static void logError(String serviceName, String operName, ErrorType errorType, Throwable e,

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/utils/AzureModelController.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/utils/AzureModelController.java
@@ -28,7 +28,6 @@ import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.resources.Location;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.azure.management.resources.Subscription;
-import com.microsoft.azuretools.adauth.AuthException;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.authmanage.CommonSettings;
 import com.microsoft.azuretools.authmanage.ISubscriptionSelectionListener;
@@ -43,7 +42,6 @@ import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -100,7 +98,7 @@ public class AzureModelController {
         AzureUIRefreshCore.removeAll();
     }
 
-    private static synchronized void subscriptionSelectionChanged(IProgressIndicator progressIndicator) throws IOException, AuthException {
+    private static synchronized void subscriptionSelectionChanged(IProgressIndicator progressIndicator) {
         System.out.println("AzureModelController.subscriptionSelectionChanged: starting");
         AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
         // not signed in
@@ -235,7 +233,7 @@ public class AzureModelController {
                 });
     }
 
-    public static synchronized void updateSubscriptionMaps(IProgressIndicator progressIndicator) throws IOException, CanceledByUserException, AuthException {
+    public static synchronized void updateSubscriptionMaps(IProgressIndicator progressIndicator) throws CanceledByUserException {
         AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
         // not signed in
         if (azureManager == null) {
@@ -299,7 +297,7 @@ public class AzureModelController {
         azureModel.setSubscriptionToLocationMap(sdlocMap);
     }
 
-    public static synchronized void updateResourceGroupMaps(IProgressIndicator progressIndicator) throws IOException, CanceledByUserException, AuthException {
+    public static synchronized void updateResourceGroupMaps(IProgressIndicator progressIndicator) throws CanceledByUserException {
         AzureManager azureManager = AuthMethodManager.getInstance().getAzureManager();
         // not signed in
         if (azureManager == null) {

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/HDIEnvironment.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/HDIEnvironment.java
@@ -27,7 +27,6 @@ import com.microsoft.azuretools.authmanage.Environment;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,29 +35,37 @@ public final class HDIEnvironment implements IEnvironment {
     private final Map<String, String> endpoints;
     private final Environment environment;
 
-    private static final HDIEnvironment GLOBAL = new HDIEnvironment(new HashMap<String, String>() {{
+    private static final HDIEnvironment GLOBAL = new HDIEnvironment(new HashMap<String, String>() {
+        {
             put("connectionString", "https://%s.azurehdinsight.net/");
             put("blobFullName", "%s.blob.core.windows.net");
             put("portalUrl", "https://portal.azure.com/");
-        }}, Environment.GLOBAL);
+        }
+    }, Environment.GLOBAL);
 
-    private static final HDIEnvironment CHINA = new HDIEnvironment(new HashMap<String, String>() {{
-        put("connectionString", "https://%s.azurehdinsight.cn/");
-        put("blobFullName", "%s.blob.core.chinacloudapi.cn");
-        put("portalUrl", "https://portal.azure.cn/");
-    }}, Environment.CHINA);
+    private static final HDIEnvironment CHINA = new HDIEnvironment(new HashMap<String, String>() {
+        {
+            put("connectionString", "https://%s.azurehdinsight.cn/");
+            put("blobFullName", "%s.blob.core.chinacloudapi.cn");
+            put("portalUrl", "https://portal.azure.cn/");
+        }
+    }, Environment.CHINA);
 
-    private static final HDIEnvironment US_GOVERNMENT = new HDIEnvironment(new HashMap<String, String>() {{
-        put("connectionString", "https://%s.azurehdinsight.us/");
-        put("blobFullName", "%s.blob.core.usgovcloudapi.net");
-        put("portalUrl", "https://manage.windowsazure.us/");
-    }}, Environment.US_GOVERNMENT);
+    private static final HDIEnvironment US_GOVERNMENT = new HDIEnvironment(new HashMap<String, String>() {
+        {
+            put("connectionString", "https://%s.azurehdinsight.us/");
+            put("blobFullName", "%s.blob.core.usgovcloudapi.net");
+            put("portalUrl", "https://manage.windowsazure.us/");
+        }
+    }, Environment.US_GOVERNMENT);
 
-    private static final HDIEnvironment GERMANY = new HDIEnvironment(new HashMap<String, String>() {{
-        put("connectionString", "https://%s.azurehdinsight.de/");
-        put("blobFullName", "%s.blob.core.cloudapi.de");
-        put("portalUrl", "https://portal.microsoftazure.de/");
-    }}, Environment.GERMAN);
+    private static final HDIEnvironment GERMANY = new HDIEnvironment(new HashMap<String, String>() {
+        {
+            put("connectionString", "https://%s.azurehdinsight.de/");
+            put("blobFullName", "%s.blob.core.cloudapi.de");
+            put("portalUrl", "https://portal.microsoftazure.de/");
+        }
+    }, Environment.GERMAN);
 
     private HDIEnvironment(Map<String, String> endpoints, Environment environment) {
         this.endpoints = endpoints;
@@ -110,11 +117,7 @@ public final class HDIEnvironment implements IEnvironment {
         AzureManager azureManager = null;
         Environment env = Environment.GLOBAL;
 
-        try {
-            azureManager = AuthMethodManager.getInstance().getAzureManager();
-        } catch (IOException ignored) {
-            // ignore the exception
-        }
+        azureManager = AuthMethodManager.getInstance().getAzureManager();
 
         if (azureManager != null) {
             env = azureManager.getEnvironment();

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/azure/serverless/AzureSparkCosmosClusterManager.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/azure/serverless/AzureSparkCosmosClusterManager.java
@@ -52,7 +52,6 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.apache.http.NameValuePair;
 import rx.Observable;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -81,7 +80,8 @@ public class AzureSparkCosmosClusterManager implements ClusterContainer,
     // FIXME!!!
     private static final String ACCOUNT_FILTER = CommonSettings.getAdEnvironment().endpoints()
             .getOrDefault("dataLakeSparkAccountFilter",
-                    "length(name) gt 4 and substring(name, length(name) sub 4) ge '-c00' and substring(name, length(name) sub 4) le '-c99'");
+                    "length(name) gt 4 and substring(name, length(name) sub 4) ge '-c00' and "
+                        + "substring(name, length(name) sub 4) le '-c99'");
 
     @NotNull
     private final HashMap<String, AzureHttpObservable> httpMap = new HashMap<>();
@@ -90,7 +90,7 @@ public class AzureSparkCosmosClusterManager implements ClusterContainer,
     private AzureEnvironment azureEnv = CommonSettings.getAdEnvironment();
 
     @NotNull
-    private ImmutableSortedSet<? extends AzureSparkServerlessAccount> accounts= ImmutableSortedSet.of();
+    private ImmutableSortedSet<? extends AzureSparkServerlessAccount> accounts = ImmutableSortedSet.of();
 
     public AzureSparkCosmosClusterManager() {
         this.httpMap.put("common", new AzureHttpObservable(ApiVersion.VERSION));
@@ -131,13 +131,7 @@ public class AzureSparkCosmosClusterManager implements ClusterContainer,
 
     @Nullable
     public AzureManager getAzureManager() {
-        try {
-            return AuthMethodManager.getInstance().getAzureManager();
-        } catch (IOException e) {
-            log().info("Can't get Azure manager now, please sign in. error: " + e);
-
-            return null;
-        }
+        return AuthMethodManager.getInstance().getAzureManager();
     }
 
     /**

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/azure/serverless/AzureSparkCosmosClusterManager.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/azure/serverless/AzureSparkCosmosClusterManager.java
@@ -77,7 +77,7 @@ public class AzureSparkCosmosClusterManager implements ClusterContainer,
     private static final String REST_SEGMENT_SUBSCRIPTION = "/subscriptions/";
     private static final String REST_SEGMENT_ADL_ACCOUNT = "providers/Microsoft.DataLakeAnalytics/accounts";
 
-    // FIXME!!!
+    // TODO!!!
     private static final String ACCOUNT_FILTER = CommonSettings.getAdEnvironment().endpoints()
             .getOrDefault("dataLakeSparkAccountFilter",
                     "length(name) gt 4 and substring(name, length(name) sub 4) ge '-c00' and "
@@ -189,17 +189,15 @@ public class AzureSparkCosmosClusterManager implements ClusterContainer,
                 }))
                 .map(account -> account.getClusters())
                 .flatMap(Observable::from)
-                .flatMap(cluster -> ((AzureSparkCosmosCluster)cluster).get().onErrorReturn(err -> {
+                .flatMap(cluster -> ((AzureSparkCosmosCluster) cluster).get().onErrorReturn(err -> {
                     log().warn(String.format("Can't get the cluster %s details: %s", cluster.getName(), err));
-
                     return (AzureSparkCosmosCluster) cluster;
                 }))
                 .map(clusters -> this)
                 .defaultIfEmpty(this);
     }
 
-    private Observable<List<Triple<SubscriptionDetail, DataLakeAnalyticsAccountBasic, DataLakeAnalyticsAccount>>>
-    getAzureDataLakeAccountsRequest() {
+    private Observable<List<Triple<SubscriptionDetail, DataLakeAnalyticsAccountBasic, DataLakeAnalyticsAccount>>> getAzureDataLakeAccountsRequest() {
         if (getAzureManager() == null) {
             return Observable.error(new AuthException(
                     "Can't get Azure Data Lake account since the user isn't signed in, please sign in by Azure Explorer."));
@@ -221,7 +219,7 @@ public class AzureSparkCosmosClusterManager implements ClusterContainer,
                                 .get(subUriPair.getRight().toString(),
                                         getAccountFilter(),
                                         null,
-                                        // FIXME!!! Needs to support paging
+                                        // TODO!!! Needs to support paging
                                         GetAccountsListResponse.class)))
                 // account basic list -> account basic
                 .flatMap(subAccountsObPair -> subAccountsObPair.getRight()
@@ -327,9 +325,9 @@ public class AzureSparkCosmosClusterManager implements ClusterContainer,
             props.put("requestUri", serviceException.getRequestUri() != null ? serviceException.getRequestUri().toString() : "");
             props.put("statusCode", String.valueOf(serviceException.getStatusCode()));
             props.put("x-ms-request-id", serviceException.getRequestId());
-            EventUtil.logErrorClassNameOnly(TelemetryConstants.SPARK_ON_COSMOS, operationName, ErrorType.serviceError, serviceException,  props, null);
+            EventUtil.logErrorClassNameOnly(TelemetryConstants.SPARK_ON_COSMOS, operationName, ErrorType.serviceError, serviceException, props, null);
         } else {
-            EventUtil.logErrorClassNameOnly(TelemetryConstants.SPARK_ON_COSMOS, operationName, ErrorType.unclassifiedError, ex,  props, null);
+            EventUtil.logErrorClassNameOnly(TelemetryConstants.SPARK_ON_COSMOS, operationName, ErrorType.unclassifiedError, ex, props, null);
         }
     }
 

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/azure/serverless/AzureSparkServerlessAccount.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/common/azure/serverless/AzureSparkServerlessAccount.java
@@ -55,6 +55,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
+import static com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.job.models.ApiVersion.VERSION;
+
 public class AzureSparkServerlessAccount implements IClusterDetail, ClusterContainer, ILogger {
     private static final String REST_SEGMENT_SPARK_RESOURCEPOOLS = "/activityTypes/spark/resourcePools";
     private static final String REST_SEGMENT_SPARK_BATCH_JOB = "/activityTypes/spark/batchJobs";
@@ -223,7 +225,6 @@ public class AzureSparkServerlessAccount implements IClusterDetail, ClusterConta
                 .requestWithHttpResponse(new HttpGet(url), null, null, null);
     }
 
-
     /**
      * Kill Cosmos Serverless Spark batch job
      * @return http response of the killing request
@@ -248,10 +249,9 @@ public class AzureSparkServerlessAccount implements IClusterDetail, ClusterConta
     public Observable<JobInfoListResult> getJobs() {
         URI url = getUri().resolve(REST_SEGMENT_JOB_LIST);
         List<NameValuePair> parameters = Collections.singletonList(
-                ODataParam.filter(String.format("state eq '%s'",JobState.RUNNING.toString())));
+                ODataParam.filter(String.format("state eq '%s'", JobState.RUNNING.toString())));
 
-        return new AzureDataLakeHttpObservable(subscription.getTenantId(),
-                com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.job.models.ApiVersion.VERSION)
+        return new AzureDataLakeHttpObservable(subscription.getTenantId(), VERSION)
                 .withUuidUserAgent()
                 .get(url.toString(), parameters, null, JobInfoListResult.class);
     }
@@ -288,7 +288,7 @@ public class AzureSparkServerlessAccount implements IClusterDetail, ClusterConta
     @Override
     public ImmutableSortedSet<? extends IClusterDetail> getClusters() {
         return ImmutableSortedSet.copyOf(getRawClusters().stream()
-                .filter(cluster -> ((AzureSparkCosmosCluster)cluster).isRunning()).iterator());
+                 .filter(cluster -> ((AzureSparkCosmosCluster) cluster).isRunning()).iterator());
     }
 
     /**

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/StorageAccountNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/StorageAccountNode.java
@@ -28,7 +28,6 @@ import com.microsoft.azure.hdinsight.sdk.cluster.ClusterDetail;
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
 import com.microsoft.azure.hdinsight.sdk.storage.IHDIStorageAccount;
 import com.microsoft.azure.hdinsight.sdk.storage.StorageAccountType;
-import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
@@ -63,20 +62,16 @@ public class StorageAccountNode extends Node implements TelemetryProperties, ILo
             addAction("Open Storage in Azure Management Portal", new NodeActionListener() {
                 @Override
                 protected void actionPerformed(NodeActionEvent e) {
-                    String subscriptionId = clusterDetail.getSubscription().getSubscriptionId();
-                    String storageRelativePath = ((ClusterDetail) clusterDetail).getId() + REST_SEGMENT_STORAGE_ACCOUNT;
-                    try {
-                        openResourcesInPortal(subscriptionId, storageRelativePath);
-                    } catch (AzureCmdException ex) {
-                        log().warn("Can't open Storage in Azure Management Portal", ex);
-                    }
+                    final String subscriptionId = clusterDetail.getSubscription().getSubscriptionId();
+                    final String storageRelativePath = ((ClusterDetail) clusterDetail).getId() + REST_SEGMENT_STORAGE_ACCOUNT;
+                    openResourcesInPortal(subscriptionId, storageRelativePath);
                 }
             });
         }
     }
 
     private static String getIconPath(IHDIStorageAccount storageAccount) {
-        if(storageAccount.getAccountType() == StorageAccountType.ADLS) {
+        if (storageAccount.getAccountType() == StorageAccountType.ADLS) {
             return ADLS_ICON_PATH;
         } else {
             return ICON_PATH;

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/StorageAccountNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/StorageAccountNode.java
@@ -51,7 +51,8 @@ public class StorageAccountNode extends Node implements TelemetryProperties, ILo
     private IClusterDetail clusterDetail;
 
     public StorageAccountNode(Node parent, @NotNull IHDIStorageAccount storageAccount, @NotNull IClusterDetail clusterDetail, boolean isDefaultStorageAccount) {
-       super(STORAGE_ACCOUNT_MODULE_ID, isDefaultStorageAccount ? storageAccount.getName() + DEFAULT_STORAGE_FLAG : storageAccount.getName(), parent, getIconPath(storageAccount));
+        super(STORAGE_ACCOUNT_MODULE_ID, isDefaultStorageAccount ? storageAccount.getName() + DEFAULT_STORAGE_FLAG : storageAccount.getName(), parent,
+              getIconPath(storageAccount));
         this.storageAccount = storageAccount;
         this.clusterDetail = clusterDetail;
         loadAdditionalActions();

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/projectarcadia/common/ArcadiaSparkComputeManager.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/projectarcadia/common/ArcadiaSparkComputeManager.java
@@ -42,7 +42,6 @@ import org.apache.http.NameValuePair;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -69,13 +68,7 @@ public class ArcadiaSparkComputeManager implements ClusterContainer, ILogger {
 
     @Nullable
     public AzureManager getAzureManager() {
-        try {
-            return AuthMethodManager.getInstance().getAzureManager();
-        } catch (IOException e) {
-            log().info("Failed to get AzureManager. Error: " + e);
-
-            return null;
-        }
+        return AuthMethodManager.getInstance().getAzureManager();
     }
 
     public ArcadiaSparkComputeManager() {
@@ -159,7 +152,7 @@ public class ArcadiaSparkComputeManager implements ClusterContainer, ILogger {
         return Collections.singletonList(ODataParam.filter(SYNAPSE_WORKSPACE_FILTER));
     }
 
-        @NotNull
+    @NotNull
     private Observable<List<ArcadiaWorkSpace>> getWorkSpacesRequest() {
         AzureManager azureManager = getAzureManager();
         if (azureManager == null) {


### PR DESCRIPTION
Almost all the fixed IOException are thrown from auth related code. 
User must signin first before they can use any feature of the plugin, so we can just throw a runtime exception to terminate user action if auth related problem found.

these are the original methods throwing IOException before fix (which finally pollutes >50 classes and hundreds of methods) 
![image](https://user-images.githubusercontent.com/69189193/98890115-396d5580-24d6-11eb-95c6-7b019803f022.png)
