### PR TITLE
upgrade gradle to 6.5

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -30,19 +30,13 @@ compileTestKotlin {
 
 tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
 
-//apply plugin: 'checkstyle'
-//apply plugin: 'findbugs'
+apply plugin: 'checkstyle'
 
-//checkstyle {
-//    toolVersion = '8.30'
-//    configFile = new File('config/checkstyle/checkstyle.xml')
-//    showViolations = false
-//}
-
-//findbugs {
-//    toolVersion = "3.0.1"
-//    ignoreFailures = true
-//}
+checkstyle {
+    toolVersion = '8.30'
+    configFile = new File('config/checkstyle/checkstyle.xml')
+    showViolations = false
+}
 
 intellij {
     pluginName = 'azure-toolkit-for-intellij'
@@ -189,7 +183,7 @@ wrapper() {
 apply plugin: BundleBuildIDEAPlugin
 
 installIdea.dependsOn buildPlugin
-//installIdea.dependsOn checkstyleMain
+installIdea.dependsOn checkstyleMain
 
 patchPluginXml {
     sinceBuild = patchPluginXmlSinceBuild

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -31,7 +31,7 @@ compileTestKotlin {
 tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
 
 //apply plugin: 'checkstyle'
-apply plugin: 'findbugs'
+//apply plugin: 'findbugs'
 
 //checkstyle {
 //    toolVersion = '8.30'
@@ -39,10 +39,10 @@ apply plugin: 'findbugs'
 //    showViolations = false
 //}
 
-findbugs {
-    toolVersion = "3.0.1"
-    ignoreFailures = true
-}
+//findbugs {
+//    toolVersion = "3.0.1"
+//    ignoreFailures = true
+//}
 
 intellij {
     pluginName = 'azure-toolkit-for-intellij'
@@ -182,7 +182,7 @@ test.dependsOn cucumber
 defaultTasks 'buildPlugin'
 
 wrapper() {
-    gradleVersion = '5.0'
+    gradleVersion = '6.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle/wrapper/gradle-wrapper.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/SubscriptionManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/SubscriptionManager.java
@@ -77,6 +77,7 @@ public class SubscriptionManager {
 
         return getAccountSidList().stream()
                 .map(sid -> subscriptionIdToSubscriptionDetailMap.get(sid))
+                .filter(s -> Objects.nonNull(s) && s.isSelected())
                 .collect(Collectors.toList());
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/upgrading_version_5.html#the_findbugs_plugin_has_been_removed

**The FindBugs plugin has been removed**
The deprecated FindBugs plugin has been removed. As an alternative, you can use the SpotBugs plugin from the Gradle Plugin Portal.
