### PR TITLE
Upgrade azure blob batch sdk to 12.7.0 with excluded in spark local r…

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -48,7 +48,7 @@
         <azure.security.keyvault.certificates.version>4.1.0</azure.security.keyvault.certificates.version>
         <azure.storage.queue.version>12.7.0</azure.storage.queue.version>
         <azure.storage.blob.version>12.9.0</azure.storage.blob.version>
-        <azure.storage.blob.batch.version>12.6.0</azure.storage.blob.batch.version>
+        <azure.storage.blob.batch.version>12.7.0</azure.storage.blob.batch.version>
         <azure.storage.file.share.version>12.7.0</azure.storage.file.share.version>
         <azure.storage.file.datalake.version>12.3.0</azure.storage.file.datalake.version>
         <jtwig.core.version>5.87.0.RELEASE</jtwig.core.version>

--- a/Utils/spark-localrun-mock/pom.xml
+++ b/Utils/spark-localrun-mock/pom.xml
@@ -160,6 +160,12 @@
             <groupId>com.microsoft.azuretools</groupId>
             <artifactId>azuretools-core</artifactId>
             <version>${azuretool.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-buffer</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>


### PR DESCRIPTION
…un mock

The upgraded netty-buffer 4.1.52 removed symbols depends by Spark