### PR TITLE
Fix bug [#1803710] "Display twice its name after deleted a function app".

### DIFF
--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionModule.java
@@ -52,12 +52,8 @@ public class FunctionModule extends AzureRefreshableNode implements FunctionModu
     @Override
     @AzureOperation(value = "remove function app", type = AzureOperation.Type.ACTION)
     public void removeNode(String sid, String id, Node node) {
-        try {
-            functionModulePresenter.onDeleteFunctionApp(sid, id);
-            removeDirectChildNode(node);
-        } finally {
-            functionModulePresenter.onModuleRefresh();
-        }
+        functionModulePresenter.onDeleteFunctionApp(sid, id);
+        removeDirectChildNode(node);
     }
 
     @Override


### PR DESCRIPTION
Bug link: https://dev.azure.com/mseng/VSJava/_workitems/edit/1803710