### PR TITLE
exclude stax-api

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -89,6 +89,7 @@ repositories {
 configurations {
     compile.exclude module:'slf4j-api'
     compile.exclude module:'log4j'
+    compile.exclude module:'stax-api'
     cucumberRuntime {
         extendsFrom testRuntime
     }


### PR DESCRIPTION
XmlInputFactory in stax-api causing weired runtime exceptions
![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/69189193/108808537-ca79bf80-75e1-11eb-92b1-25fb9c8e16ab.png)
![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/69189193/108808538-cc438300-75e1-11eb-9e52-9f3b0fefae8d.png)
