### PR TITLE
skeleton of modulized intellij plugin

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/.idea/gradle.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/.idea/gradle.xml
@@ -11,11 +11,11 @@
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/azure-intellij-plugin-lib" />
+            <option value="$PROJECT_DIR$/azure-sdk-reference-book" />
             <option value="$PROJECT_DIR$/buildSrc" />
           </set>
         </option>
-        <option name="useAutoImport" value="true" />
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+    id "org.jetbrains.intellij"
+}
+
+group 'com.microsoft.azuretools'
+
+intellij {
+    version = intellij_version
+    downloadSources = Boolean.valueOf(true)
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/action/AzureToolkitTopMenuGroup.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/action/AzureToolkitTopMenuGroup.java
@@ -1,0 +1,11 @@
+package com.microsoft.azure.toolkit.intellij.action;
+
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+
+public class AzureToolkitTopMenuGroup extends DefaultActionGroup{
+
+    public AzureToolkitTopMenuGroup() {
+        super();
+        getTemplatePresentation().setText("Azure Toolkit");
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/resources/META-INF/azure-intellij-plugin-lib.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/resources/META-INF/azure-intellij-plugin-lib.xml
@@ -1,0 +1,11 @@
+<idea-plugin>
+    <extensionPoints>
+    </extensionPoints>
+    <extensions defaultExtensionNs="com.intellij">
+    </extensions>
+    <actions>
+        <group id="AzureToolkit.menu.tools" class="com.microsoft.azure.toolkit.intellij.action.AzureToolkitTopMenuGroup" popup="true">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </group>
+    </actions>
+</idea-plugin>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'java'
+    id "org.jetbrains.intellij"
+}
+
+group 'com.microsoft.azuretools'
+
+intellij {
+    version = intellij_version
+    downloadSources = Boolean.valueOf(true)
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':azure-intellij-plugin-lib')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/sdkreferencebook/OpenSdkReferenceBook.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/sdkreferencebook/OpenSdkReferenceBook.java
@@ -1,0 +1,13 @@
+package com.microsoft.azure.toolkit.intellij.sdkreferencebook;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+
+import javax.annotation.Nonnull;
+
+public class OpenSdkReferenceBook extends AnAction {
+    @Override
+    public void actionPerformed(@Nonnull final AnActionEvent anActionEvent) {
+        System.out.println(OpenSdkReferenceBook.class.getName());
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/resources/META-INF/azure-sdk-reference-book.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/resources/META-INF/azure-sdk-reference-book.xml
@@ -1,0 +1,14 @@
+<idea-plugin>
+    <extensionPoints>
+    </extensionPoints>
+    <extensions defaultExtensionNs="com.intellij">
+    </extensions>
+    <actions>
+        <action id="AzureToolkit.OpenSdkReferenceBook"
+                class="com.microsoft.azure.toolkit.intellij.sdkreferencebook.OpenSdkReferenceBook"
+                text="Azure SDKs"
+                description="Open Azure SDK reference book dialog.">
+            <add-to-group group-id="AzureToolkit.menu.tools"/>
+        </action>
+    </actions>
+</idea-plugin>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -58,7 +58,7 @@ intellij {
     version = intellij_version
     updateSinceUntilBuild = Boolean.valueOf(updateVersionRange)
     plugins = ['java', 'maven', 'gradle', dep_plugins, "properties", 'markdown', 'terminal']
-	downloadSources = Boolean.valueOf(sources)
+	downloadSources = Boolean.valueOf(true)
 }
 
 sourceSets {
@@ -98,6 +98,8 @@ configurations {
 apply plugin: 'java'
 
 dependencies {
+    compile project(':azure-intellij-plugin-lib')
+    compile project(':azure-sdk-reference-book')
     compile 'com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8'
     compile 'commons-io:commons-io:2.7'
     compile group: 'org.apache.commons', name: 'commons-text', version: '1.8'

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -1,4 +1,5 @@
-<idea-plugin url="https://github.com/Microsoft/azure-tools-for-java">
+<idea-plugin url="https://github.com/Microsoft/azure-tools-for-java"
+             xmlns:xi="http://www.w3.org/2001/XInclude">
   <id>com.microsoft.tooling.msservices.intellij.azure</id>
   <name>Azure Toolkit for IntelliJ</name>
   <version>3.51.0-SNAPSHOT</version>
@@ -47,6 +48,8 @@
   <depends>org.jetbrains.plugins.terminal</depends>
   <depends>com.intellij.gradle</depends>
   <depends optional="true">com.intellij.database</depends>
+  <xi:include href="/META-INF/azure-intellij-plugin-lib.xml" xpointer="xpointer(/idea-plugin/*)"/>
+  <xi:include href="/META-INF/azure-sdk-reference-book.xml" xpointer="xpointer(/idea-plugin/*)"/>
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->
   <!-- uncomment to enable plugin in all products

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/settings.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'azure-toolkit-for-intellij'
-//intellij_version = 'IU-2016.3'
+include 'azure-sdk-reference-book'
+include 'azure-intellij-plugin-lib'
 


### PR DESCRIPTION
we are going to modulize the toolkits(including `Intellij`/`Maven`/`Gradle` plugins)
thanks to [XInclude](https://www.w3.org/TR/xinclude-11/), `azure-toolkit-for-intellij` can be modulized based the skeleton presented in this PR. 
more about `XInclude`:
https://www.xml.com/pub/a/2002/07/31/xinclude.html
https://en.wikipedia.org/wiki/XInclude
![image](https://user-images.githubusercontent.com/69189193/110280825-72e24780-8016-11eb-8f0d-4d41502ef67d.png)
![image](https://user-images.githubusercontent.com/69189193/110277769-ebdea080-8010-11eb-9763-1f8c374886f6.png)

`azure-toolkit-libs` is currently hosted in [azure-maven-plugins](https://github.com/microsoft/azure-maven-plugins/tree/develop/azure-toolkit-libs)

![image](https://user-images.githubusercontent.com/69189193/110277714-d5d0e000-8010-11eb-8dad-710d4d4c6870.png)
