### PR TITLE
In CommandUtils.java, don't output error message when not needed

### DIFF
--- a/Utils/azuretools-core/src/com/microsoft/azuretools/utils/CommandUtils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/utils/CommandUtils.java
@@ -103,7 +103,7 @@ public class CommandUtils {
         executor.setExitValues(null);
         try {
             executor.execute(commandLine);
-            if (!mergeErrorStream) {
+            if (!mergeErrorStream && err.size() > 0) {
                 logger.log(Level.SEVERE, err.toString());
             }
             return out.toString();


### PR DESCRIPTION
Updated version of https://github.com/microsoft/azure-tools-for-java/pull/5041