### PR TITLE
Fix library configuration in IntelliJ 2021.1 EAP

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/libraries/LibrariesConfigurationDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/ui/libraries/LibrariesConfigurationDialog.java
@@ -5,7 +5,6 @@
 
 package com.microsoft.intellij.ui.libraries;
 
-import com.intellij.openapi.application.AccessToken;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ModifiableRootModel;
@@ -24,8 +23,8 @@ import com.intellij.ui.components.JBList;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import com.microsoft.azuretools.telemetry.AppInsightsClient;
 import com.microsoft.intellij.AzurePlugin;
-import com.microsoft.intellij.ui.components.DefaultDialogWrapper;
 import com.microsoft.intellij.ui.components.AzureDialogWrapper;
+import com.microsoft.intellij.ui.components.DefaultDialogWrapper;
 import com.microsoft.intellij.util.PluginHelper;
 import com.microsoft.intellij.util.PluginUtil;
 import org.jetbrains.annotations.NotNull;
@@ -106,61 +105,57 @@ public class LibrariesConfigurationDialog extends AzureDialogWrapper {
             AzureLibrary azureLibrary = model.getSelectedLibrary();
             final LibrariesContainer.LibraryLevel level = LibrariesContainer.LibraryLevel.MODULE;
 
-            AccessToken token = WriteAction.start();
-            try {
-                final ModifiableRootModel modifiableModel = ModuleRootManager.getInstance(module).getModifiableModel();
-                for (OrderEntry orderEntry : modifiableModel.getOrderEntries()) {
-                    if (orderEntry instanceof ModuleLibraryOrderEntryImpl
-                            && azureLibrary.getName().equals(((ModuleLibraryOrderEntryImpl) orderEntry).getLibraryName())) {
-                        AzureTaskManager.getInstance().runLater(() -> PluginUtil.displayErrorDialog(message(
-                            "error"), message("libraryExistsError")));
-                        return;
-                    }
-                }
-
-                Library newLibrary = LibrariesContainerFactory.createContainer(modifiableModel).createLibrary(azureLibrary.getName(), level, new ArrayList<OrderRoot>());
-                if (model.isExported()) {
+            WriteAction.runAndWait(() -> {
+                try {
+                    final ModifiableRootModel modifiableModel = ModuleRootManager.getInstance(module).getModifiableModel();
                     for (OrderEntry orderEntry : modifiableModel.getOrderEntries()) {
-                        if (orderEntry instanceof ModuleLibraryOrderEntryImpl
-                                && azureLibrary.getName().equals(((ModuleLibraryOrderEntryImpl) orderEntry).getLibraryName())) {
-                            ((ModuleLibraryOrderEntryImpl) orderEntry).setExported(true);
-                            break;
+                        if (azureLibrary.getName().equals(orderEntry.getPresentableName())) {
+                            AzureTaskManager.getInstance().runLater(() -> PluginUtil.displayErrorDialog(message("error"), message("libraryExistsError")));
+                            return;
                         }
                     }
+
+                    Library newLibrary = LibrariesContainerFactory.createContainer(modifiableModel)
+                                                                  .createLibrary(azureLibrary.getName(), level, new ArrayList<OrderRoot>());
+                    // todo: Find new method to set library exported in IntelliJ 2021 EAP
+                    if (model.isExported()) {
+                        for (OrderEntry orderEntry : modifiableModel.getOrderEntries()) {
+                            if (orderEntry instanceof ModuleLibraryOrderEntryImpl
+                                && azureLibrary.getName().equals(((ModuleLibraryOrderEntryImpl) orderEntry).getLibraryName())) {
+                                ((ModuleLibraryOrderEntryImpl) orderEntry).setExported(true);
+                                break;
+                            }
+                        }
+                    }
+                    Library.ModifiableModel newLibraryModel = newLibrary.getModifiableModel();
+                    // if there is separate resources folder
+                    if (azureLibrary.getLocation() != null) {
+                        File file = new File(String.format("%s%s%s", AzurePlugin.pluginFolder, File.separator, azureLibrary.getLocation()));
+                        AddLibraryUtility.addLibraryRoot(file, newLibraryModel);
+                    }
+                    // if some files already contained in plugin dependencies, take them from there - true for azure sdk library
+                    if (azureLibrary.getFiles().length > 0) {
+                        AddLibraryUtility.addLibraryFiles(new File(PluginHelper.getAzureLibLocation()), newLibraryModel, azureLibrary.getFiles());
+                    }
+                    newLibraryModel.commit();
+                    modifiableModel.commit();
+                    ((DefaultListModel) librariesList.getModel()).addElement(azureLibrary);
+                    tempList.add(azureLibrary);
+                } catch (Exception ex) {
+                    PluginUtil.displayErrorDialogAndLog(message("error"), message("addLibraryError"), ex);
                 }
-                Library.ModifiableModel newLibraryModel = newLibrary.getModifiableModel();
-                // if there is separate resources folder
-                if (azureLibrary.getLocation() != null) {
-                    File file = new File(String.format("%s%s%s", AzurePlugin.pluginFolder, File.separator, azureLibrary.getLocation()));
-                    AddLibraryUtility.addLibraryRoot(file, newLibraryModel);
-                }
-                // if some files already contained in plugin dependencies, take them from there - true for azure sdk library
-                if (azureLibrary.getFiles().length > 0) {
-                    AddLibraryUtility.addLibraryFiles(new File(PluginHelper.getAzureLibLocation()), newLibraryModel, azureLibrary.getFiles());
-                }
-                newLibraryModel.commit();
-                modifiableModel.commit();
-                ((DefaultListModel) librariesList.getModel()).addElement(azureLibrary);
-                tempList.add(azureLibrary);
-            } catch (Exception ex) {
-                PluginUtil.displayErrorDialogAndLog(message("error"), message("addLibraryError"), ex);
-            } finally {
-                token.finish();
-            }
+            });
             LocalFileSystem.getInstance().findFileByPath(PluginUtil.getModulePath(module)).refresh(true, true);
         }
     }
 
     private void removeLibrary() {
         AzureLibrary azureLibrary = (AzureLibrary) librariesList.getSelectedValue();
-        AccessToken token = WriteAction.start();
-        try {
+        WriteAction.runAndWait(() -> {
             final ModifiableRootModel modifiableModel = ModuleRootManager.getInstance(module).getModifiableModel();
             modifiableModel.getModuleLibraryTable().removeLibrary(modifiableModel.getModuleLibraryTable().getLibraryByName(azureLibrary.getName()));
             modifiableModel.commit();
-        } finally {
-            token.finish();
-        }
+        });
         ((DefaultListModel) librariesList.getModel()).removeElement(azureLibrary);
         tempList.remove(azureLibrary);
     }
@@ -170,25 +165,17 @@ public class LibrariesConfigurationDialog extends AzureDialogWrapper {
         final ModifiableRootModel modifiableModel = ModuleRootManager.getInstance(module).getModifiableModel();
         OrderEntry libraryOrderEntry = null;
         for (OrderEntry orderEntry : modifiableModel.getOrderEntries()) {
-            if (orderEntry instanceof ModuleLibraryOrderEntryImpl
-                    && azureLibrary.getName().equals(((ModuleLibraryOrderEntryImpl) orderEntry).getLibraryName())) {
+            if (azureLibrary.getName().equals(orderEntry.getPresentableName())) {
                 libraryOrderEntry = orderEntry;
                 break;
             }
         }
         if (libraryOrderEntry != null) {
-            LibraryPropertiesPanel libraryPropertiesPanel = new LibraryPropertiesPanel(module, azureLibrary, true,
-                    ((ModuleLibraryOrderEntryImpl) libraryOrderEntry).isExported());
+            // todo: Find new method to get/set library exported in IntelliJ 2021 EAP
+            LibraryPropertiesPanel libraryPropertiesPanel = new LibraryPropertiesPanel(module, azureLibrary, true, false);
             DefaultDialogWrapper libraryProperties = new DefaultDialogWrapper(module.getProject(), libraryPropertiesPanel);
             libraryProperties.show();
             if (libraryProperties.isOK()) {
-                AccessToken token = WriteAction.start();
-                try {
-                    ((ModuleLibraryOrderEntryImpl) libraryOrderEntry).setExported(libraryPropertiesPanel.isExported());
-                    modifiableModel.commit();
-                } finally {
-                    token.finish();
-                }
                 LocalFileSystem.getInstance().findFileByPath(PluginUtil.getModulePath(module)).refresh(true, true);
             }
         } else {


### PR DESCRIPTION
Fix library configuration in IntelliJ 2021.1 EAP, fixes [#1824459](https://dev.azure.com/mseng/VSJava/_workitems/edit/1824459/), [#1831650](https://dev.azure.com/mseng/VSJava/_workitems/edit/1831650)

Known Issues: Can not set library exported