### PR TITLE
Fix issue:  Access is allowed from event dispatch thread with IW lock only

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/webapp/runner/webappconfig/slimui/WebAppSlimSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/webapp/runner/webappconfig/slimui/WebAppSlimSettingPanel.java
@@ -7,13 +7,13 @@ package com.microsoft.azure.toolkit.intellij.webapp.runner.webappconfig.slimui;
 
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.IdeTooltipManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Comparing;
 import com.intellij.packaging.artifacts.Artifact;
 import com.intellij.ui.HideableDecorator;
 import com.intellij.ui.HyperlinkLabel;
 import com.microsoft.azure.management.appservice.DeploymentSlot;
-import com.microsoft.azure.toolkit.intellij.appservice.AppServiceComboBoxModel;
 import com.microsoft.azure.toolkit.intellij.common.*;
 import com.microsoft.azure.toolkit.intellij.webapp.WebAppComboBox;
 import com.microsoft.azure.toolkit.intellij.webapp.WebAppComboBoxModel;
@@ -250,7 +250,14 @@ public class WebAppSlimSettingPanel extends AzureSettingPanel<WebAppConfiguratio
         }
         configuration.setDeployToRoot(chkToRoot.isVisible() && chkToRoot.isSelected());
         configuration.setOpenBrowserAfterDeployment(chkOpenBrowser.isSelected());
-        syncBeforeRunTasks(comboBoxArtifact.getValue(), configuration);
+        // hot fix, to avoid similar cases, prefer to refactor this code with common factory
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            syncBeforeRunTasks(comboBoxArtifact.getValue(), configuration);
+        } else {
+            ApplicationManager.getApplication().invokeLater(() ->
+                syncBeforeRunTasks(comboBoxArtifact.getValue(), configuration)
+            );
+        }
     }
 
     private boolean isAbleToDeployToRoot(final AzureArtifact azureArtifact) {


### PR DESCRIPTION
…20Azure%20Tooling/Stories/?workitem=1831634

Access is allowed from event dispatch thread with IW lock only.

com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: EventQueue.isDispatchThread()=false Toolkit.getEventQueue()=com.intellij.ide.IdeEventQueue@16879474

Current thread: Thread[IconCalculating Pool,4,Idea Thread Group] 876846843

SystemEventQueueThread: Thread[AWT-EventQueue-0,6,Idea Thread Group] 1124278295

at com.intellij.openapi.application.impl.ApplicationImpl.throwThreadAccessException(ApplicationImpl.java:1047)

at com.intellij.openapi.application.impl.ApplicationImpl.assertIsDispatchThread(ApplicationImpl.java:1022)

at com.intellij.ide.impl.DataManagerImpl.getDataContext(DataManagerImpl.java:167)

at com.microsoft.azure.toolkit.intellij.common.AzureSettingPanel.syncBeforeRunTasks(AzureSettingPanel.java:165)

at com.microsoft.azure.toolkit.intellij.webapp.runner.webappconfig.slimui.WebAppSlimSettingPanel.apply(WebAppSlimSettingPanel.java:253)

at com.microsoft.azure.toolkit.intellij.webapp.runner.webappconfig.slimui.WebAppSlimSettingPanel.apply(WebAppSlimSettingPanel.java:43)

at com.microsoft.azure.toolkit.intellij.common.AzureSettingsEditor.applyEditorTo(AzureSettingsEditor.java:24)

at com.microsoft.azure.toolkit.intellij.common.AzureSettingsEditor.applyEditorTo(AzureSettingsEditor.java:15)

at com.intellij.openapi.options.SettingsEditor.applyTo(SettingsEditor.java:93)

at com.intellij.execution.impl.ConfigurationSettingsEditor$ConfigToSettingsWrapper.applyEditorTo(ConfigurationSettingsEditor.java:312)

at com.intellij.execution.impl.ConfigurationSettingsEditor$ConfigToSettingsWrapper.applyEditorTo(ConfigurationSettingsEditor.java:290)

at com.intellij.openapi.options.SettingsEditor.applyTo(SettingsEditor.java:93)