### PR TITLE
Add firewall document link to message when failed to connect mysql

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/link/mysql/BasicLinkMySQLPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/link/mysql/BasicLinkMySQLPanel.form
@@ -161,14 +161,6 @@
           <text value="Env prefix:"/>
         </properties>
       </component>
-      <component id="5f3cd" class="javax.swing.JTextPane" binding="testResultTextPane">
-        <constraints>
-          <grid row="9" column="1" row-span="2" col-span="3" vsize-policy="6" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="50"/>
-          </grid>
-        </constraints>
-        <properties/>
-      </component>
       <component id="4b6c5" class="javax.swing.JTextField" binding="envPrefixTextField">
         <constraints>
           <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
@@ -192,6 +184,22 @@
           <grid row="9" column="0" row-span="2" col-span="1" vsize-policy="0" hsize-policy="0" anchor="5" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
       </nested-form>
+      <scrollpane id="4a8b8">
+        <constraints>
+          <grid row="9" column="1" row-span="2" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <horizontalScrollBarPolicy value="31"/>
+          <verticalScrollBarPolicy value="20"/>
+        </properties>
+        <border type="empty"/>
+        <children>
+          <component id="5f3cd" class="javax.swing.JTextPane" binding="testResultTextPane">
+            <constraints/>
+            <properties/>
+          </component>
+        </children>
+      </scrollpane>
     </children>
   </grid>
 </form>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/link/mysql/PasswordDialog.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/link/mysql/PasswordDialog.form
@@ -39,14 +39,6 @@
           <text value=""/>
         </properties>
       </component>
-      <component id="e626c" class="javax.swing.JTextPane" binding="testResultTextPane">
-        <constraints>
-          <grid row="3" column="1" row-span="2" col-span="3" vsize-policy="6" hsize-policy="6" anchor="1" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="50"/>
-          </grid>
-        </constraints>
-        <properties/>
-      </component>
       <component id="22170" class="javax.swing.JButton" binding="testConnectionButton">
         <constraints>
           <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -93,6 +85,22 @@
           <grid row="3" column="0" row-span="2" col-span="1" vsize-policy="2" hsize-policy="0" anchor="5" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
       </nested-form>
+      <scrollpane id="63832">
+        <constraints>
+          <grid row="3" column="1" row-span="2" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <horizontalScrollBarPolicy value="31"/>
+          <verticalScrollBarPolicy value="20"/>
+        </properties>
+        <border type="empty"/>
+        <children>
+          <component id="e626c" class="javax.swing.JTextPane" binding="testResultTextPane">
+            <constraints/>
+            <properties/>
+          </component>
+        </children>
+      </scrollpane>
     </children>
   </grid>
 </form>


### PR DESCRIPTION
- Add firewall document link to message when failed to connect mysql, workaround for https://dev.azure.com/mseng/VSJava/_sprints/backlog/Java%20Azure%20Tooling/VSJava/Sprint%20186?workitem=1831651
- Surround connection message panel with scroll pane, in case error message is too long