### PR TITLE
Add new gradle submodule azure-intellij-resource-connector-aad

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(":azure-intellij-plugin-lib")
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/java/com/microsoft/azure/toolkit/intellij/connector/aad/Messages.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/java/com/microsoft/azure/toolkit/intellij/connector/aad/Messages.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.intellij.connector.aad;
+
+import com.intellij.AbstractBundle;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.PropertyKey;
+
+import java.util.function.Supplier;
+
+class Messages extends AbstractBundle {
+    private static final Messages ourInstance = new Messages();
+    private static final String BUNDLE = "messages.aadBundle";
+
+    private Messages() {
+        super(BUNDLE);
+    }
+
+    public static String message(@NotNull @PropertyKey(resourceBundle = BUNDLE) String key, @NotNull Object... params) {
+        return ourInstance.getMessage(key, params);
+    }
+
+    public static Supplier<String> lazy(@NotNull @PropertyKey(resourceBundle = BUNDLE) String key, @NotNull Object... params) {
+        return () -> ourInstance.getMessage(key, params);
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/resources/META-INF/azure-intellij-resource-connector-aad.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/resources/META-INF/azure-intellij-resource-connector-aad.xml
@@ -1,0 +1,3 @@
+<idea-plugin>
+  <resource-bundle>messages.aadBundle</resource-bundle>
+</idea-plugin>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -150,6 +150,7 @@ dependencies {
     compile group: 'io.projectreactor.addons', name: 'reactor-adapter', version: '3.3.3.RELEASE'
     compile "com.github.akarnokd:rxjava3-interop:3.0.2"
     compile project(':azure-intellij-resource-connector-lib')
+    compile project(':azure-intellij-resource-connector-aad')
     compile 'com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8'
     compile 'commons-io:commons-io:2.7'
     compile group: 'org.apache.commons', name: 'commons-text', version: '1.8'

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml
@@ -80,6 +80,7 @@
   <xi:include href="/META-INF/azure-intellij-plugin-lib.xml" xpointer="xpointer(/idea-plugin/*)"/>
   <xi:include href="/META-INF/azure-sdk-reference-book.xml" xpointer="xpointer(/idea-plugin/*)"/>
   <xi:include href="/META-INF/azure-intellij-resource-connector-lib.xml" xpointer="xpointer(/idea-plugin/*)"/>
+  <xi:include href="/META-INF/azure-intellij-resource-connector-aad.xml" xpointer="xpointer(/idea-plugin/*)"/>
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->
   <!-- uncomment to enable plugin in all products

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/settings.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/settings.gradle
@@ -3,4 +3,4 @@ include 'azure-intellij-plugin-lib'
 include 'azure-intellij-resource-connector-lib'
 include 'azure-sdk-reference-book'
 include 'azure-intellij-resource-connector-mysql'
-
+include 'azure-intellij-resource-connector-aad'


### PR DESCRIPTION
This pull request adds a new, empty Gradle submodule to the build.
The new module includes an empty plugin.xml with just the declaration for the message bundle. It also contains the default definition of the Message bundle.

- CI is failing, including the unrelated `Azure-Toolkits-for-Java-CI-Eclipse`. I'm not sure what I can about this. I also can't view the CI logs, because this requires a login.