### PR TITLE
Fix linked blob storage not working for livy interactive session issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/hdinsight/spark/run/SparkBatchJobRunner.java
@@ -70,6 +70,7 @@ public class SparkBatchJobRunner extends DefaultProgramRunner implements SparkSu
                : url;
     }
 
+    // WARNING: When you change anything in this method, you should also change it in SparkScalaLivyConsoleRunConfiguration::applyRunConfiguration accordingly
     protected SparkSubmissionParameter updateStorageConfigForSubmissionParameter(SparkSubmitModel submitModel) throws ExecutionException {
         // If we use virtual file system to select referenced jars or files on ADLS Gen2 storage, the selected file path will
         // be of URI schema which starts with "https://". Then job submission will fail with error like


### PR DESCRIPTION
 #### Background
 - Currently when we start a livy interactive session,  some necessary config is missing if we use linked blob storage to store jar file. This PR is to add the missing config.
 
#### Todo
 - As you can see, the code I add is kind of duplicate at class `SparkBatchJobRunner`. Maybe we should refactor the code to put the code together at one place.