### PR TITLE
Fix exception when switch region in app service panel with a draft app service plan

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/lib/appservice/DraftServicePlan.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/lib/appservice/DraftServicePlan.java
@@ -99,7 +99,7 @@ public class DraftServicePlan implements AppServicePlan, Draft {
 
     @Override
     public String regionName() {
-        throw new OperationNotSupportedException();
+        return this.region == null ? null : this.region.getName();
     }
 
     @Override


### PR DESCRIPTION
Fix exception when switch region in app service panel with a draft app service plan, fixes 