### PR TITLE
Add combo box component for Microsoft Graph applications

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/build.gradle
@@ -1,3 +1,5 @@
 dependencies {
     implementation project(":azure-intellij-plugin-lib")
+
+    implementation 'com.microsoft.graph:microsoft-graph:3.7.0'
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/java/com/microsoft/azure/toolkit/intellij/connector/aad/AzureApplicationComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/java/com/microsoft/azure/toolkit/intellij/connector/aad/AzureApplicationComboBox.java
@@ -7,26 +7,13 @@ package com.microsoft.azure.toolkit.intellij.connector.aad;
 
 import com.microsoft.azure.toolkit.intellij.common.AzureComboBox;
 import com.microsoft.graph.models.Application;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
-import java.util.function.Supplier;
 
 /**
  * Combobox listing Azure AD applications.
  */
 class AzureApplicationComboBox extends AzureComboBox<Application> {
-    private final Supplier<List<Application>> supplier;
-
-    /**
-     * Create a new application combo box.
-     *
-     * @param supplier Supplies the applications to show. This allows to adjust the applications to show,
-     *                 depending on the context.
-     */
-    AzureApplicationComboBox(@NotNull Supplier<List<Application>> supplier) {
+    AzureApplicationComboBox() {
         super(false);
-        this.supplier = supplier;
 
         this.setEditable(false);
     }
@@ -37,11 +24,5 @@ class AzureApplicationComboBox extends AzureComboBox<Application> {
             return ((Application) item).displayName;
         }
         return super.getItemText(item);
-    }
-
-    @NotNull
-    @Override
-    protected List<? extends Application> loadItems() throws Exception {
-        return supplier.get();
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/java/com/microsoft/azure/toolkit/intellij/connector/aad/AzureApplicationComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/java/com/microsoft/azure/toolkit/intellij/connector/aad/AzureApplicationComboBox.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.intellij.connector.aad;
+
+import com.microsoft.azure.toolkit.intellij.common.AzureComboBox;
+import com.microsoft.graph.models.Application;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Combobox listing Azure AD applications.
+ */
+class AzureApplicationComboBox extends AzureComboBox<Application> {
+    private final Supplier<List<Application>> supplier;
+
+    /**
+     * Create a new application combo box.
+     *
+     * @param supplier Supplies the applications to show. This allows to adjust the applications to show,
+     *                 depending on the context.
+     */
+    AzureApplicationComboBox(@NotNull Supplier<List<Application>> supplier) {
+        super(false);
+        this.supplier = supplier;
+
+        this.setEditable(false);
+    }
+
+    @Override
+    protected String getItemText(Object item) {
+        if (item instanceof Application) {
+            return ((Application) item).displayName;
+        }
+        return super.getItemText(item);
+    }
+
+    @NotNull
+    @Override
+    protected List<? extends Application> loadItems() throws Exception {
+        return supplier.get();
+    }
+}


### PR DESCRIPTION
This is part of #5190 and commits a part of the code to simplify the code review.

It adds a combo box component which displays Microsoft Graph applications. 

The new component is added to the `azure-intellij-resource-connector-aad` sub-project.