### PR TITLE
[Task 1853335] Add label for property for app service creation/deployment components

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/appservice/AppServiceInfoAdvancedPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/appservice/AppServiceInfoAdvancedPanel.form
@@ -19,7 +19,7 @@
           <titleFont style="1"/>
         </properties>
       </component>
-      <component id="c0640" class="javax.swing.JLabel">
+      <component id="c0640" class="javax.swing.JLabel" binding="lblName">
         <constraints>
           <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="true"/>
         </constraints>
@@ -35,7 +35,7 @@
           <required value="true"/>
         </properties>
       </component>
-      <component id="c6b66" class="javax.swing.JLabel">
+      <component id="c6b66" class="javax.swing.JLabel" binding="lblPlatform">
         <constraints>
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="true"/>
         </constraints>
@@ -43,7 +43,7 @@
           <text value="Platform:"/>
         </properties>
       </component>
-      <component id="928ea" class="javax.swing.JLabel">
+      <component id="928ea" class="javax.swing.JLabel" binding="lblRegion">
         <constraints>
           <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
@@ -72,7 +72,7 @@
           <toolTipText value="Select a subscription to manage deployed resources and costs. Use resource groups like folders to organize and manage all your resources."/>
         </properties>
       </component>
-      <component id="4b4a6" class="javax.swing.JLabel">
+      <component id="4b4a6" class="javax.swing.JLabel" binding="lblSubscription">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
@@ -83,7 +83,7 @@
           <toolTipText value="All resources in an Azure subscription are billed together."/>
         </properties>
       </component>
-      <component id="2676b" class="javax.swing.JLabel">
+      <component id="2676b" class="javax.swing.JLabel" binding="lblResourceGroup">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
@@ -110,7 +110,7 @@
           <toolTipText value="App Service plan pricing tier determines the location, features, cost and compute resources associated with your app." noi18n="true"/>
         </properties>
       </component>
-      <component id="37aee" class="javax.swing.JLabel">
+      <component id="37aee" class="javax.swing.JLabel" binding="lblAppServicePlan">
         <constraints>
           <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
@@ -121,7 +121,7 @@
           <toolTipText value="App Service Plans are filtered based on your region and operating system selection."/>
         </properties>
       </component>
-      <component id="71269" class="javax.swing.JLabel">
+      <component id="71269" class="javax.swing.JLabel" binding="lblSku">
         <constraints>
           <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
@@ -149,7 +149,7 @@
           <titleFont style="1"/>
         </properties>
       </component>
-      <component id="ed0ca" class="javax.swing.JLabel" binding="deploymentLabel">
+      <component id="ed0ca" class="javax.swing.JLabel" binding="lblArtifact">
         <constraints>
           <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="true"/>
         </constraints>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/appservice/AppServiceInfoAdvancedPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/appservice/AppServiceInfoAdvancedPanel.java
@@ -60,7 +60,14 @@ public class AppServiceInfoAdvancedPanel<T extends AppServiceConfig> extends JPa
     private AzureArtifactComboBox selectorApplication;
     private ServicePlanComboBox selectorServicePlan;
     private TitledSeparator deploymentTitle;
-    private JLabel deploymentLabel;
+    private JLabel lblArtifact;
+    private JLabel lblSubscription;
+    private JLabel lblResourceGroup;
+    private JLabel lblName;
+    private JLabel lblPlatform;
+    private JLabel lblRegion;
+    private JLabel lblAppServicePlan;
+    private JLabel lblSku;
 
     public AppServiceInfoAdvancedPanel(final Project project, final Supplier<? extends T> supplier) {
         super();
@@ -127,7 +134,7 @@ public class AppServiceInfoAdvancedPanel<T extends AppServiceConfig> extends JPa
 
     public void setDeploymentVisible(boolean visible) {
         this.deploymentTitle.setVisible(visible);
-        this.deploymentLabel.setVisible(visible);
+        this.lblArtifact.setVisible(visible);
         this.selectorApplication.setVisible(visible);
     }
 
@@ -163,6 +170,13 @@ public class AppServiceInfoAdvancedPanel<T extends AppServiceConfig> extends JPa
         this.selectorRuntime.setRequired(true);
         this.selectorRegion.setRequired(true);
 
+        this.lblSubscription.setLabelFor(selectorSubscription);
+        this.lblResourceGroup.setLabelFor(selectorGroup);
+        this.lblName.setLabelFor(textName);
+        this.lblPlatform.setLabelFor(selectorRuntime);
+        this.lblRegion.setLabelFor(selectorRegion);
+        this.lblAppServicePlan.setLabelFor(selectorServicePlan);
+        this.lblArtifact.setLabelFor(selectorApplication);
         this.selectorApplication.setFileFilter(virtualFile -> {
             final String ext = FileNameUtils.getExtension(virtualFile.getPath());
             final Runtime runtime = this.selectorRuntime.getValue();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/appservice/AppServiceInfoBasicPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/appservice/AppServiceInfoBasicPanel.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="contentPanel" layout-manager="GridLayoutManager" row-count="6" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="417" height="170"/>
+      <xy x="20" y="20" width="417" height="180"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -19,7 +19,7 @@
           <titleFont style="1"/>
         </properties>
       </component>
-      <component id="c0640" class="javax.swing.JLabel">
+      <component id="c0640" class="javax.swing.JLabel" binding="lblName">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="true"/>
         </constraints>
@@ -35,7 +35,7 @@
           <required value="true"/>
         </properties>
       </component>
-      <component id="c6b66" class="javax.swing.JLabel">
+      <component id="c6b66" class="javax.swing.JLabel" binding="lblPlatform">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="true"/>
         </constraints>
@@ -58,7 +58,7 @@
           <titleFont style="1"/>
         </properties>
       </component>
-      <component id="ed0ca" class="javax.swing.JLabel" binding="deploymentLabel">
+      <component id="ed0ca" class="javax.swing.JLabel" binding="lblArtifact">
         <constraints>
           <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="true"/>
         </constraints>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/appservice/AppServiceInfoBasicPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/appservice/AppServiceInfoBasicPanel.java
@@ -49,7 +49,9 @@ public class AppServiceInfoBasicPanel<T extends AppServiceConfig> extends JPanel
     private RuntimeComboBox selectorRuntime;
     private AzureArtifactComboBox selectorApplication;
     private TitledSeparator deploymentTitle;
-    private JLabel deploymentLabel;
+    private JLabel lblArtifact;
+    private JLabel lblName;
+    private JLabel lblPlatform;
 
     private Subscription subscription;
 
@@ -75,6 +77,10 @@ public class AppServiceInfoBasicPanel<T extends AppServiceConfig> extends JPanel
         this.setDeploymentVisible(false);
         this.config = initConfig();
         setData(this.config);
+
+        this.lblName.setLabelFor(textName);
+        this.lblPlatform.setLabelFor(selectorRuntime);
+        this.lblArtifact.setLabelFor(selectorApplication);
     }
 
     @SneakyThrows
@@ -146,7 +152,7 @@ public class AppServiceInfoBasicPanel<T extends AppServiceConfig> extends JPanel
 
     public void setDeploymentVisible(boolean visible) {
         this.deploymentTitle.setVisible(visible);
-        this.deploymentLabel.setVisible(visible);
+        this.lblArtifact.setVisible(visible);
         this.selectorApplication.setVisible(visible);
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/webapp/runner/webappconfig/slimui/WebAppSlimSettingPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/webapp/runner/webappconfig/slimui/WebAppSlimSettingPanel.form
@@ -229,7 +229,7 @@
           </component>
         </children>
       </grid>
-      <component id="55d0" class="javax.swing.JLabel">
+      <component id="55d0" class="javax.swing.JLabel" binding="lblArtifact">
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -243,7 +243,7 @@
         </constraints>
         <properties/>
       </component>
-      <component id="5fd73" class="javax.swing.JLabel">
+      <component id="5fd73" class="javax.swing.JLabel" binding="lblWebApp">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/webapp/runner/webappconfig/slimui/WebAppSlimSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/webapp/runner/webappconfig/slimui/WebAppSlimSettingPanel.java
@@ -74,6 +74,8 @@ public class WebAppSlimSettingPanel extends AzureSettingPanel<WebAppConfiguratio
     private JButton btnSlotHover;
     private AzureArtifactComboBox comboBoxArtifact;
     private WebAppComboBox comboBoxWebApp;
+    private JLabel lblArtifact;
+    private JLabel lblWebApp;
     private final HideableDecorator slotDecorator;
 
     public WebAppSlimSettingPanel(@NotNull Project project, @NotNull WebAppConfiguration webAppConfiguration) {
@@ -114,6 +116,9 @@ public class WebAppSlimSettingPanel extends AzureSettingPanel<WebAppConfiguratio
         labelForNewSlotName.setLabelFor(txtNewSlotName);
         final JLabel labelForExistingSlotName = new JLabel("Slot Name");
         labelForExistingSlotName.setLabelFor(cbxSlotName);
+
+        lblArtifact.setLabelFor(comboBoxArtifact);
+        lblWebApp.setLabelFor(comboBoxWebApp);
 
         slotDecorator = new HideableDecorator(pnlSlotHolder, DEPLOYMENT_SLOT, true);
         slotDecorator.setContentComponent(pnlSlot);


### PR DESCRIPTION
Add label for property for app service creation/deployment components, fix labels is not read by screen readers.

[AB#1853335](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1853335)