### PR TITLE
[Bugfix 1835135] sync to set default password save type of input dialog on running the application.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/connector/database/component/PasswordDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/connector/database/component/PasswordDialog.java
@@ -32,7 +32,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 
 public class PasswordDialog extends AzureDialog<Password> implements AzureForm<Password> {
 
@@ -64,13 +64,7 @@ public class PasswordDialog extends AzureDialog<Password> implements AzureForm<P
         this.passwordSaveComboBox.setPreferredSize(lastColumnSize);
         this.passwordSaveComboBox.setMaximumSize(lastColumnSize);
         this.passwordSaveComboBox.setSize(lastColumnSize);
-        if (Objects.nonNull(resource.getPassword()) && Objects.nonNull(resource.getPassword().saveType())) {
-            this.passwordSaveComboBox.setValue(resource.getPassword().saveType());
-        } else {
-            this.passwordSaveComboBox.setValue(Arrays.stream(Password.SaveType.values())
-                    .filter(e -> StringUtils.equals(e.name(), AzureConfigurations.getInstance().passwordSaveType())).findAny()
-                    .orElse(Password.SaveType.UNTIL_RESTART));
-        }
+        this.setData(resource.getPassword());
         this.init();
         this.initListener();
     }
@@ -159,7 +153,9 @@ public class PasswordDialog extends AzureDialog<Password> implements AzureForm<P
 
     @Override
     public void setData(Password data) {
-        passwordSaveComboBox.setValue(data.saveType());
+        this.passwordSaveComboBox.setValue(Optional.ofNullable(data).map(e -> e.saveType()).orElse(Arrays.stream(Password.SaveType.values())
+                .filter(e -> StringUtils.equals(e.name(), AzureConfigurations.getInstance().passwordSaveType())).findAny()
+                .orElse(Password.SaveType.UNTIL_RESTART)));
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/connector/database/component/PasswordDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/connector/database/component/PasswordDialog.java
@@ -9,6 +9,7 @@ import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.AnimatedIcon;
 import com.microsoft.azure.toolkit.intellij.common.AzureDialog;
+import com.microsoft.azure.toolkit.intellij.common.settings.AzureConfigurations;
 import com.microsoft.azure.toolkit.intellij.connector.Password;
 import com.microsoft.azure.toolkit.intellij.connector.database.DatabaseConnectionUtils;
 import com.microsoft.azure.toolkit.intellij.connector.database.DatabaseResource;
@@ -31,6 +32,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class PasswordDialog extends AzureDialog<Password> implements AzureForm<Password> {
 
@@ -58,10 +60,17 @@ public class PasswordDialog extends AzureDialog<Password> implements AzureForm<P
         testConnectionActionPanel.setVisible(false);
         testResultTextPane.setEditable(false);
         testResultTextPane.setText(StringUtils.EMPTY);
-        final Dimension lastColumnSize = new Dimension(106, 30);
-        passwordSaveComboBox.setPreferredSize(lastColumnSize);
-        passwordSaveComboBox.setMaximumSize(lastColumnSize);
-        passwordSaveComboBox.setSize(lastColumnSize);
+        final Dimension lastColumnSize = new Dimension(106, this.passwordSaveComboBox.getPreferredSize().height);
+        this.passwordSaveComboBox.setPreferredSize(lastColumnSize);
+        this.passwordSaveComboBox.setMaximumSize(lastColumnSize);
+        this.passwordSaveComboBox.setSize(lastColumnSize);
+        if (Objects.nonNull(resource.getPassword()) && Objects.nonNull(resource.getPassword().saveType())) {
+            this.passwordSaveComboBox.setValue(resource.getPassword().saveType());
+        } else {
+            this.passwordSaveComboBox.setValue(Arrays.stream(Password.SaveType.values())
+                    .filter(e -> StringUtils.equals(e.name(), AzureConfigurations.getInstance().passwordSaveType())).findAny()
+                    .orElse(Password.SaveType.UNTIL_RESTART));
+        }
         this.init();
         this.initListener();
     }


### PR DESCRIPTION
[AB#1835135](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1835135)