### PR TITLE
Fix app service creation dialog takes much time to initialize

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/appservice/serviceplan/ServicePlanComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/appservice/serviceplan/ServicePlanComboBox.java
@@ -55,8 +55,6 @@ public class ServicePlanComboBox extends AzureComboBox<AppServicePlanEntity> {
             this.clear();
             return;
         }
-        // force refresh service plan when switch subscription
-        Azure.az(AzureAppService.class).subscription(subscription.getId()).appServicePlans(true);
         this.refreshItems();
     }
 
@@ -114,7 +112,7 @@ public class ServicePlanComboBox extends AzureComboBox<AppServicePlanEntity> {
                     .collect(Collectors.toList()));
             }
             final List<AppServicePlanEntity> remotePlans = Azure.az(AzureAppService.class)
-                .subscription(subscription.getId()).appServicePlans().stream().map(IAppServicePlan::entity)
+                .subscription(subscription.getId()).appServicePlans(true).stream().map(IAppServicePlan::entity)
                 .collect(Collectors.toList());
             plans.addAll(remotePlans);
             Stream<AppServicePlanEntity> stream = plans.stream();


### PR DESCRIPTION
### Issue
App service creation dialog will froze for few seconds after pop up. The reason is we call force refresh method in `setSubscription()` of `ServicePlanComboBox`，however, this method will be called in EDT during dialog initialization, which may froze the UI

### Solution
Do force refresh action in `loadItems` which will be called in background thread