### PR TITLE
[Task 1862535] Migrate to `AzureTelemetryClient` in Eclipse toolkit to erase PII info

### DIFF
--- a/Utils/azuretools-core/pom.xml
+++ b/Utils/azuretools-core/pom.xml
@@ -97,6 +97,10 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-toolkit-common-lib</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-queue</artifactId>
         </dependency>

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/AppInsightsClient.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/AppInsightsClient.java
@@ -5,13 +5,12 @@
 
 package com.microsoft.azuretools.telemetry;
 
-import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetryClient;
 import com.microsoft.azuretools.adauth.StringUtils;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.telemetrywrapper.TelemetryManager;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 public class AppInsightsClient {
@@ -97,11 +96,10 @@ public class AppInsightsClient {
         if (isAppInsightsClientAvailable() && configuration.validated()) {
             String prefValue = configuration.preferenceVal();
             if (prefValue == null || prefValue.isEmpty() || prefValue.equalsIgnoreCase("true") || force) {
-                TelemetryClient telemetry = TelemetryClientSingleton.getTelemetry();
+                AzureTelemetryClient telemetry = TelemetryClientSingleton.getTelemetry();
                 Map<String, String> properties = buildProperties(version, myProperties);
                 synchronized (TelemetryClientSingleton.class) {
                     telemetry.trackEvent(eventName, properties, metrics);
-                    telemetry.flush();
                 }
             }
         }
@@ -113,12 +111,7 @@ public class AppInsightsClient {
         properties.put("IDE", configuration.ide());
 
         // Telemetry client doesn't accept null value for ConcurrentHashMap doesn't accept null as key or value..
-        for (Iterator<Map.Entry<String, String>> iter = properties.entrySet().iterator(); iter.hasNext();) {
-            Map.Entry<String, String> entry = iter.next();
-            if (StringUtils.isNullOrEmpty(entry.getKey()) || StringUtils.isNullOrEmpty(entry.getValue())) {
-                iter.remove();
-            }
-        }
+        properties.entrySet().removeIf(entry -> StringUtils.isNullOrEmpty(entry.getKey()) || StringUtils.isNullOrEmpty(entry.getValue()));
         if (version != null && !version.isEmpty()) {
             properties.put("Library Version", version);
         }
@@ -134,50 +127,19 @@ public class AppInsightsClient {
         return properties;
     }
 
-    public static void createFTPEvent(String eventName, String uri, String appName, String subId) {
-        if (!isAppInsightsClientAvailable())
-            return;
-
-        TelemetryClient telemetry = TelemetryClientSingleton.getTelemetry();
-
-        Map<String, String> properties = new HashMap<String, String>();
-        properties.put("SessionId", configuration.sessionId());
-        if (uri != null && !uri.isEmpty()) {
-            properties.put("WebApp URI", uri);
-        }
-        if (appName != null && !appName.isEmpty()) {
-            properties.put("Java app name", appName);
-        }
-        if (subId != null && !subId.isEmpty()) {
-            properties.put("Subscription ID", subId);
-        }
-        if (configuration.validated()) {
-            String pluginVersion = configuration.pluginVersion();
-            if (pluginVersion != null && !pluginVersion.isEmpty()) {
-                properties.put("Plugin Version", pluginVersion);
-            }
-
-            String instID = configuration.installationId();
-            if (instID != null && !instID.isEmpty()) {
-                properties.put("Installation ID", instID);
-            }
-        }
-        synchronized (TelemetryClientSingleton.class) {
-            telemetry.trackEvent(eventName, properties, null);
-            telemetry.flush();
-        }
-    }
-
     private static boolean isAppInsightsClientAvailable() {
         return configuration != null;
     }
 
     private static void initTelemetryManager() {
         try {
+            final Map<String, String> properties = buildProperties("", new HashMap<>());
             TelemetryClientSingleton.setConfiguration(configuration);
-            TelemetryManager.getInstance().setCommonProperties(buildProperties("", new HashMap<>()));
-            TelemetryManager.getInstance().setTelemetryClient(TelemetryClientSingleton.getTelemetry());
-            TelemetryManager.getInstance().setEventNamePrefix(configuration.eventName());
+            final AzureTelemetryClient client = TelemetryClientSingleton.getTelemetry();
+            final String eventNamePrefix = configuration.eventName();
+            TelemetryManager.getInstance().setTelemetryClient(client);
+            TelemetryManager.getInstance().setCommonProperties(properties);
+            TelemetryManager.getInstance().setEventNamePrefix(eventNamePrefix);
             TelemetryManager.getInstance().sendCachedTelemetries();
         } catch (Exception ignore) {
         }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/TelemetryClientSingleton.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetry/TelemetryClientSingleton.java
@@ -5,18 +5,18 @@
 
 package com.microsoft.azuretools.telemetry;
 
-import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetryClient;
 import org.apache.commons.lang3.StringUtils;
 
 public final class TelemetryClientSingleton {
-    private TelemetryClient telemetry = null;
+    private final AzureTelemetryClient telemetry;
     private AppInsightsConfiguration configuration = null;
 
     private static final class SingletonHolder {
         private static final TelemetryClientSingleton INSTANCE = new TelemetryClientSingleton();
     }
 
-    public static TelemetryClient getTelemetry() {
+    public static AzureTelemetryClient getTelemetry() {
         return SingletonHolder.INSTANCE.telemetry;
     }
 
@@ -25,13 +25,13 @@ public final class TelemetryClientSingleton {
     }
 
     private TelemetryClientSingleton() {
-        telemetry = new TelemetryClient() {
+        telemetry = new AzureTelemetryClient() {
             @Override
-            public boolean isDisabled() {
+            public boolean isEnabled() {
                 if (configuration == null) {
-                    return true;
+                    return false;
                 }
-                return (StringUtils.isNotEmpty(configuration.preferenceVal()) && !Boolean.valueOf(configuration.preferenceVal())) || super.isDisabled();
+                return (StringUtils.isEmpty(configuration.preferenceVal()) || Boolean.parseBoolean(configuration.preferenceVal())) && super.isEnabled();
             }
         };
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/CommonUtil.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/CommonUtil.java
@@ -5,7 +5,7 @@
 
 package com.microsoft.azuretools.telemetrywrapper;
 
-import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetryClient;
 import com.microsoft.azuretools.adauth.StringUtils;
 import org.apache.commons.lang3.tuple.MutableTriple;
 import org.joda.time.Instant;
@@ -19,15 +19,15 @@ public class CommonUtil {
 
     public static final String OPERATION_NAME = "operationName";
     public static final String OPERATION_ID = "operationId";
-    public static final String ERROR_CODE = "errorCode";
-    public static final String ERROR_MSG = "message";
-    public static final String ERROR_TYPE = "errorType";
-    public static final String ERROR_CLASSNAME = "errorClassName";
-    public static final String ERROR_STACKTRACE = "errorStackTrace";
+    public static final String ERROR_CODE = "error.code";
+    public static final String ERROR_MSG = "error.message";
+    public static final String ERROR_TYPE = "error.type";
+    public static final String ERROR_CLASSNAME = "error.class_name";
+    public static final String ERROR_STACKTRACE = "error.stack";
     public static final String DURATION = "duration";
     public static final String SERVICE_NAME = "serviceName";
     public static final String TIMESTAMP = "timestamp";
-    public static TelemetryClient client;
+    public static AzureTelemetryClient client;
     private static List<MutableTriple<EventType, Map, Map>> cachedEvents = new ArrayList<>();
 
     public static Map<String, String> mergeProperties(Map<String, String> properties) {
@@ -50,7 +50,6 @@ public class CommonUtil {
         if (client != null) {
             final String eventName = getFullEventName(eventType);
             client.trackEvent(eventName, mutableProps, metrics);
-            client.flush();
         } else {
             cacheEvents(eventType, mutableProps, metrics);
         }
@@ -59,7 +58,6 @@ public class CommonUtil {
     public static void clearCachedEvents() {
         if (client != null) {
             cachedEvents.forEach(triple -> client.trackEvent(getFullEventName(triple.left), triple.middle, triple.right));
-            client.flush();
             cachedEvents.clear();
         }
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/TelemetryManager.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/telemetrywrapper/TelemetryManager.java
@@ -5,7 +5,7 @@
 
 package com.microsoft.azuretools.telemetrywrapper;
 
-import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetryClient;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,7 +27,7 @@ public class TelemetryManager {
         return SingletonHolder.INSTANCE;
     }
 
-    public void setTelemetryClient(TelemetryClient telemetryClient) {
+    public void setTelemetryClient(AzureTelemetryClient telemetryClient) {
         CommonUtil.client = telemetryClient;
     }
 

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -32,7 +32,8 @@
     <name>${project.artifactId}-${project.version}</name>
     <properties>
         <azuretool.version>3.44.0</azuretool.version>
-        <applicationinsights.version>2.6.1</applicationinsights.version>
+        <applicationinsights.version>2.6.3</applicationinsights.version>
+        <azure.toolkit-lib.version>0.10.0</azure.toolkit-lib.version>
         <kotlin.version>1.3.72</kotlin.version>
         <kotlin.jvmTargetVersion>1.8</kotlin.jvmTargetVersion>
         <jackson.version>2.11.1</jackson.version>
@@ -131,6 +132,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-toolkit-common-lib</artifactId>
+                <version>${azure.toolkit-lib.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-storage-queue</artifactId>


### PR DESCRIPTION
### Issue to solve
We used to collect error stack directly, which may collect PII data (user name in path, email address in service response) accidentally. 

[AB#1862535](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1862535)

### Solution
Migrate to use `AzureTelemetryClient` instead of use `TelemetryClient` directly, which contains the data clean process. Besides, this PR also upgrade Application insights library to 2.6.3, which support java 16 runtime.

Refers https://github.com/microsoft/azure-tools-for-java/pull/5513
