### PR TITLE
[Task 1863278] use az config to replace AzureConfigurations.getInstance()

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureInitializer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureInitializer.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.intellij;
+
+import com.intellij.openapi.application.PermanentInstallationID;
+import com.microsoft.azure.toolkit.intellij.common.settings.AzureConfigurations;
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.AzureConfiguration;
+import com.microsoft.azure.toolkit.lib.auth.AzureCloud;
+import com.microsoft.azure.toolkit.lib.auth.util.AzureEnvironmentUtils;
+import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemeter;
+import com.microsoft.azure.toolkit.lib.common.utils.InstallationIdUtils;
+import com.microsoft.azuretools.authmanage.CommonSettings;
+import com.microsoft.azuretools.azurecommons.util.ParserXMLUtility;
+import com.microsoft.azuretools.azurecommons.xmlhandling.DataOperations;
+import com.microsoft.azuretools.telemetry.AppInsightsClient;
+import com.microsoft.azuretools.telemetry.AppInsightsConstants;
+import com.microsoft.azuretools.telemetry.TelemetryConstants;
+import com.microsoft.azuretools.telemetrywrapper.EventType;
+import com.microsoft.azuretools.telemetrywrapper.EventUtil;
+import com.microsoft.intellij.ui.messages.AzureBundle;
+import com.microsoft.intellij.util.PluginHelper;
+import com.microsoft.rest.LogLevel;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.PLUGIN_INSTALL;
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.PLUGIN_LOAD;
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.PLUGIN_UPGRADE;
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.PROXY;
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.SYSTEM;
+import static com.microsoft.intellij.ui.messages.AzureBundle.message;
+
+public class AzureInitializer {
+    public static void initialize() {
+        ProxyUtils.initProxy();
+        initializeConfigFromLegacySettings();
+        initializeMachineId();
+        initializeAzureConfiguration();
+        initializeTelemetry();
+    }
+
+    private static void initializeAzureConfiguration() {
+        final AzureConfiguration config = Azure.az().config();
+        config.setLogLevel(LogLevel.NONE.name());
+
+        final AzureConfigurations.AzureConfigurationData state = AzureConfigurations.getInstance().getState();
+        final String userAgent = String.format(AzurePlugin.USER_AGENT, AzurePlugin.PLUGIN_VERSION,
+            state.allowTelemetry() ? state.installationId() : StringUtils.EMPTY);
+        config.setUserAgent(userAgent);
+        CommonSettings.setUserAgent(userAgent);
+
+        if (StringUtils.isNotBlank(state.environment())) {
+            Azure.az(AzureCloud.class).set(AzureEnvironmentUtils.stringToAzureEnvironment(state.environment()));
+        }
+        config.setCloud(state.environment());
+        config.setTelemetryEnabled(state.allowTelemetry());
+        config.setDatabasePasswordSaveType(state.passwordSaveType());
+        config.setFunctionCoreToolsPath(state.functionCoreToolsPath());
+        config.setProduct(CommonConst.PLUGIN_NAME);
+        config.setVersion(CommonConst.PLUGIN_VERSION);
+        config.setMachineId(state.installationId());
+    }
+
+    private static void initializeConfigFromLegacySettings() {
+        final AzureConfigurations.AzureConfigurationData state = AzureConfigurations.getInstance().getState();
+        if (isDataFileValid()) {
+            // read legacy settings from old data.xml
+            try {
+                final String dataFile = PluginHelper.getTemplateFile(AzureBundle.message("dataFileName"));
+                final boolean allowTelemetry = Boolean.parseBoolean(DataOperations.getProperty(dataFile, AzureBundle.message("prefVal")));
+                final String installationId = DataOperations.getProperty(dataFile, AzureBundle.message("instID"));
+                final String pluginVersion = DataOperations.getProperty(dataFile, AzureBundle.message("pluginVersion"));
+
+                // check non-empty for valid data.xml
+                if (StringUtils.isNoneBlank(installationId, pluginVersion)) {
+
+                    if (state.allowTelemetry()) {
+                        state.allowTelemetry(allowTelemetry);
+                    }
+                    if (StringUtils.isBlank(state.pluginVersion())) {
+                        state.pluginVersion(pluginVersion);
+                    }
+                    if (StringUtils.isBlank(state.installationId()) && InstallationIdUtils.isValidHashMac(installationId)) {
+                        state.installationId(installationId);
+                    }
+                }
+                FileUtils.deleteQuietly(new File(dataFile));
+            } catch (Exception ex) {
+                final Map<String, String> props = new HashMap<>();
+                props.put("error", ex.getMessage());
+                EventUtil.logEvent(EventType.error, SYSTEM, TelemetryConstants.PLUGIN_TRANSFER_SETTINGS, props, null);
+            }
+        }
+
+        if (CommonSettings.getEnvironment() != null && StringUtils.isBlank(state.environment())) {
+            // normalize cloud name
+            state.environment(AzureEnvironmentUtils.azureEnvironmentToString(
+                AzureEnvironmentUtils.stringToAzureEnvironment(CommonSettings.getEnvironment().getName())));
+        }
+    }
+
+    private static void initializeMachineId() {
+        final AzureConfigurations.AzureConfigurationData state = AzureConfigurations.getInstance().getState();
+        String installationId = state.installationId();
+        if (StringUtils.isBlank(installationId)) {
+            installationId = StringUtils.firstNonBlank(InstallationIdUtils.getHashMac(), InstallationIdUtils.hash(PermanentInstallationID.get()));
+        }
+        state.installationId(installationId);
+    }
+
+    private static void initializeTelemetry() {
+        final AzureConfigurations.AzureConfigurationData state = AzureConfigurations.getInstance().getState();
+        final String version = state.pluginVersion();
+        AppInsightsClient.setAppInsightsConfiguration(new AppInsightsConfigurationImpl());
+        if (StringUtils.isBlank(version)) {
+            AppInsightsClient.createByType(AppInsightsClient.EventType.Plugin, "", AppInsightsConstants.Install, null, true);
+            EventUtil.logEvent(EventType.info, SYSTEM, PLUGIN_INSTALL, null, null);
+        } else if (StringUtils.isNotBlank(version) && !AzurePlugin.PLUGIN_VERSION.equalsIgnoreCase(version)) {
+            AppInsightsClient.createByType(AppInsightsClient.EventType.Plugin, "", AppInsightsConstants.Upgrade, null, true);
+            EventUtil.logEvent(EventType.info, SYSTEM, PLUGIN_UPGRADE, null, null);
+        }
+        AppInsightsClient.createByType(AppInsightsClient.EventType.Plugin, "", AppInsightsConstants.Load, null, true);
+        EventUtil.logEvent(EventType.info, SYSTEM, PLUGIN_LOAD, null, null);
+        if (Azure.az().config().getHttpProxy() != null) {
+            final Map<String, String> map = Optional.ofNullable(AzureTelemeter.getCommonProperties()).map(HashMap::new).orElse(new HashMap<>());
+            map.put(PROXY, "true");
+            AzureTelemeter.setCommonProperties(map);
+        }
+    }
+
+    private static boolean isDataFileValid() {
+        final String dataFile = PluginHelper.getTemplateFile(message("dataFileName"));
+        final File file = new File(dataFile);
+        if (!file.exists()) {
+            return false;
+        }
+        try {
+            return ParserXMLUtility.parseXMLFile(dataFile) != null;
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/hdinsight/common/HDInsightHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/hdinsight/common/HDInsightHelperImpl.java
@@ -15,17 +15,18 @@ import com.microsoft.azure.hdinsight.sdk.cluster.ClusterDetail;
 import com.microsoft.azure.hdinsight.sdk.cluster.IClusterDetail;
 import com.microsoft.azure.hdinsight.serverexplore.hdinsightnode.HDInsightRootModule;
 import com.microsoft.azure.hdinsight.serverexplore.ui.AddNewHDInsightReaderClusterForm;
+import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
-import com.microsoft.azure.toolkit.intellij.common.settings.AzureConfigurations;
 import com.microsoft.intellij.ui.WarningMessageForm;
 import com.microsoft.intellij.util.PluginUtil;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
+import org.apache.commons.lang3.ObjectUtils;
 
 import javax.swing.Icon;
 
@@ -44,7 +45,7 @@ public class HDInsightHelperImpl implements HDInsightHelper {
     @Override
     public String getInstallationId() {
         if (isOptIn()) {
-            return AzureConfigurations.getInstance().getState().installationId();
+            return Azure.az().config().getMachineId();
         } else {
             return "";
         }
@@ -52,7 +53,7 @@ public class HDInsightHelperImpl implements HDInsightHelper {
 
     @Override
     public boolean isOptIn() {
-        return AzureConfigurations.getInstance().getState().allowTelemetry();
+        return ObjectUtils.firstNonNull(Azure.az().config().getTelemetryEnabled(), true);
     }
 
     public void openJobViewEditor(final Object projectObject, final String uuid) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/connector/database/DatabaseResourcePanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/connector/database/DatabaseResourcePanel.java
@@ -11,7 +11,6 @@ import com.intellij.ui.AnimatedIcon;
 import com.microsoft.azure.toolkit.intellij.appservice.subscription.SubscriptionComboBox;
 import com.microsoft.azure.toolkit.intellij.common.AzureComboBox;
 import com.microsoft.azure.toolkit.intellij.common.AzureFormJPanel;
-import com.microsoft.azure.toolkit.intellij.common.settings.AzureConfigurations;
 import com.microsoft.azure.toolkit.intellij.connector.Password;
 import com.microsoft.azure.toolkit.intellij.connector.ResourceDefinition;
 import com.microsoft.azure.toolkit.intellij.connector.database.component.DatabaseComboBox;
@@ -261,7 +260,7 @@ public class DatabaseResourcePanel implements AzureFormJPanel<DatabaseResource> 
             this.passwordSaveComboBox.setValue(resource.getPassword().saveType());
         } else {
             this.passwordSaveComboBox.setValue(Arrays.stream(Password.SaveType.values())
-                .filter(e -> StringUtils.equals(e.name(), AzureConfigurations.getInstance().passwordSaveType())).findAny()
+                .filter(e -> StringUtils.equals(e.name(), Azure.az().config().getDatabasePasswordSaveType())).findAny()
                 .orElse(Password.SaveType.UNTIL_RESTART));
         }
         Optional.ofNullable(resource.getDatabaseName()).ifPresent(dbName -> {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/connector/database/component/PasswordDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/connector/database/component/PasswordDialog.java
@@ -9,10 +9,10 @@ import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.AnimatedIcon;
 import com.microsoft.azure.toolkit.intellij.common.AzureDialog;
-import com.microsoft.azure.toolkit.intellij.common.settings.AzureConfigurations;
 import com.microsoft.azure.toolkit.intellij.connector.Password;
 import com.microsoft.azure.toolkit.intellij.connector.database.DatabaseConnectionUtils;
 import com.microsoft.azure.toolkit.intellij.connector.database.DatabaseResource;
+import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.form.AzureForm;
 import com.microsoft.azure.toolkit.lib.common.form.AzureFormInput;
@@ -154,7 +154,7 @@ public class PasswordDialog extends AzureDialog<Password> implements AzureForm<P
     @Override
     public void setData(Password data) {
         this.passwordSaveComboBox.setValue(Optional.ofNullable(data).map(e -> e.saveType()).orElse(Arrays.stream(Password.SaveType.values())
-                .filter(e -> StringUtils.equals(e.name(), AzureConfigurations.getInstance().passwordSaveType())).findAny()
+                .filter(e -> StringUtils.equals(e.name(), Azure.az().config().getDatabasePasswordSaveType())).findAny()
                 .orElse(Password.SaveType.UNTIL_RESTART)));
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/core/FunctionCliResolver.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/core/FunctionCliResolver.java
@@ -50,13 +50,13 @@ public abstract class FunctionCliResolver {
                 // when `func core tools` is manually installed and func is available at PATH
                 // use canonical path to locate the real installation path
                 String result = findFuncInFolder(parentFolder);
-                if (result == null) {
-                    result = resolveAdditionalFunc(parentFolder);
-                }
                 if (result != null) {
                     results.add(result);
                 }
-
+                result = findFuncInAdditionalFolder(parentFolder);
+                if (result != null) {
+                    results.add(result);
+                }
             } catch (IOException ignored) {
                 // ignore
             }
@@ -117,7 +117,7 @@ public abstract class FunctionCliResolver {
         return isWindows ? "func.exe" : "func";
     }
 
-    private static String resolveAdditionalFunc(String funcParentFolder) {
+    private static String findFuncInAdditionalFolder(String funcParentFolder) {
         // from C:\ProgramData\chocolatey\bin\func.exe -> C:\ProgramData\chocolatey\lib\azure-functions-core-tools\tools\func.exe
         return Optional.ofNullable(findFuncInFolder(Paths.get(funcParentFolder, "../lib/azure-functions-core-tools/tools").toString()))
             // detect func installed by `brew install azure-functions-core-tools@3`

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/core/FunctionUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/core/FunctionUtils.java
@@ -28,6 +28,8 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.searches.AnnotatedElementsSearch;
 import com.intellij.util.containers.ContainerUtil;
 import com.microsoft.azure.functions.annotation.StorageAccount;
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.AzureConfiguration;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureExecutionException;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.logging.Log;
@@ -37,7 +39,6 @@ import com.microsoft.azure.toolkit.lib.legacy.function.bindings.BindingEnum;
 import com.microsoft.azure.toolkit.lib.legacy.function.configurations.FunctionConfiguration;
 import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.utils.JsonUtils;
-import com.microsoft.azure.toolkit.intellij.common.settings.AzureConfigurations;
 import com.microsoft.intellij.secure.IdeaSecureStore;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FileUtils;
@@ -283,11 +284,11 @@ public class FunctionUtils {
     }
 
     public static String getFuncPath() throws IOException, InterruptedException {
-        final AzureConfigurations.AzureConfigurationData state = AzureConfigurations.getInstance().getState();
-        if (StringUtils.isBlank(state.functionCoreToolsPath())) {
+        final AzureConfiguration config = Azure.az().config();
+        if (StringUtils.isBlank(config.getFunctionCoreToolsPath())) {
             return FunctionCliResolver.resolveFunc();
         }
-        return state.functionCoreToolsPath();
+        return config.getFunctionCoreToolsPath();
     }
 
     public static List<String> getFunctionBindingList(Map<String, FunctionConfiguration> configMap) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/localrun/ui/FunctionRunPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/localrun/ui/FunctionRunPanel.form
@@ -32,15 +32,12 @@
                   <text value="Function CLI:"/>
                 </properties>
               </component>
-              <component id="3e77f" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="txtFunc">
+              <component id="a6210" class="com.microsoft.azure.toolkit.lib.function.FunctionCoreToolsCombobox" binding="txtFunc" custom-create="true">
                 <constraints>
                   <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
-                <properties>
-                  <editable value="true"/>
-                </properties>
               </component>
               <component id="ae00f" class="javax.swing.JLabel">
                 <constraints>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/localrun/ui/FunctionRunPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/localrun/ui/FunctionRunPanel.java
@@ -6,10 +6,8 @@
 package com.microsoft.azure.toolkit.intellij.function.runner.localrun.ui;
 
 import com.intellij.icons.AllIcons;
-import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.packaging.artifacts.Artifact;
 import com.intellij.ui.ListCellRendererWrapper;
 import com.microsoft.azure.toolkit.intellij.common.AzureSettingPanel;
@@ -17,7 +15,7 @@ import com.microsoft.azure.toolkit.intellij.function.runner.component.table.AppS
 import com.microsoft.azure.toolkit.intellij.function.runner.component.table.AppSettingsTableUtils;
 import com.microsoft.azure.toolkit.intellij.function.runner.core.FunctionUtils;
 import com.microsoft.azure.toolkit.intellij.function.runner.localrun.FunctionRunConfiguration;
-import com.microsoft.intellij.ui.util.UIUtils;
+import com.microsoft.azure.toolkit.lib.function.FunctionCoreToolsCombobox;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -27,7 +25,6 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
-import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,7 +36,7 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
 
     private JPanel settings;
     private JPanel pnlMain;
-    private TextFieldWithBrowseButton txtFunc;
+    private com.microsoft.azure.toolkit.lib.function.FunctionCoreToolsCombobox txtFunc;
     private JPanel pnlAppSettings;
     private JComboBox<Module> cbFunctionModule;
     private AppSettingsTable appSettingsTable;
@@ -61,15 +58,7 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
             }
         });
 
-        txtFunc.addActionListener(
-                UIUtils.createFileChooserListenerWithTextPath(txtFunc, project,
-                        FileChooserDescriptorFactory.createSingleFileDescriptor()));
 
-        try {
-            txtFunc.setText(FunctionUtils.getFuncPath());
-        } catch (IOException | InterruptedException e) {
-            // swallow as leave blank
-        }
         fillModules();
     }
 
@@ -95,7 +84,7 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
         // In case `FUNCTIONS_WORKER_RUNTIME` or `AZURE_WEB_JOB_STORAGE_KEY` was missed in configuration
         appSettingsTable.loadRequiredSettings();
         if (StringUtils.isNotEmpty(configuration.getFuncPath())) {
-            txtFunc.setText(configuration.getFuncPath());
+            txtFunc.setValue(configuration.getFuncPath());
         }
         for (int i = 0; i < cbFunctionModule.getItemCount(); i++) {
             final Module module = cbFunctionModule.getItemAt(i);
@@ -108,7 +97,7 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
 
     @Override
     protected void apply(@NotNull FunctionRunConfiguration configuration) {
-        configuration.setFuncPath(txtFunc.getText());
+        configuration.setFuncPath(txtFunc.getItem());
         configuration.saveModule((Module) cbFunctionModule.getSelectedItem());
         FunctionUtils.saveAppSettingsToSecurityStorage(appSettingsKey, appSettingsTable.getAppSettings());
         // save app settings storage key instead of real value
@@ -147,6 +136,7 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
     }
 
     private void createUIComponents() {
+        txtFunc = new FunctionCoreToolsCombobox(project, true);
         final String localSettingPath = Paths.get(project.getBasePath(), "local.settings.json").toString();
         appSettingsTable = new AppSettingsTable(localSettingPath);
         pnlAppSettings = AppSettingsTableUtils.createAppSettingPanel(appSettingsTable);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/localrun/ui/FunctionRunPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/localrun/ui/FunctionRunPanel.java
@@ -36,7 +36,7 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
 
     private JPanel settings;
     private JPanel pnlMain;
-    private com.microsoft.azure.toolkit.lib.function.FunctionCoreToolsCombobox txtFunc;
+    private FunctionCoreToolsCombobox txtFunc;
     private JPanel pnlAppSettings;
     private JComboBox<Module> cbFunctionModule;
     private AppSettingsTable appSettingsTable;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/lib/function/FunctionCoreToolsCombobox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/lib/function/FunctionCoreToolsCombobox.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.function;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.fileChooser.FileChooser;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Comparing;
+import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.SimpleListCellRenderer;
+import com.intellij.ui.components.fields.ExtendableTextComponent;
+import com.microsoft.azure.toolkit.intellij.common.AzureComboBox;
+import com.microsoft.azure.toolkit.intellij.function.runner.core.FunctionCliResolver;
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
+import com.microsoft.intellij.AzureConfigurable;
+import org.apache.commons.lang3.StringUtils;
+
+import java.awt.event.ItemEvent;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class FunctionCoreToolsCombobox extends AzureComboBox<String> {
+    private static final String AZURE_TOOLKIT_FUNCTION_CORE_TOOLS_HISTORY = "azure_toolkit.function.core.tools.history";
+    private static final int MAX_HISTORY_SIZE = 15;
+    private final Set<String> funcCoreToolsPathList = new LinkedHashSet<>();
+
+    private Condition<? super VirtualFile> fileFilter;
+    private Project project;
+    private String openSettings = "Open IDE Settings";
+    private String lastSelected;
+    private boolean includeSettings;
+
+    public FunctionCoreToolsCombobox(Project project, boolean includeSettings) {
+        super(false);
+        this.project = project;
+        this.includeSettings = includeSettings;
+        final List<String> exePostfix = Arrays.asList("exe|bat|cmd|sh|bin|run".split("\\|"));
+        this.fileFilter = file ->
+            Comparing.equal(file.getNameWithoutExtension(), "func", file.isCaseSensitive())
+                    && (file.getExtension() == null || exePostfix.contains(
+                file.isCaseSensitive() ? file.getExtension() : StringUtils.lowerCase(file.getExtension())
+                )
+
+            );
+        if (includeSettings) {
+            this.setRenderer(SimpleListCellRenderer.create((label, value, index) -> {
+                label.setText(value);
+                if (StringUtils.equals(value, openSettings)) {
+                    label.setIcon(AllIcons.General.GearPlain);
+                }
+            }));
+
+            this.addItemListener(e -> {
+                if (e.getStateChange() == ItemEvent.SELECTED) {
+                    if (StringUtils.equals((String) e.getItem(), openSettings)) {
+                        AzureTaskManager.getInstance().runLater(() -> {
+                            ShowSettingsUtil.getInstance().showSettingsDialog(project, AzureConfigurable.AzureAbstractConfigurable.class);
+                            FunctionCoreToolsCombobox.this.reset();
+                        });
+                        FunctionCoreToolsCombobox.this.setValue(lastSelected);
+                        return;
+                    }
+
+                } else {
+                    lastSelected = (String) e.getItem();
+                }
+            });
+        }
+        reset();
+    }
+
+    public void reset() {
+        funcCoreToolsPathList.clear();
+        this.clear();
+        funcCoreToolsPathList.addAll(loadHistory());
+        funcCoreToolsPathList.addAll(FunctionCliResolver.resolve());
+
+        final String valueFromAzConfig = Azure.az().config().getFunctionCoreToolsPath();
+        if (StringUtils.isNotBlank(valueFromAzConfig)) {
+            funcCoreToolsPathList.add(valueFromAzConfig);
+        }
+        funcCoreToolsPathList.forEach(this::addItem);
+        if (StringUtils.isNotBlank(valueFromAzConfig)) {
+            this.setValue(valueFromAzConfig);
+        }
+        if (includeSettings) {
+            this.addItem(openSettings);
+        }
+    }
+
+    @Override
+    public void setValue(String value) {
+        saveHistory();
+        super.setValue(value);
+    }
+
+    private void onSelectFile(String lastFilePath) {
+        final FileChooserDescriptor fileDescriptor =
+            new FileChooserDescriptor(true, false, false, false, false, false);
+        if (fileFilter != null) {
+            fileDescriptor.withFileFilter(fileFilter);
+        }
+        fileDescriptor.withTitle("Select Path to Azure Functions Core Tools");
+        final VirtualFile lastFile = new File(lastFilePath).exists() ? LocalFileSystem.getInstance().findFileByIoFile(new File(lastFilePath)) : null;
+        FileChooser.chooseFile(fileDescriptor, project, this, lastFile, (file) -> {
+            if (file != null && file.exists()) {
+                addOrSelectExistingVirtualFile(file);
+            }
+        });
+    }
+
+    @Nullable
+    protected ExtendableTextComponent.Extension getExtension() {
+        return ExtendableTextComponent.Extension.create(AllIcons.General.OpenDisk, "Open file", () -> onSelectFile(getItem()));
+    }
+
+    private void addOrSelectExistingVirtualFile(VirtualFile virtualFile) {
+        try {
+            final String selectFile = Paths.get(virtualFile.getPath()).toRealPath().toString();
+            if (funcCoreToolsPathList.add(selectFile)) {
+                this.addItem(selectFile);
+            }
+            this.setSelectedItem(selectFile);
+        } catch (IOException e) {
+            AzureMessager.getMessager().error(e);
+        }
+    }
+
+    private List<String> loadHistory() {
+        final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance();
+        final String history = propertiesComponent.getValue(AZURE_TOOLKIT_FUNCTION_CORE_TOOLS_HISTORY);
+        if (history != null) {
+            final String[] items = history.split("\n");
+            List<String> result = new ArrayList<>();
+            for (String item : items) {
+                if (StringUtils.isNotBlank(item) && new File(item).exists()) {
+                    try {
+                        result.add(Paths.get(item).toRealPath().toString());
+                    } catch (IOException ignore) {
+                        // ignore since the history data is not important
+                    }
+                }
+            }
+            return result;
+        }
+        return Collections.emptyList();
+    }
+
+    private void saveHistory() {
+        final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance();
+        final List<String> subList = funcCoreToolsPathList.stream().skip(Math.max(funcCoreToolsPathList.size() - MAX_HISTORY_SIZE, 0))
+            .collect(Collectors.toList());
+        propertiesComponent.setValue(AZURE_TOOLKIT_FUNCTION_CORE_TOOLS_HISTORY, StringUtils.join(
+            subList.toArray(), "\n"));
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AppInsightsConfigurationImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AppInsightsConfigurationImpl.java
@@ -6,8 +6,8 @@
 package com.microsoft.intellij;
 
 import com.intellij.openapi.application.ApplicationInfo;
+import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azuretools.telemetry.AppInsightsConfiguration;
-import com.microsoft.azure.toolkit.intellij.common.settings.AzureConfigurations;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.UUID;
@@ -36,17 +36,17 @@ public class AppInsightsConfigurationImpl implements AppInsightsConfiguration {
 
     @Override
     public String installationId() {
-        return AzureConfigurations.getInstance().getState().installationId();
+        return Azure.az().config().getMachineId();
     }
 
     @Override
     public String preferenceVal() {
-        return String.valueOf(AzureConfigurations.getInstance().getState().allowTelemetry());
+        return String.valueOf(Azure.az().config().getTelemetryEnabled());
     }
 
     @Override
     public boolean validated() {
-        return StringUtils.isNotBlank(AzureConfigurations.getInstance().getState().installationId());
+        return StringUtils.isNotBlank(Azure.az().config().getMachineId());
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureActionsListener.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureActionsListener.java
@@ -20,8 +20,6 @@ import com.microsoft.azure.toolkit.intellij.common.messager.IntellijAzureMessage
 import com.microsoft.azure.toolkit.intellij.common.task.IntellijAzureTaskManager;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
-import com.microsoft.azure.toolkit.lib.auth.AzureCloud;
-import com.microsoft.azure.toolkit.lib.auth.util.AzureEnvironmentUtils;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
@@ -32,7 +30,6 @@ import com.microsoft.azuretools.core.mvp.ui.base.MvpUIHelperFactory;
 import com.microsoft.azuretools.core.mvp.ui.base.SchedulerProviderFactory;
 import com.microsoft.azuretools.securestore.SecureStore;
 import com.microsoft.azuretools.service.ServiceManager;
-import com.microsoft.azure.toolkit.intellij.common.settings.AzureConfigurations;
 import com.microsoft.intellij.helpers.IDEHelperImpl;
 import com.microsoft.intellij.helpers.MvpUIHelperImpl;
 import com.microsoft.intellij.helpers.UIHelperImpl;
@@ -47,7 +44,6 @@ import com.microsoft.tooling.msservices.components.PluginSettings;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import lombok.Lombok;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.ssl.TrustStrategy;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Hooks;
@@ -96,12 +92,7 @@ public class AzureActionsListener implements AppLifecycleListener, PluginCompone
 
     @Override
     public void appFrameCreated(@NotNull List<String> commandLineArgs) {
-        ProxyUtils.initProxy();
-        if (StringUtils.isNotBlank(AzureConfigurations.getInstance().getState().environment())) {
-            Azure.az(AzureCloud.class).set(AzureEnvironmentUtils.stringToAzureEnvironment(AzureConfigurations.getInstance().getState().environment()));
-        } else if (CommonSettings.getEnvironment() != null) {
-            Azure.az(AzureCloud.class).set(AzureEnvironmentUtils.stringToAzureEnvironment(CommonSettings.getEnvironment().getName()));
-        }
+        AzureInitializer.initialize();
         DefaultLoader.setPluginComponent(this);
         DefaultLoader.setUiHelper(new UIHelperImpl());
         DefaultLoader.setIdeHelper(new IDEHelperImpl());

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureConfigurable.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureConfigurable.java
@@ -37,7 +37,7 @@ public class AzureConfigurable extends SearchableConfigurable.Parent.Abstract im
     protected Configurable[] buildConfigurables() {
         myPanels = new ArrayList<Configurable>();
         if (!AzurePlugin.IS_ANDROID_STUDIO) {
-            myPanels.add(new AzureAbstractConfigurable(new AzurePanel()));
+            myPanels.add(new AzureAbstractConfigurable(new AzurePanel(myProject)));
             myPanels.add(new AzureAbstractConfigurable(new AppInsightsMngmtPanel(myProject)));
         }
         return myPanels.toArray(new Configurable[myPanels.size()]);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureInitializer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureInitializer.java
@@ -126,7 +126,7 @@ public class AzureInitializer {
         }
         AppInsightsClient.createByType(AppInsightsClient.EventType.Plugin, "", AppInsightsConstants.Load, null, true);
         EventUtil.logEvent(EventType.info, SYSTEM, PLUGIN_LOAD, null, null);
-        if (Azure.az().config().getHttpProxy() != null) {
+        if (StringUtils.isNotBlank(Azure.az().config().getProxySource())) {
             final Map<String, String> map = Optional.ofNullable(AzureTelemeter.getCommonProperties()).map(HashMap::new).orElse(new HashMap<>());
             map.put(PROXY, "true");
             AzureTelemeter.setCommonProperties(map);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/CommonConst.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/CommonConst.java
@@ -14,7 +14,7 @@ public class CommonConst {
     public static final String REMOTE_SPARK_JOB_WINDOW_ID = "Remote Spark Job in Cluster";
     public static final String PLUGIN_ID = "com.microsoft.tooling.msservices.intellij.azure";
     public static final String PLUGIN_NAME = "azure-toolkit-for-intellij";
-    public static final String PLUGIN_VERISON = PluginManager.getPlugin(PluginId.getId(PLUGIN_ID)).getVersion();
+    public static final String PLUGIN_VERSION = PluginManager.getPlugin(PluginId.getId(PLUGIN_ID)).getVersion();
     public static final String SPARK_APPLICATION_TYPE = "com.microsoft.azure.hdinsight.DefaultSparkApplicationType";
 
     public static final String LOADING_TEXT = "Loading...";

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.microsoft.intellij.ui.AzurePanel">
-  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="10" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="10" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -8,11 +8,6 @@
     <properties/>
     <border type="none"/>
     <children>
-      <hspacer id="5c63f">
-        <constraints>
-          <grid row="8" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </hspacer>
       <component id="7b456" class="javax.swing.JLabel">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -67,42 +62,6 @@
           </component>
         </children>
       </grid>
-      <component id="40168" class="com.intellij.ui.TitledSeparator">
-        <constraints>
-          <grid row="7" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Telemetry"/>
-          <titleFont style="1"/>
-        </properties>
-      </component>
-      <component id="82f52" class="com.intellij.ui.TitledSeparator">
-        <constraints>
-          <grid row="3" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Database"/>
-          <titleFont style="1"/>
-        </properties>
-      </component>
-      <component id="28fc7" class="com.intellij.ui.TitledSeparator">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Sign-in"/>
-          <titleFont style="1"/>
-        </properties>
-      </component>
-      <component id="fbf71" class="com.intellij.ui.TitledSeparator">
-        <constraints>
-          <grid row="5" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Azure Functions"/>
-          <titleFont style="1"/>
-        </properties>
-      </component>
       <component id="f1153" class="javax.swing.JLabel">
         <constraints>
           <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -111,7 +70,7 @@
           <text value="Function Core Tools path:"/>
         </properties>
       </component>
-      <component id="f4df3" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="funcCoreToolsPath">
+      <component id="8822" class="com.microsoft.azure.toolkit.lib.function.FunctionCoreToolsCombobox" binding="funcCoreToolsPath" custom-create="true">
         <constraints>
           <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.form
@@ -119,9 +119,7 @@
       </component>
       <component id="a96dd" class="javax.swing.JLabel" binding="azureEnvDesc">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="1" fill="1" indent="2" use-parent-layout="false">
-            <preferred-size width="150" height="50"/>
-          </grid>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=""/>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.java
@@ -19,6 +19,7 @@ import com.microsoft.azure.toolkit.intellij.connector.Password;
 import com.microsoft.azure.toolkit.intellij.connector.database.component.PasswordSaveComboBox;
 import com.microsoft.azure.toolkit.intellij.function.runner.core.FunctionCliResolver;
 import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.AzureConfiguration;
 import com.microsoft.azure.toolkit.lib.auth.AzureCloud;
 import com.microsoft.azure.toolkit.lib.auth.util.AzureEnvironmentUtils;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
@@ -62,6 +63,8 @@ public class AzurePanel implements AzureAbstractConfigurablePanel {
     private TextFieldWithBrowseButton funcCoreToolsPath;
     private JLabel azureEnvDesc;
 
+    private AzureConfiguration originalData;
+
     public AzurePanel() {
     }
 
@@ -92,26 +95,40 @@ public class AzurePanel implements AzureAbstractConfigurablePanel {
         funcCoreToolsPath.addBrowseFolderListener(null, "Path to Azure Functions Core Tools", null, FileChooserDescriptorFactory.createSingleFileDescriptor(),
             TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT);
 
-        final AzureConfigurations.AzureConfigurationData state = AzureConfigurations.getInstance().getState();
-        if (StringUtils.isBlank(state.functionCoreToolsPath())) {
+        setData(Azure.az().config());
+    }
+
+    public void setData(AzureConfiguration config) {
+        if (StringUtils.isBlank(config.getFunctionCoreToolsPath())) {
             try {
                 funcCoreToolsPath.setText(FunctionCliResolver.resolveFunc());
             } catch (final Throwable ex) {
                 //ignore
             }
         } else {
-            funcCoreToolsPath.setText(state.functionCoreToolsPath());
+            funcCoreToolsPath.setText(config.getFunctionCoreToolsPath());
         }
 
-        allowTelemetryCheckBox.setSelected(state.allowTelemetry());
-
-        azureEnvironmentComboBox.setSelectedItem(ObjectUtils.firstNonNull(AzureEnvironmentUtils.stringToAzureEnvironment(state.environment())
-            , AzureEnvironment.AZURE
-        ));
-
         savePasswordComboBox.setValue(Arrays.stream(Password.SaveType.values())
-            .filter(e -> StringUtils.equals(e.name(), AzureConfigurations.getInstance().passwordSaveType())).findAny()
+            .filter(e -> StringUtils.equals(e.name(), config.getDatabasePasswordSaveType())).findAny()
             .orElse(Password.SaveType.UNTIL_RESTART));
+        allowTelemetryCheckBox.setSelected(config.getTelemetryEnabled());
+
+        azureEnvironmentComboBox.setSelectedItem(ObjectUtils.firstNonNull(AzureEnvironmentUtils.stringToAzureEnvironment(config.getCloud()),
+            AzureEnvironment.AZURE
+        ));
+        this.originalData = getData();
+    }
+
+    public AzureConfiguration getData() {
+        final AzureConfiguration data = new AzureConfiguration();
+        data.setCloud(AzureEnvironmentUtils.azureEnvironmentToString((AzureEnvironment) azureEnvironmentComboBox.getSelectedItem()));
+        if (savePasswordComboBox.getValue() != null) {
+            data.setDatabasePasswordSaveType(savePasswordComboBox.getValue().name());
+        }
+        data.setTelemetryEnabled(allowTelemetryCheckBox.isSelected());
+        data.setFunctionCoreToolsPath(funcCoreToolsPath.getText());
+        return data;
     }
 
     private void displayDescriptionForAzureEnv() {
@@ -119,7 +136,7 @@ public class AzurePanel implements AzureAbstractConfigurablePanel {
             final String azureEnv = AuthMethodManager.getInstance().getAuthMethodDetails().getAzureEnv();
             final AzureEnvironment currentEnv =
                 AzureEnvironmentUtils.stringToAzureEnvironment(azureEnv);
-            String currentEnvStr = azureEnvironmentToString(currentEnv);
+            final String currentEnvStr = azureEnvironmentToString(currentEnv);
             if (Objects.equals(currentEnv, azureEnvironmentComboBox.getSelectedItem())) {
                 setTextToLabel(azureEnvDesc, "You are currently signed in with environment: " + currentEnvStr);
                 azureEnvDesc.setIcon(AllIcons.General.Information);
@@ -159,21 +176,28 @@ public class AzurePanel implements AzureAbstractConfigurablePanel {
 
     @Override
     public boolean doOKAction() {
-        final AzureConfigurations.AzureConfigurationData config = AzureConfigurations.getInstance().getState();
-        config.allowTelemetry(allowTelemetryCheckBox.isSelected());
-        config.functionCoreToolsPath(this.funcCoreToolsPath.getText());
-        config.environment(AzureEnvironmentUtils.azureEnvironmentToString((AzureEnvironment) azureEnvironmentComboBox.getSelectedItem()));
-        config.passwordSaveType(savePasswordComboBox.getValue().name());
-        AzureConfigurations.getInstance().loadState(config);
+        final AzureConfiguration data = getData();
+        // persistent current state
+        persistentData(data);
 
+        // set state to global config
+        final AzureConfiguration config = Azure.az().config();
+        config.setCloud(data.getCloud());
+        config.setTelemetryEnabled(data.getTelemetryEnabled());
+        config.setDatabasePasswordSaveType(data.getDatabasePasswordSaveType());
+        config.setFunctionCoreToolsPath(data.getFunctionCoreToolsPath());
+
+        // apply state
+        // we need get rid of CommonSettings later
         final String userAgent = String.format(AzurePlugin.USER_AGENT, AzurePlugin.PLUGIN_VERSION,
-            config.allowTelemetry() ? config.installationId() : StringUtils.EMPTY);
-        Azure.az().config().setUserAgent(userAgent);
+            config.getTelemetryEnabled() ? config.getMachineId() : StringUtils.EMPTY);
+        config.setUserAgent(userAgent);
         CommonSettings.setUserAgent(userAgent);
 
+        // we need to get rid of AuthMethodManager, using az.azure_account
         if (AuthMethodManager.getInstance().isSignedIn()) {
-            AuthMethodManager authMethodManager = AuthMethodManager.getInstance();
-            final String azureEnv = AuthMethodManager.getInstance().getAuthMethodDetails().getAzureEnv();
+            final AuthMethodManager authMethodManager = AuthMethodManager.getInstance();
+            final String azureEnv = authMethodManager.getAuthMethodDetails().getAzureEnv();
             final AzureEnvironment currentEnv = AzureEnvironmentUtils.stringToAzureEnvironment(azureEnv);
             if (!Objects.equals(currentEnv, azureEnvironmentComboBox.getSelectedItem())) {
                 EventUtil.executeWithLog(ACCOUNT, SIGNOUT, (operation) -> {
@@ -182,7 +206,7 @@ public class AzurePanel implements AzureAbstractConfigurablePanel {
             }
         }
 
-        Azure.az(AzureCloud.class).set(AzureEnvironmentUtils.stringToAzureEnvironment(config.environment()));
+        Azure.az(AzureCloud.class).setByName(data.getCloud());
         return true;
     }
 
@@ -203,10 +227,38 @@ public class AzurePanel implements AzureAbstractConfigurablePanel {
 
     @Override
     public boolean isModified() {
-        return true;
+        if (originalData == null) {
+            return false;
+        }
+
+        final AzureConfiguration data = getData();
+
+        if (!StringUtils.equalsIgnoreCase(data.getCloud(), originalData.getCloud())) {
+            return true;
+        }
+
+        if (!StringUtils.equalsIgnoreCase(data.getDatabasePasswordSaveType(), originalData.getDatabasePasswordSaveType())) {
+            return true;
+        }
+
+        if (!StringUtils.equalsIgnoreCase(data.getFunctionCoreToolsPath(), originalData.getFunctionCoreToolsPath())) {
+            return true;
+        }
+
+        return !Objects.equals(data.getTelemetryEnabled(), data.getTelemetryEnabled());
     }
 
     @Override
     public void reset() {
+        setData(originalData);
+    }
+
+    private void persistentData(AzureConfiguration data) {
+        final AzureConfigurations.AzureConfigurationData config = AzureConfigurations.getInstance().getState();
+
+        config.allowTelemetry(data.getTelemetryEnabled());
+        config.functionCoreToolsPath(data.getFunctionCoreToolsPath());
+        config.environment(data.getCloud());
+        config.passwordSaveType(data.getDatabasePasswordSaveType());
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.java
@@ -10,15 +10,12 @@ import com.azure.core.management.AzureEnvironment;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
-import com.intellij.openapi.ui.TextComponentAccessor;
-import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.ui.SimpleListCellRenderer;
 import com.intellij.util.ui.UIUtil;
 import com.microsoft.azure.toolkit.intellij.common.settings.AzureConfigurations;
 import com.microsoft.azure.toolkit.intellij.connector.Password;
 import com.microsoft.azure.toolkit.intellij.connector.database.component.PasswordSaveComboBox;
-import com.microsoft.azure.toolkit.intellij.function.runner.core.FunctionCliResolver;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.AzureConfiguration;
 import com.microsoft.azure.toolkit.lib.auth.AzureCloud;
@@ -28,14 +25,12 @@ import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.authmanage.CommonSettings;
 import com.microsoft.azuretools.telemetrywrapper.EventUtil;
 import com.microsoft.intellij.AzurePlugin;
-import com.microsoft.azure.toolkit.intellij.common.settings.AzureConfigurations;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
 import javax.swing.ComboBoxModel;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JCheckBox;
@@ -103,7 +98,7 @@ public class AzurePanel implements AzureAbstractConfigurablePanel {
 
     public void setData(AzureConfiguration config) {
         if (StringUtils.isNotBlank(config.getFunctionCoreToolsPath())) {
-                //ignore
+            //ignore
             funcCoreToolsPath.setValue(config.getFunctionCoreToolsPath());
         }
 
@@ -250,6 +245,7 @@ public class AzurePanel implements AzureAbstractConfigurablePanel {
     public void reset() {
         setData(originalData);
     }
+
     private void createUIComponents() {
         this.funcCoreToolsPath = new FunctionCoreToolsCombobox(project, false);
     }


### PR DESCRIPTION
# What's the problem?
Currently there are two kinds of config: az config and AzureConfigurations, we need to choose one to avoid confusion

# How to solve this problem?
1. Replace the read scenarios of AzureConfigurations.getInstance() to Azure.az().config().getxxx
2. Refactor AzureConfiguration to have two methods: saveAzConfig and loadToAzConfig
3. In AzureInitializer call loadToAzConfig to load the persistent data into az config and save the az config when user clicks ok on intellij settings
4. This PR also fix a `reset` doesn't work issue in intellij settings

[AB#1863278](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1863278)