### PR TITLE
[Bug 1864196]spring cloud artifacts not show in Azure SDK Reference Book

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/azuresdk/referencebook/AzureSdkArtifactDetailPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/azuresdk/referencebook/AzureSdkArtifactDetailPanel.java
@@ -49,11 +49,12 @@ public class AzureSdkArtifactDetailPanel {
 
     private void setLinks(@Nonnull final Map<String, String> links) {
         this.links.removeAll();
-        links.forEach((type, url) -> {
-            final HyperlinkLabel link = new HyperlinkLabel();
+        linkNames.forEach((type, name) -> {
+            final String url = links.get(type);
             if (StringUtils.isNotBlank(url)) {
+                final HyperlinkLabel link = new HyperlinkLabel();
                 this.links.add(new JToolBar.Separator());
-                link.setHyperlinkText(linkNames.get(type));
+                link.setHyperlinkText(name);
                 link.setHyperlinkTarget(url);
                 this.links.add(new JSeparator(SwingConstants.VERTICAL));
                 this.links.add(link);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/azuresdk/referencebook/AzureSdkArtifactDetailPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/azuresdk/referencebook/AzureSdkArtifactDetailPanel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
 package com.microsoft.azure.toolkit.intellij.azuresdk.referencebook;
 
 import com.google.common.collect.ImmutableMap;
@@ -70,14 +75,14 @@ public class AzureSdkArtifactDetailPanel {
         if (StringUtils.isNotBlank(artifact.getVersionPreview())) {
             versions.add(artifact.getVersionPreview());
         }
-        final DropDownLink<String> version = new DropDownLink<>(versions.get(0), versions, (String v) -> {
+        final DropDownLink<String> versionSelector = new DropDownLink<>(versions.get(0), versions, (String v) -> {
             if (this.artifactId.isSelected()) {
                 this.setLinks(this.artifact.getLinks(v));
                 this.onArtifactOrVersionSelected.accept(this.artifact, this.version.getSelectedItem());
             }
         }, true);
-        version.setForeground(JBColor.BLACK);
-        return version;
+        versionSelector.setForeground(JBColor.BLACK);
+        return versionSelector;
     }
 
     public void setSelected(boolean selected) {


### PR DESCRIPTION
[AB#1864196](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1864196), [AB#1864232](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1864232)
### Problem
https://github.com/Azure/azure-sdk-for-java/pull/23287 added `sample` link for some artifacts. While the `sample` link has no corresponding label, which cause set `null` label(which is actually not acceptable) to `HyperLinkLabel`.

### Solution
loop over (predefined known link names) instead of (provided links by meta data) when preparing links for artifacts