### PR TITLE
Register mnemonic short cut for HideableDecorator

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/messager/IntellijErrorDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/messager/IntellijErrorDialog.java
@@ -58,7 +58,7 @@ public class IntellijErrorDialog extends DialogWrapper {
         });
         final String details = message.getDetails();
         if (StringUtils.isNotBlank(details)) {
-            final HideableDecorator slotDecorator = new HideableDecorator(detailsContainer, "Call Stack", false);
+            final HideableDecorator slotDecorator = new HideableDecorator(detailsContainer, "&Call Stack", false);
             slotDecorator.setContentComponent(detailsScrollPane);
             slotDecorator.setOn(false);
             this.detailsPane.setText(details);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/webapp/docker/webapponlinux/ui/SettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/webapp/docker/webapponlinux/ui/SettingPanel.java
@@ -68,10 +68,10 @@ public class SettingPanel extends AzureSettingPanel<WebAppOnLinuxDeployConfigura
     private static final String APP_NAME_PREFIX = "webapp-linux";
     private static final String RESOURCE_GROUP_NAME_PREFIX = "rg-web-linux";
     private static final String APP_SERVICE_PLAN_NAME_PREFIX = "appsp-linux-";
-    private static final String TITLE_RESOURCE_GROUP = "Resource Group";
-    private static final String TITLE_APP_SERVICE_PLAN = "App Service Plan";
-    private static final String TITLE_ACR = "Azure Container Registry";
-    private static final String TITLE_WEB_APP = "Web App for Containers";
+    private static final String TITLE_RESOURCE_GROUP = "&Resource Group";
+    private static final String TITLE_APP_SERVICE_PLAN = "App Service &Plan";
+    private static final String TITLE_ACR = "Azure &Container Registry";
+    private static final String TITLE_WEB_APP = "&Web App for Containers";
 
     private final WebAppOnLinuxDeployPresenter<SettingPanel> webAppOnLinuxDeployPresenter;
     private JTextField textAppName;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/webapp/runner/webappconfig/slimui/WebAppSlimSettingPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/webapp/runner/webappconfig/slimui/WebAppSlimSettingPanel.java
@@ -48,7 +48,7 @@ import static com.microsoft.intellij.ui.messages.AzureBundle.message;
 
 public class WebAppSlimSettingPanel extends AzureSettingPanel<WebAppConfiguration> implements WebAppDeployMvpViewSlim {
     private static final String[] FILE_NAME_EXT = {"war", "jar", "ear"};
-    private static final String DEPLOYMENT_SLOT = "Deployment Slot";
+    private static final String DEPLOYMENT_SLOT = "&Deployment Slot";
     private static final String DEFAULT_SLOT_NAME = "slot-%s";
 
     private final WebAppDeployViewPresenterSlim presenter;


### PR DESCRIPTION
### Issues to resolve
Now we use `HideableDecorator` to show the panel which could be hide, however, the decorated panel is not accessible by `Tab` in hide state, which is hard to use for keyboard only users

### Solution
Add [mnemonic](https://docs.oracle.com/javase/tutorial/uiswing/components/menu.html#mnemonic) short cut for `HideableDecorator` by add `&` to title of `HideableDecorator`, refers 
- https://github.com/JetBrains/intellij-community/blob/master/platform/platform-impl/src/com/intellij/ui/HideableDecorator.java#L165
- https://github.com/JetBrains/intellij-community/blob/master/platform/util/ui/src/com/intellij/openapi/util/text/TextWithMnemonic.java#L181

![accessibility-2](https://user-images.githubusercontent.com/12445236/128981842-c45daf69-c8d6-444c-9971-6e90a3a26f61.gif)
