### PR TITLE
Fix web container was null when open web app creation dialog

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/ui/AppServiceCreateDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.webapp/src/com/microsoft/azuretools/webapp/ui/AppServiceCreateDialog.java
@@ -349,6 +349,7 @@ public class AppServiceCreateDialog extends AppServiceBaseDialog {
         scrolledComposite.setExpandVertical(true);
         scrolledComposite.setMinSize(group.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 
+        fillJavaVersion();
         fillLinuxRuntime();
         fillWebContainers();
         fillSubscriptions();
@@ -366,7 +367,7 @@ public class AppServiceCreateDialog extends AppServiceBaseDialog {
         fillAppServicePlansDetails();
         fillAppServicePlanLocations();
         fillAppServicePlanPricingTiers();
-        fillJavaVersion();
+
         return scrolledComposite;
     }
 


### PR DESCRIPTION
### Issue to resolve
When create new app services, it shows null for Web container. After changing the java version, it shows a value then.
![image](https://user-images.githubusercontent.com/12445236/129002821-101eda44-5e3c-4c4f-b699-6e6849096290.png)

### Analysis & Solution
We used to fill web container before java version, but we need the selected java version to get correspond web container for java se runtime, which makes the web container default to be null for jar project, so change to fill java version first.