### PR TITLE
Add application insights dependency to Utils

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -47,7 +47,7 @@
         <mockito.version>2.22.0</mockito.version>
         <powermock.version>1.7.0RC4</powermock.version>
         <rx.version>1.3.8</rx.version>
-
+        <azure.mgmt-insights.version>1.0.0-beta</azure.mgmt-insights.version>
         <azure.toolkit-lib.version>0.11.0-SNAPSHOT</azure.toolkit-lib.version>
         <powermock.version>2.0.9</powermock.version>
     </properties>
@@ -235,6 +235,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.microsoft.azure.applicationinsights.v2015_05_01</groupId>
+                <artifactId>azure-mgmt-insights</artifactId>
+                <version>${azure.mgmt-insights.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-client</artifactId>


### PR DESCRIPTION
### Issues to resolve:
Add application insights dependency to Utils, as we have removed the dependency from toolkits-lib.
Refers https://github.com/microsoft/azure-maven-plugins/pull/1701

Todo: migrate application insights to Track2 SDK, remove track one dependency