### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,5 @@ branches:
   - develop.next
 install: skip
 script:
-- 'travis_wait 40 ./gradlew buildAll --quiet'
+- ' ./gradlew buildAll --quiet'
 dist: trusty
-


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
