### PR TITLE
Fix Spark local console launch EDT issue at 2021.2

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/kotlin/com/microsoft/azure/hdinsight/spark/console/RunSparkScalaLocalConsoleAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/kotlin/com/microsoft/azure/hdinsight/spark/console/RunSparkScalaLocalConsoleAction.kt
@@ -23,10 +23,15 @@
 package com.microsoft.azure.hdinsight.spark.console
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.ui.Messages
 import com.microsoft.azuretools.telemetry.TelemetryConstants
+import com.microsoft.azuretools.telemetrywrapper.Operation
 import org.jetbrains.plugins.scala.console.configuration.ScalaConsoleRunConfigurationFactory
 
 class RunSparkScalaLocalConsoleAction : RunSparkScalaConsoleAction() {
+    private var isMockFs: Boolean = false
+
     override val selectedMenuActionId: String
         get() = "Actions.SparkRunLocalConsoleActionGroups"
 
@@ -37,9 +42,21 @@ class RunSparkScalaLocalConsoleAction : RunSparkScalaConsoleAction() {
         get() = 0
 
     override val consoleRunConfigurationFactory: ScalaConsoleRunConfigurationFactory
-        get() = SparkScalaLocalConsoleConfigurationType().sparkLocalConfFactory()
+        get() = SparkScalaLocalConsoleConfigurationType().sparkLocalConfFactory(isMockFs)
 
     override fun getNewSettingName(): String = "Spark Local Console(Scala)"
 
     override fun getOperationName(event: AnActionEvent?): String = TelemetryConstants.RUN_SPARK_LOCAL_CONSOLE
+
+    override fun onActionPerformed(event: AnActionEvent, operation: Operation?): Boolean {
+        val project = CommonDataKeys.PROJECT.getData(event.dataContext) ?: return true
+
+        isMockFs = Messages.YES == Messages.showYesNoDialog(
+                        project,
+                        "Do you want to use a mocked file system?",
+                        "Setting file system",
+                        Messages.getQuestionIcon())
+
+        return super.onActionPerformed(event, operation)
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/kotlin/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/kotlin/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleConfigurationType.kt
@@ -31,7 +31,8 @@ class SparkScalaLocalConsoleConfigurationType : ScalaConsoleConfigurationType() 
         @JvmStatic
         val instance by lazy { ConfigurationTypeUtil.findConfigurationType(SparkScalaLocalConsoleConfigurationType::class.java) }
     }
-    fun sparkLocalConfFactory(): ScalaConsoleRunConfigurationFactory = SparkScalaLocalConsoleRunConfigurationFactory(this)
+    fun sparkLocalConfFactory(isMockFs: Boolean): ScalaConsoleRunConfigurationFactory =
+            SparkScalaLocalConsoleRunConfigurationFactory(this, isMockFs)
 
     override fun getDisplayName(): String = "Spark Local Console(Scala)"
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/kotlin/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/kotlin/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleRunConfiguration.kt
@@ -42,7 +42,6 @@ import com.intellij.openapi.roots.libraries.Library
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.roots.libraries.NewLibraryConfiguration
 import com.intellij.openapi.roots.ui.configuration.libraryEditor.NewLibraryEditor
-import com.intellij.openapi.ui.Messages
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.search.ProjectScope
 import com.intellij.util.PathUtil.getJarPathForClass
@@ -56,7 +55,9 @@ import org.jdom.Element
 import java.nio.file.Paths
 import javax.swing.Action
 
-class SparkScalaLocalConsoleRunConfiguration(private val scalaConsoleRunConfDelegate: ScalaConsoleRunConfiguration)
+class SparkScalaLocalConsoleRunConfiguration(
+        private val scalaConsoleRunConfDelegate: ScalaConsoleRunConfiguration,
+        private val isMockFs: Boolean)
     : ModuleBasedConfiguration<RunConfigurationModule, Element>(
         scalaConsoleRunConfDelegate.name,
         scalaConsoleRunConfDelegate.configurationModule,
@@ -105,15 +106,6 @@ class SparkScalaLocalConsoleRunConfiguration(private val scalaConsoleRunConfDele
     }
 
     fun createJavaParams(): JavaParameters {
-        var isMockFs = false
-        if (Messages.YES == Messages.showYesNoDialog(
-                        project,
-                        "Do you want to use a mocked file system?",
-                        "Setting file system",
-                        Messages.getQuestionIcon())) {
-            isMockFs = true
-        }
-
         val localRunParams = SparkBatchLocalRunState(project, batchRunConfiguration.model.localRunConfigurableModel, null)
                 .createParams(executor = null, hasJmockit = isMockFs, hasMainClass = false, hasClassPath = false)
         val params = createScalaParams()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/kotlin/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleRunConfigurationFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/kotlin/com/microsoft/azure/hdinsight/spark/console/SparkScalaLocalConsoleRunConfigurationFactory.kt
@@ -30,10 +30,13 @@ import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRu
 import org.jetbrains.plugins.scala.console.configuration.ScalaConsoleRunConfiguration
 import org.jetbrains.plugins.scala.console.configuration.ScalaConsoleRunConfigurationFactory
 
-class SparkScalaLocalConsoleRunConfigurationFactory(sparkConsoleType: SparkScalaLocalConsoleConfigurationType)
+class SparkScalaLocalConsoleRunConfigurationFactory(
+        sparkConsoleType: SparkScalaLocalConsoleConfigurationType,
+        private val isMockFs: Boolean)
     : ScalaConsoleRunConfigurationFactory(sparkConsoleType) {
     override fun createTemplateConfiguration(project: Project): RunConfiguration {
-        return SparkScalaLocalConsoleRunConfiguration(ScalaConsoleRunConfiguration(project, this, ""))
+        return SparkScalaLocalConsoleRunConfiguration(
+                ScalaConsoleRunConfiguration(project, this, ""), isMockFs)
     }
 
     override fun createConfiguration(name: String?, template: RunConfiguration): RunConfiguration {


### PR DESCRIPTION
Move the dialog of asking if mocking file system or not into action context.