### PR TITLE
Sync function before list function triggers

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/deploy/FunctionDeploymentState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/function/runner/deploy/FunctionDeploymentState.java
@@ -6,7 +6,6 @@
 package com.microsoft.azure.toolkit.intellij.function.runner.deploy;
 
 import com.azure.core.management.exception.ManagementException;
-import com.azure.resourcemanager.AzureResourceManager;
 import com.intellij.execution.process.ProcessOutputType;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiMethod;


### PR DESCRIPTION
### Issues to resolve:
Function triggers will take quite a bit time to refresh (30~60s) after deployment
- For new created triggers, triggers could not be listed after deployment
- For update, old triggers will still shown in portal/deployment status

### Solution
- Sync function before list function triggers, refers https://github.com/Azure/azure-functions-core-tools/blob/3.0.3568/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs#L452