### PR TITLE
Update plugin.xml path in intellij version helper

### DIFF
--- a/tools/IntellijVersionHelper
+++ b/tools/IntellijVersionHelper
@@ -6,7 +6,7 @@ SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 cd $SCRIPTPATH
 
-XMLFile="../PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/plugin.xml"
+XMLFile="../PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml"
 
 git checkout -- $XMLFile
 javac XMLHelper.java


### PR DESCRIPTION
Update plugin.xml path in intellij version helper, which may make release bits lack ide version