### PR TITLE
Fix invalid cache name for app service plan

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/appservice/serviceplan/ServicePlanComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/appservice/serviceplan/ServicePlanComboBox.java
@@ -60,7 +60,7 @@ public class ServicePlanComboBox extends AzureComboBox<AppServicePlanEntity> {
         // Clean up app service plan cache when switch subscription
         // todo: leverage event hub to update resource cache automatically
         try {
-            CacheManager.evictCache("appservcie/{}/plans", subscription.getId());
+            CacheManager.evictCache("appservice/{}/plans", subscription.getId());
         } catch (ExecutionException e) {
             // swallow exception while clean up cache
         }


### PR DESCRIPTION
Fix invalid cache name for app service plan, which may make service plan always use cached list