### PR TITLE
[WIP] Fix ADLA accounts can't be listed in SoC subscription issue

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/datalake/analytics/accounts/models/api/GetAccountsListResponse.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/rest/azure/datalake/analytics/accounts/models/api/GetAccountsListResponse.java
@@ -5,10 +5,12 @@
 
 package com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.accounts.models.api;
 
-        import com.microsoft.azure.hdinsight.sdk.rest.IConvertible;
-        import com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.accounts.models.DataLakeAnalyticsAccountBasic;
-        import com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.accounts.models.PageImpl;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.microsoft.azure.hdinsight.sdk.rest.IConvertible;
+import com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.accounts.models.DataLakeAnalyticsAccountBasic;
+import com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.accounts.models.PageImpl;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class GetAccountsListResponse extends PageImpl<DataLakeAnalyticsAccountBasic>
         implements IConvertible {
 


### PR DESCRIPTION
- We create this PR to fix the customer reported bug.
 When refresh `Apache Spark on Cosmos` node, no ADLA accounts are listed and the following exception is observed in log file.

```
2021-10-11 14:12:45,896 [251205530]   WARN - AzureSparkCosmosClusterManager - Ignore subscription Cosmos_WDG_Core_Enterprise and Security_100519(0967fa02-6d49-4548-92db-1adc399558d7) with exception 
java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "count" (class com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.accounts.models.api.GetAccountsListResponse), not marked as ignorable (2 known properties: "value", "nextLink"])
 at [Source: (String)"{"value":[{"properties":{"provisioningState":"Succeeded","state":"Active","endpoint":"commercialdata-nonprod-c15.azuredatalakeanalytics.net","accountId":"929ff3cb-2c86-4452-869f-e0fa0d28c83d","creationTime":"2018-09-19T21:26:52.8332771Z","lastModifiedTime":"2018-09-19T21:26:52.8332771Z"},"location":"westcentralus","id":"/subscriptions/0967fa02-6d49-4548-92db-1adc399558d7/resourceGroups/conv/providers/Microsoft.DataLakeAnalytics/accounts/commercialdata-nonprod-c15","name":"commercialdata-nonprod-"[truncated 1153 chars]; line: 1, column: 1653] (through reference chain: com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.accounts.models.api.GetAccountsListResponse["count"])
	at rx.exceptions.Exceptions.propagate(Exceptions.java:57)
	at com.microsoft.azure.hdinsight.sdk.common.HttpObservable.convertJsonResponseToObject(HttpObservable.java:344)
	at com.microsoft.azure.hdinsight.sdk.common.HttpObservable.lambda$get$7(HttpObservable.java:406)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:69)
	at rx.internal.operators.OperatorMerge$MergeSubscriber.emitScalar(OperatorMerge.java:395)
	at rx.internal.operators.OperatorMerge$MergeSubscriber.tryEmit(OperatorMerge.java:355)
	at rx.internal.operators.OperatorMerge$InnerSubscriber.onNext(OperatorMerge.java:846)
	at rx.observers.Subscribers$5.onNext(Subscribers.java:235)
	at rx.internal.operators.OperatorDoAfterTerminate$1.onNext(OperatorDoAfterTerminate.java:50)
	at rx.internal.util.ScalarSynchronousObservable$WeakSingleProducer.request(ScalarSynchronousObservable.java:276)
	at rx.Subscriber.setProducer(Subscriber.java:211)
	at rx.Subscriber.setProducer(Subscriber.java:205)
	at rx.Subscriber.setProducer(Subscriber.java:205)
	at rx.internal.util.ScalarSynchronousObservable$JustOnSubscribe.call(ScalarSynchronousObservable.java:138)
	at rx.internal.util.ScalarSynchronousObservable$JustOnSubscribe.call(ScalarSynchronousObservable.java:129)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeUsing.call(OnSubscribeUsing.java:94)
	at rx.internal.operators.OnSubscribeUsing.call(OnSubscribeUsing.java:32)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OperatorMerge$MergeSubscriber.onNext(OperatorMerge.java:248)
	at rx.internal.operators.OperatorMerge$MergeSubscriber.onNext(OperatorMerge.java:148)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:77)
	at rx.internal.producers.SingleDelayedProducer.emit(SingleDelayedProducer.java:102)
	at rx.internal.producers.SingleDelayedProducer.setValue(SingleDelayedProducer.java:85)
	at rx.internal.operators.OnSubscribeFromCallable.call(OnSubscribeFromCallable.java:48)
	at rx.internal.operators.OnSubscribeFromCallable.call(OnSubscribeFromCallable.java:33)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OperatorMerge$MergeSubscriber.onNext(OperatorMerge.java:248)
	at rx.internal.operators.OperatorMerge$MergeSubscriber.onNext(OperatorMerge.java:148)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:77)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:77)
	at rx.internal.operators.OnSubscribeDoOnEach$DoOnEachSubscriber.onNext(OnSubscribeDoOnEach.java:101)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:77)
	at rx.internal.operators.OperatorMerge$MergeSubscriber.emitScalar(OperatorMerge.java:395)
	at rx.internal.operators.OperatorMerge$MergeSubscriber.tryEmit(OperatorMerge.java:355)
	at rx.internal.operators.OperatorMerge$InnerSubscriber.onNext(OperatorMerge.java:846)
	at rx.internal.operators.OnSubscribeFromIterable$IterableProducer.slowPath(OnSubscribeFromIterable.java:117)
	at rx.internal.operators.OnSubscribeFromIterable$IterableProducer.request(OnSubscribeFromIterable.java:89)
	at rx.Subscriber.setProducer(Subscriber.java:211)
	at rx.internal.operators.OnSubscribeFromIterable.call(OnSubscribeFromIterable.java:63)
	at rx.internal.operators.OnSubscribeFromIterable.call(OnSubscribeFromIterable.java:34)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OperatorMerge$MergeSubscriber.onNext(OperatorMerge.java:248)
	at rx.internal.operators.OperatorMerge$MergeSubscriber.onNext(OperatorMerge.java:148)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:77)
	at rx.internal.producers.SingleDelayedProducer.emit(SingleDelayedProducer.java:102)
	at rx.internal.producers.SingleDelayedProducer.setValue(SingleDelayedProducer.java:85)
	at rx.internal.operators.OnSubscribeFromCallable.call(OnSubscribeFromCallable.java:48)
	at rx.internal.operators.OnSubscribeFromCallable.call(OnSubscribeFromCallable.java:33)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeDoOnEach.call(OnSubscribeDoOnEach.java:41)
	at rx.internal.operators.OnSubscribeDoOnEach.call(OnSubscribeDoOnEach.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeDoOnEach.call(OnSubscribeDoOnEach.java:41)
	at rx.internal.operators.OnSubscribeDoOnEach.call(OnSubscribeDoOnEach.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeSwitchIfEmpty$ParentSubscriber.subscribe(OnSubscribeSwitchIfEmpty.java:104)
	at rx.internal.operators.OnSubscribeSwitchIfEmpty.call(OnSubscribeSwitchIfEmpty.java:52)
	at rx.internal.operators.OnSubscribeSwitchIfEmpty.call(OnSubscribeSwitchIfEmpty.java:31)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.unsafeSubscribe(Observable.java:10327)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$0(AzureRxTaskManager.java:30)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureRxTaskManager.lambda$register$1(AzureRxTaskManager.java:30)
	at rx.Observable.subscribe(Observable.java:10423)
	at rx.Observable.subscribe(Observable.java:10390)
	at rx.observables.BlockingObservable.blockForSingle(BlockingObservable.java:443)
	at rx.observables.BlockingObservable.singleOrDefault(BlockingObservable.java:372)
	at com.microsoft.azure.hdinsight.sdk.common.azure.serverless.AzureSparkCosmosClusterManager.refresh(AzureSparkCosmosClusterManager.java:144)
	at com.microsoft.azure.cosmosspark.serverexplore.cosmossparknode.CosmosSparkClusterRootModuleImpl.refreshItems(CosmosSparkClusterRootModuleImpl.java:47)
	at com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode.refreshItems(RefreshableNode.java:86)
	at com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode$1.run(RefreshableNode.java:143)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTask.lambda$new$0(AzureTask.java:101)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager.lambda$runInObservable$0(AzureTaskManager.java:359)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext.run(AzureTaskContext.java:85)
	at com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager.lambda$runInObservable$1(AzureTaskManager.java:357)
	at com.microsoft.azure.toolkit.intellij.common.task.IntellijAzureTaskManager$1.run(IntellijAzureTaskManager.java:54)
	at com.intellij.openapi.progress.impl.CoreProgressManager$TaskRunnable.run(CoreProgressManager.java:998)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressAsync$5(CoreProgressManager.java:497)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$3(ProgressRunner.java:228)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:178)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:688)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:634)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:64)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:165)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:228)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "count" (class com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.accounts.models.api.GetAccountsListResponse), not marked as ignorable (2 known properties: "value", "nextLink"])
 at [Source: (String)"{"value":[{"properties":{"provisioningState":"Succeeded","state":"Active","endpoint":"commercialdata-nonprod-c15.azuredatalakeanalytics.net","accountId":"929ff3cb-2c86-4452-869f-e0fa0d28c83d","creationTime":"2018-09-19T21:26:52.8332771Z","lastModifiedTime":"2018-09-19T21:26:52.8332771Z"},"location":"westcentralus","id":"/subscriptions/0967fa02-6d49-4548-92db-1adc399558d7/resourceGroups/conv/providers/Microsoft.DataLakeAnalytics/accounts/commercialdata-nonprod-c15","name":"commercialdata-nonprod-"[truncated 1153 chars]; line: 1, column: 1653] (through reference chain: com.microsoft.azure.hdinsight.sdk.rest.azure.datalake.analytics.accounts.models.api.GetAccountsListResponse["count"])
	at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownProperty(DeserializationContext.java:987)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:1974)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1701)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1679)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:330)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:187)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4593)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3548)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3516)
	at com.microsoft.azure.hdinsight.sdk.rest.ObjectConvertUtils.convertJsonToObject(ObjectConvertUtils.java:30)
	at com.microsoft.azure.hdinsight.sdk.common.HttpObservable.convertJsonResponseToObject(HttpObservable.java:340)
	... 195 more

```