### PR TITLE
fix some job view page accessability bugs

### DIFF
--- a/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/css/jobgraph.css
+++ b/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/css/jobgraph.css
@@ -1,5 +1,5 @@
 g.sparkJob-success > rect {
-    fill: #00ffd0;
+    fill: var(--Job-s-color);
 }
 
 g.sparkJob-error > rect {
@@ -7,18 +7,20 @@ g.sparkJob-error > rect {
 }
 
 text {
+    fill: var(--text-color);
     font-weight: 300;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serf;
     font-size: 14px;
 }
 
 .node rect {
-    stroke: #999;
-    fill: #fff;
+    stroke: var(--edge-color);
+    fill: var(--bg-color);
     stroke-width: 1.5px;
 }
 
 .edgePath path {
-    stroke: #333;
+    fill: var(--arrow-color);
+    stroke: var(--arrow-color);
     stroke-width: 1.5px;
 }

--- a/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/index.html
+++ b/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/index.html
@@ -51,7 +51,7 @@
             <div></div>
                 <table id="myTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content">
                     <thead class="ui-widget-content">
-                    <tr align="center" class="ui-widget-content" style="word-wrap: break-word;">
+                    <tr align="center" class="ui-widget-content">
                         <th class="ui-widget-content" style="width:35px;">State</th>
                         <th class="ui-widget-content">Application ID</th>
                         <th class="ui-widget-content">Job Name</th>
@@ -77,7 +77,7 @@
                         </div>
                     </div>
                 </div>
-                <div  id="sparkDetailsPanel" style="overflow: auto;">
+                <div  id="sparkDetailsPanel">
                    <div role="tablist" id="bottomTab" >
                         <button id="applicationGraphButton"  role="tab" aria-selected="true" aria-controls="applicationGraph">Application Graph</button>
                         <button id="stageSummaryButton"  role="tab" aria-selected="false" tabindex="0" aria-controls="stageSummary">Stage Summary</button>
@@ -96,7 +96,7 @@
                             </div>
                         </div>
                         <div id="stageSummary" role="tabpanel" aria-labelledby="stageSummaryButton" hidden="" >
-                            <table id="stageSummaryTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content">
+                            <table id="stageSummaryTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content JColResizer">
                                 <thead class="ui-widget-content">
                                 <tr align="center" class="ui-widget-content">
                                     <th class="ui-widget-content">status</th>
@@ -115,7 +115,7 @@
                         </div>
                         <div id="taskSummary" role="tabpanel" aria-labelledby="taskSummaryButton" hidden="">
                             <input id="filterTableInput" type="text" placeholder="Search.." style="margin-bottom: 5px; height:1.6em; width:350px;" onkeyup="filterTaskSummaryTable()">
-                            <table id="taskSummaryTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content">
+                            <table id="taskSummaryTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content JColResizer">
                                 <thead class="ui-widget-content">
                                 <tr align="center" class="ui-widget-content">
                                     <th class="ui-widget-content">taskId</th>
@@ -133,7 +133,7 @@
                             </table>
                         </div>
                         <div id="executorDetailsDiv" role="tabpanel" aria-labelledby="executorDetailsDivButton" hidden="">
-                            <table id="executorDetailsTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content">
+                            <table id="executorDetailsTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content JColResizer">
                                 <thead class="ui-widget-content">
                                 <tr align="center" class="ui-widget-content">
                                     <th class="ui-widget-content">id</th>

--- a/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/index.html
+++ b/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/index.html
@@ -51,7 +51,7 @@
             <div></div>
                 <table id="myTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content">
                     <thead class="ui-widget-content">
-                    <tr align="center" class="ui-widget-content">
+                    <tr align="center" class="ui-widget-content" style="word-wrap: break-word;">
                         <th class="ui-widget-content" style="width:35px;">State</th>
                         <th class="ui-widget-content">Application ID</th>
                         <th class="ui-widget-content">Job Name</th>
@@ -70,23 +70,23 @@
                 <div class="fxs-startboard-header container">
                     <div class="row">
                         <p id="jobName"></p>
-                        <div id="rightButtonPanel" class="btn-group">
+                        <div id="rightButtonPanel">
                             <!--<button id="refreshButton" type="button" class="btn btn-default"><span class="glyphicon glyphicon-refresh"></span> Refresh</button>-->
-                            <button id="openSparkUIButton" type="button" class="btn btn-link">Open Spark History UI</button>
-                            <button id="openYarnUIButton" type="button" class="btn btn-link">Open Yarn UI</button>
+                            <a id="openSparkUIButton" href="#" >Open Spark History UI</a>
+                            <a id="openYarnUIButton" href="#" >Open Yarn UI</a>
                         </div>
                     </div>
                 </div>
-                <div id="sparkDetailsPanel" class="fxs-startboard-layout container hdiPanel">
-                    <ul id="bottomTab" class="nav nav-tabs">
-                        <li class="active"><a href="#applicationGraph" data-toggle="tab">Application Graph</a></li>
-                        <li><a href="#stageSummary" data-toggle="tab">Stage Summary</a></li>
-                        <li><a href="#executorDetailsDiv" data-toggle="tab">Executors</a></li>
-                        <li><a href="#taskSummary" data-toggle="tab">Task Summary</a></li>
-                        <li><a href="#myTabContent" data-toggle="tab">Logs</a></li>
-                    </ul>
+                <div  id="sparkDetailsPanel" style="overflow: auto;">
+                   <div role="tablist" id="bottomTab" >
+                        <button id="applicationGraphButton"  role="tab" aria-selected="true" aria-controls="applicationGraph">Application Graph</button>
+                        <button id="stageSummaryButton"  role="tab" aria-selected="false" tabindex="0" aria-controls="stageSummary">Stage Summary</button>
+                        <button id="executorDetailsDivButton" role="tab"  aria-selected="false" tabindex="0" aria-controls="executorDetailsDiv">Executors</button>
+                        <button id="taskSummaryButton"  role="tab"  aria-selected="false" tabindex="0" aria-controls="taskSummary">Task Summary</button>
+                        <button id="myTabContentButton"  role="tab"  aria-selected="false" tabindex="0" aria-controls="myTabContent">Logs</button>
+                    </div>
                     <div id="bottomTabContent" class="tab-content" style="width: 100%; height: 100%">
-                        <div class="tab-pane fade in active" id="applicationGraph" style="width: 100%; height: 100%">
+                        <div id="applicationGraph" role="tabpanel" aria-labelledby="applicationGraphButton" style="width: 100%; height: 100%">
                             <div id="applicationGraphDiv" style="width: 100%; height: 100%">
                                 <svg id="applicationGraphSvg" width="100%" height="100%"></svg>
                             </div>
@@ -95,7 +95,7 @@
                                 <svg id="jobGraphSvg" width="100%" height="80%"></svg>
                             </div>
                         </div>
-                        <div class="tab-pane fade" id="stageSummary">
+                        <div id="stageSummary" role="tabpanel" aria-labelledby="stageSummaryButton" hidden="" >
                             <table id="stageSummaryTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content">
                                 <thead class="ui-widget-content">
                                 <tr align="center" class="ui-widget-content">
@@ -113,7 +113,7 @@
                             </table>
                             <p id="stage_detail_info_message"></p>
                         </div>
-                        <div class="tab-pane fade" id="taskSummary">
+                        <div id="taskSummary" role="tabpanel" aria-labelledby="taskSummaryButton" hidden="">
                             <input id="filterTableInput" type="text" placeholder="Search.." style="margin-bottom: 5px; height:1.6em; width:350px;" onkeyup="filterTaskSummaryTable()">
                             <table id="taskSummaryTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content">
                                 <thead class="ui-widget-content">
@@ -132,7 +132,7 @@
                                 </tbody>
                             </table>
                         </div>
-                        <div class="tab-pane fade" id="executorDetailsDiv">
+                        <div id="executorDetailsDiv" role="tabpanel" aria-labelledby="executorDetailsDivButton" hidden="">
                             <table id="executorDetailsTable" class="table table-bordered table-condensed table-striped sortable ui-widget-content">
                                 <thead class="ui-widget-content">
                                 <tr align="center" class="ui-widget-content">
@@ -152,17 +152,17 @@
                                 </tbody>
                             </table>
                         </div>
-                        <div id="myTabContent" class="tab-pane fade">
+                        <div id="myTabContent" role="tabpanel" aria-labelledby="myTabContentButton" hidden="">
                             <div id="error">
-                                <p>Driver Stderr</p>
+                                <label for="driverErrorTextArea">Driver Stderr</label>
                                 <textarea id="driverErrorTextArea" rows="20" readonly="readonly" class="resultTextArea">error Message</textarea>
                             </div>
                             <div id="jobOutput">
-                                <p>Driver Stdout</p>
+                                <label for="jobOutputTextArea">Driver Stdout</label>
                                 <textarea id="jobOutputTextArea" rows="20" readonly="readonly" class="resultTextArea">Out put</textarea>
                             </div>
                             <div  id="driverLog">
-                                <p>Directory Info</p>
+                                <label for="directoryInfoTextArea">Directory Info</label>
                                 <textarea id="directoryInfoTextArea" rows="20" readonly="readonly" class="resultTextArea">Driver Log</textarea>
                             </div>
                         </div>
@@ -171,5 +171,6 @@
             </div>
         </div>
     </div>
+    <script src="js/tabs.js"></script>
 </body>
 </html>

--- a/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/indexpage.css
+++ b/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/indexpage.css
@@ -2,14 +2,20 @@
 :root.dark-theme-mode {
     --text-color: white;
     --bg-color: #2b2b2b;
+    --selection-bg-color: #4B77AF;
+    --selection-text-color: white;
 }
 :root.light-theme-mode {
     --text-color: black;
     --bg-color: white;
+    --selection-bg-color: #2675BF;
+    --selection-text-color: white;
 }
 :root.highcontrast-theme-mode {
     --text-color: white;
     --bg-color: black;
+    --selection-bg-color: #3333FF;
+    --selection-text-color: white;
 }
 
 body {
@@ -104,7 +110,9 @@ body {
     width: 150px;
     margin-left: 10px;
 }
-#rightButtonPanel button {
+
+#rightButtonPanel a {
+    color: #2675BF;
     font-size: 11px;
     padding-top: 3px;
     padding-bottom: 3px;
@@ -189,8 +197,8 @@ body {
 
 .table-striped#myTable tbody > tr.selected-hight > td,
 .table-striped tbody > tr.selected-hight > th {
-    background-color: #FECA40;
-    color: black;
+    background-color: var(--selection-bg-color);
+    color: var(--selection-text-color);
     font-weight: bold;
     font-size: 13px;
 }
@@ -264,3 +272,20 @@ input[type=text]:focus {
     width: 100%;
 }
 
+[role="tablist"] {
+  overflow: visible;
+  margin:5px;
+}
+
+[role="tab"] {
+  position: relative;
+  margin: 0;
+  padding: 0.3em 0.5em 0.4em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0.2em 0.2em 0 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  background-color: inherit;
+  color: inherit;
+}

--- a/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/indexpage.css
+++ b/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/indexpage.css
@@ -4,18 +4,27 @@
     --bg-color: #2b2b2b;
     --selection-bg-color: #4B77AF;
     --selection-text-color: white;
+    --edge-color: #828384;
+    --arrow-color: white;
+    --Job-s-color: #4B77AF;
 }
 :root.light-theme-mode {
     --text-color: black;
     --bg-color: white;
     --selection-bg-color: #2675BF;
     --selection-text-color: white;
+    --edge-color: #828384;
+    --arrow-color: black;
+    --Job-s-color: #2687BF;
 }
 :root.highcontrast-theme-mode {
     --text-color: white;
     --bg-color: black;
     --selection-bg-color: #3333FF;
     --selection-text-color: white;
+    --edge-color: #828384;
+    --arrow-color: white;
+    --Job-s-color: #3333FF;
 }
 
 body {
@@ -91,6 +100,14 @@ body {
     font-weight: 200;
     align-content: center;
 }
+
+#stageSummaryTable > thead > tr > th,
+#taskSummaryTable > thead > tr > th,
+#executorDetailsTable > thead > tr > th {
+    text-align: center;
+    word-wrap: break-word;
+}
+
 #stored_rdd_info,
 #stage_detail_info,
 #job-details-info-table {
@@ -112,7 +129,7 @@ body {
 }
 
 #rightButtonPanel a {
-    color: #2675BF;
+    color: inherit;
     font-size: 11px;
     padding-top: 3px;
     padding-bottom: 3px;
@@ -207,12 +224,12 @@ body {
 .table-striped#myTable thead > tr> th {
     text-align: center;
     background-color: var(--bg-color);
+    word-wrap: break-word;
 }
 
 .table-striped#myTable tbody > tr> td:first-child,
 .table-striped.table-striped#myTable tbody > tr > th:first-child {
     text-align: center;
-    background-color: var(--bg-color);
 }
 
 .table-striped > tbody > tr:nth-child(odd),
@@ -288,4 +305,9 @@ input[type=text]:focus {
   font-size: inherit;
   background-color: inherit;
   color: inherit;
+}
+
+[role="tab"][aria-selected="true"] {
+  background: var(--selection-bg-color);
+  color: var(--selection-text-color);
 }

--- a/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/js/tabs.js
+++ b/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/js/tabs.js
@@ -1,0 +1,67 @@
+(function () {
+  var tablist = document.querySelectorAll('[role="tablist"]')[0];
+  var tabs;
+  var panels;
+
+  generateArrays();
+
+  function generateArrays () {
+    tabs = document.querySelectorAll('[role="tab"]');
+    panels = document.querySelectorAll('[role="tabpanel"]');
+  };
+
+  // Bind listeners
+  for (i = 0; i < tabs.length; ++i) {
+    addListeners(i);
+  };
+
+  function addListeners (index) {
+    tabs[index].addEventListener('click', clickEventListener);
+
+    // Build an array with all tabs (<button>s) in it
+    tabs[index].index = index;
+  };
+
+  // When a tab is clicked, activateTab is fired to activate it
+  function clickEventListener (event) {
+    var tab = event.target;
+    activateTab(tab, false);
+  };
+
+  // Activates any given tab panel
+  function activateTab (tab, setFocus) {
+    setFocus = setFocus || true;
+
+    // Deactivate all other tabs
+    deactivateTabs();
+
+    // Remove tabindex attribute
+    tab.removeAttribute('tabindex');
+
+    // Set the tab as selected
+    tab.setAttribute('aria-selected', 'true');
+
+    // Get the value of aria-controls (which is an ID)
+    var controls = tab.getAttribute('aria-controls');
+
+    // Remove hidden attribute from tab panel to make it visible
+    document.getElementById(controls).removeAttribute('hidden');
+
+    // Set focus when required
+    if (setFocus) {
+      tab.focus();
+    };
+  };
+
+  // Deactivate all tabs and tab panels
+  function deactivateTabs () {
+    for (t = 0; t < tabs.length; t++) {
+      tabs[t].setAttribute('tabindex', '0');
+      tabs[t].setAttribute('aria-selected', 'false');
+    };
+
+    for (p = 0; p < panels.length; p++) {
+      panels[p].setAttribute('hidden', 'hidden');
+    };
+  };
+}());


### PR DESCRIPTION
@t-rufang  please help to review this change, thanks!

bug list:

- [1870845](https://dev.azure.com/mseng/VSJava/_workitems/edit/1870845)A11y_Java Tooling for IntelliJ/Eclipse[BM]_Job View_Name, Role, Value: Incorrect role is given for 'Open spark history & Open Yarn UI' controls as 'Button'
    - the fix of tabs please refer to [Example of Tabs with Automatic Activation](https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html)

- [1870874](https://dev.azure.com/mseng/VSJava/_workitems/edit/1870874)A11y_Java Tooling for IntelliJ/Eclipse[BM]_Job View_Logs_Screen Reader: NVDA is not announcing 'Driver Stderr, Driver Stdout & Directory info' labels when focus lands on corresponding sections.

- [1870900](https://dev.azure.com/mseng/VSJava/_workitems/edit/1870900)A11y_Java Tooling for IntelliJ/Eclipse[BM]_Job View_Resize Text: "Job view" column header data is getting overlapped at different zooming conditions (150%, 175%, 200%).

- [1870901](https://dev.azure.com/mseng/VSJava/_workitems/edit/1870901)A11y_Java Tooling for IntelliJ/Eclipse[BM]_Job View_Orientation: "Jobs view" table data is not aligned properly in portrait mode.

- [1870902](https://dev.azure.com/mseng/VSJava/_workitems/edit/1870902)A11y_Java Tooling for IntelliJ/Eclipse[BM]_Job View_Non-Text Contrast: Non-Text contrast ratio between selected job and it's background is showing as 1.5:1 which is less than 3:1. 

- [1870882](https://dev.azure.com/mseng/VSJava/_workitems/edit/1870882)A11y_Java Tooling for IntelliJ/Eclipse[BM]_Job View_High Contrast: "Jobs view" window is not adopting High contrast theme.



