### PR TITLE
#1894278: declare dependency support for azure client/management/spring libs so that intellij will recommend our plugin when these libs are detected.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/resources/META-INF/azure-sdk-reference-book.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/resources/META-INF/azure-sdk-reference-book.xml
@@ -1,5 +1,10 @@
 <idea-plugin>
     <resource-bundle>com.microsoft.azure.toolkit.operation.title.sdk</resource-bundle>
+    <extensions defaultExtensionNs="com.intellij">
+        <!-- `displayName` is currently not used for bug: https://youtrack.jetbrains.com/issue/IDEA-275873 -->
+        <dependencySupport displayName="Azure SDK client libraries(Track 2)" coordinate="com.azure:azure-core" kind="java"/>
+        <dependencySupport displayName="Azure SDK client libraries" coordinate="com.microsoft.azure:azure-client-runtime" kind="java"/>
+    </extensions>
     <actions>
         <action id="AzureToolkit.OpenSdkReferenceBook"
                 class="com.microsoft.azure.toolkit.intellij.azuresdk.referencebook.OpenReferenceBookAction"


### PR DESCRIPTION
[AB#1894278](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1894278): declare dependency support for azure client/management/spring libs so that intellij will recommend our plugin when these libs are detected.