### PR TITLE
Revert "Fix bug:  unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -239,8 +239,6 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.21")
 
-    implementation group: 'io.netty', name: 'netty-resolver-dns-native-macos', version: '4.1.70.Final', classifier: 'osx-x86_64', ext: 'jar'
-
     // https://mvnrepository.com/artifact/org.projectlombok/lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
Reverts microsoft/azure-tools-for-java#6107