### PR TITLE
Implement `getId` for `DockerHostRunConfigurationFactory`

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/webapp/docker/dockerhost/DockerHostRunConfigurationFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/webapp/docker/dockerhost/DockerHostRunConfigurationFactory.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.toolkit.intellij.webapp.docker.AzureDockerSupportConf
 
 import com.microsoft.intellij.helpers.AzureIconLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureIconSymbol;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
@@ -27,6 +28,11 @@ public class DockerHostRunConfigurationFactory extends ConfigurationFactory {
     @Override
     public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
         return new DockerHostRunConfiguration(project, this, String.format("%s: %s", FACTORY_NAME, project.getName()));
+    }
+
+    @Override
+    public @NotNull @NonNls String getId() {
+        return FACTORY_NAME;
     }
 
     @Override


### PR DESCRIPTION
Implement `getId` for `DockerHostRunConfigurationFactory`, [AB#1896681](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1896681)