### PR TITLE
Fix NPE issue in UILoggerAppender

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/logger/UILoggerAppender.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/logger/UILoggerAppender.java
@@ -23,7 +23,7 @@ public class UILoggerAppender extends AppenderSkeleton {
             if (uiHelper != null) {
                 uiHelper.logError(
                         event.getRenderedMessage(),
-                        event.getThrowableInformation().getThrowable());
+                        event.getThrowableInformation() == null ? null : event.getThrowableInformation().getThrowable());
             }
         }
 


### PR DESCRIPTION
Fixe npe error during restoring sign:
java.lang.NullPointerException: Cannot invoke "org.apache.log4j.spi.ThrowableInformation.getThrowable()" because the return value of "org.apache.log4j.spi.LoggingEvent.getThrowableInformation()" is null
at com.microsoft.azure.hdinsight.common.logger.UILoggerAppender.append(UILoggerAppender.java:26)
at org.apache.log4j.AppenderSkeleton.doAppend(AppenderSkeleton.java:251)
at org.apache.log4j.helpers.AppenderAttachableImpl.appendLoopOnAppenders(AppenderAttachableImpl.java:66)
at org.apache.log4j.Category.callAppenders(Category.java:206)
at org.apache.log4j.Category.forcedLog(Category.java:391)
at org.apache.log4j.Category.log(Category.java:856)
at org.slf4j.impl.Log4jLoggerAdapter.error(Log4jLoggerAdapter.java:498)
at com.microsoft.aad.msal4jextensions.CrossProcessCacheFileLock.releaseResources(CrossProcessCacheFileLock.java:173)
at com.microsoft.aad.msal4jextensions.CrossProcessCacheFileLock.unlock(CrossProcessCacheFileLock.java:149)
at com.microsoft.aad.msal4jextensions.PersistenceTokenCacheAccessAspect.afterCacheAccess(PersistenceTokenCacheAccessAspect.java:150)
at com.azure.identity.implementation.PersistentTokenCacheImpl.afterCacheAccess(PersistentTokenCacheImpl.java:72)
at com.microsoft.aad.msal4j.TokenCache$CacheAspect.close(TokenCache.java:172)
at com.microsoft.aad.msal4j.TokenCache.getAccounts(TokenCache.java:359)
at com.microsoft.aad.msal4j.AccountsSupplier.get(AccountsSupplier.java:26)
at com.microsoft.aad.msal4j.AccountsSupplier.get(AccountsSupplier.java:11)
at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1764)