### PR TITLE
Add job view focus loop

### DIFF
--- a/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/common.js
+++ b/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/common.js
@@ -103,3 +103,12 @@ function getTimeIntervalByMins(time1, time2) {
     var strictIsoParse = d3.utcParse("%Y-%m-%dT%H:%M:%S.%LGMT");
     return ((strictIsoParse(time1) - strictIsoParse(time2))/(1000 * 60.0)).toFixed(2);
 }
+
+function onBodyFocus() {
+    if (document.activeElement != document.body) {
+        return;
+    }
+
+    console.log("tab next")
+     $.tabNext();
+}

--- a/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/index.html
+++ b/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/index.html
@@ -27,6 +27,7 @@
     <script src="js/tipsy.js"></script>
     <script src="js/colResizable-1.6.min.js"></script>
     <script src="js/jquery.dragtable.js"></script>
+    <script src="js/jquery.tabbable.js"></script>
     <script src="js/dataGrid.js"></script>
     <script src="js/utils.js"></script>
 
@@ -48,7 +49,7 @@
     <link rel="stylesheet" href="css/dataGrids.css" type="text/css">
 </head>
 
-<body>
+<body onfocus="onBodyFocus()">
     <div id="parent" class="fxs-mainwindow">
         <div id="leftDiv">
                 <table id="myTable" role="grid" class="data table table-bordered table-condensed table-striped sortable ui-widget-content">

--- a/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/js/jquery.tabbable.js
+++ b/Utils/hdinsight-node-common/resources/htmlResources/hdinsight/job/html/js/jquery.tabbable.js
@@ -1,0 +1,136 @@
+/*!
+ * jQuery.tabbable 1.0 - Simple utility for selecting the next / previous ':tabbable' element.
+ * https://github.com/marklagendijk/jQuery.tabbable
+ *
+ * Includes ':tabbable' and ':focusable' selectors from jQuery UI Core
+ *
+ * Copyright 2013, Mark Lagendijk
+ * Released under the MIT license
+ *
+ */
+(function($){
+	'use strict';
+
+	/**
+	 * Focusses the next :focusable element. Elements with tabindex=-1 are focusable, but not tabable.
+	 * Does not take into account that the taborder might be different as the :tabbable elements order
+	 * (which happens when using tabindexes which are greater than 0).
+	 */
+	$.focusNext = function(){
+		selectNextTabbableOrFocusable(':focusable');
+	};
+
+	/**
+	 * Focusses the previous :focusable element. Elements with tabindex=-1 are focusable, but not tabable.
+	 * Does not take into account that the taborder might be different as the :tabbable elements order
+	 * (which happens when using tabindexes which are greater than 0).
+	 */
+	$.focusPrev = function(){
+		selectPrevTabbableOrFocusable(':focusable');
+	};
+
+	/**
+	 * Focusses the next :tabable element.
+	 * Does not take into account that the taborder might be different as the :tabbable elements order
+	 * (which happens when using tabindexes which are greater than 0).
+	 */
+	$.tabNext = function(){
+		selectNextTabbableOrFocusable(':tabbable');
+	};
+
+	/**
+	 * Focusses the previous :tabbable element
+	 * Does not take into account that the taborder might be different as the :tabbable elements order
+	 * (which happens when using tabindexes which are greater than 0).
+	 */
+	$.tabPrev = function(){
+		selectPrevTabbableOrFocusable(':tabbable');
+	};
+
+	function selectNextTabbableOrFocusable(selector){
+		var selectables = $(selector);
+		var current = $(':focus');
+		var nextIndex = 0;
+		if(current.length === 1){
+			var currentIndex = selectables.index(current);
+			if(currentIndex + 1 < selectables.length){
+				nextIndex = currentIndex + 1;
+			}
+		}
+
+		selectables.eq(nextIndex).focus();
+	}
+
+	function selectPrevTabbableOrFocusable(selector){
+		var selectables = $(selector);
+		var current = $(':focus');
+		var prevIndex = selectables.length - 1;
+		if(current.length === 1){
+			var currentIndex = selectables.index(current);
+			if(currentIndex > 0){
+				prevIndex = currentIndex - 1;
+			}
+		}
+
+		selectables.eq(prevIndex).focus();
+	}
+
+	/**
+	 * :focusable and :tabbable, both taken from jQuery UI Core
+	 */
+	$.extend($.expr[ ':' ], {
+		data: $.expr.createPseudo ?
+			$.expr.createPseudo(function(dataName){
+				return function(elem){
+					return !!$.data(elem, dataName);
+				};
+			}) :
+			// support: jQuery <1.8
+			function(elem, i, match){
+				return !!$.data(elem, match[ 3 ]);
+			},
+
+		focusable: function(element){
+			return focusable(element, !isNaN($.attr(element, 'tabindex')));
+		},
+
+		tabbable: function(element){
+			var tabIndex = $.attr(element, 'tabindex'),
+				isTabIndexNaN = isNaN(tabIndex);
+			return ( isTabIndexNaN || tabIndex >= 0 ) && focusable(element, !isTabIndexNaN);
+		}
+	});
+
+	/**
+	 * focussable function, taken from jQuery UI Core
+	 * @param element
+	 * @returns {*}
+	 */
+	function focusable(element){
+		var map, mapName, img,
+			nodeName = element.nodeName.toLowerCase(),
+			isTabIndexNotNaN = !isNaN($.attr(element, 'tabindex'));
+		if('area' === nodeName){
+			map = element.parentNode;
+			mapName = map.name;
+			if(!element.href || !mapName || map.nodeName.toLowerCase() !== 'map'){
+				return false;
+			}
+			img = $('img[usemap=#' + mapName + ']')[0];
+			return !!img && visible(img);
+		}
+		return ( /^(input|select|textarea|button|object)$/.test(nodeName) ?
+			!element.disabled :
+			'a' === nodeName ?
+				element.href || isTabIndexNotNaN :
+				isTabIndexNotNaN) &&
+			// the element and all of its ancestors must be visible
+			visible(element);
+
+		function visible(element){
+			return $.expr.filters.visible(element) && !$(element).parents().addBack().filter(function(){
+				return $.css(this, 'visibility') === 'hidden';
+			}).length;
+		}
+	}
+})(jQuery);


### PR DESCRIPTION
To enable job view focus loop in elements on page when press 'tab'
![JobviewFocusLoopAccessibilityFix](https://user-images.githubusercontent.com/7385667/144777275-b8eb7522-c60f-4c7f-aa2f-a8f6b74557be.gif)


