### PR TITLE
fix cve issue about jackson

### DIFF
--- a/Utils/hdinsight-node-common/pom.xml
+++ b/Utils/hdinsight-node-common/pom.xml
@@ -227,6 +227,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/Utils/hdinsight-node-common/pom.xml
+++ b/Utils/hdinsight-node-common/pom.xml
@@ -227,7 +227,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/Utils/spark-localrun-mock/pom.xml
+++ b/Utils/spark-localrun-mock/pom.xml
@@ -169,6 +169,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.1/pom.xml
+++ b/Utils/spark-tools/spark-v2.1/pom.xml
@@ -131,6 +131,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.3/spark-v2.3.0/pom.xml
+++ b/Utils/spark-tools/spark-v2.3/spark-v2.3.0/pom.xml
@@ -144,6 +144,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.3/spark-v2.3.2/pom.xml
+++ b/Utils/spark-tools/spark-v2.3/spark-v2.3.2/pom.xml
@@ -144,6 +144,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
fix cve issue about jackson: 
   specify version of jackson-databind in hdinsight-node-common
   exclude jackson-mapper-asl in spark-pools and spark-localrun-mock
