### PR TITLE
Resolve slow operations in EDT issues

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/core/FunctionUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/core/FunctionUtils.java
@@ -10,6 +10,7 @@ import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.codeInsight.MetaAnnotationUtil;
 import com.intellij.lang.jvm.JvmAnnotation;
 import com.intellij.lang.jvm.JvmParameter;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
@@ -144,8 +145,7 @@ public class FunctionUtils {
                 return false;
             }
             final GlobalSearchScope scope = GlobalSearchScope.moduleWithLibrariesScope(m);
-            final PsiClass ecClass = JavaPsiFacade.getInstance(project).findClass(AZURE_FUNCTION_ANNOTATION_CLASS,
-                                                                                  scope);
+            final PsiClass ecClass = ReadAction.compute(() -> JavaPsiFacade.getInstance(project).findClass(AZURE_FUNCTION_ANNOTATION_CLASS, scope));
             return ecClass != null;
         }).toArray(Module[]::new);
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/deploy/FunctionDeploymentConfigurationFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/deploy/FunctionDeploymentConfigurationFactory.java
@@ -11,6 +11,7 @@ import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.intellij.common.AzureIcons;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureIconSymbol;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
@@ -42,5 +43,10 @@ public class FunctionDeploymentConfigurationFactory extends ConfigurationFactory
     @Override
     public Icon getIcon() {
         return AzureIcons.getIcon(AzureIconSymbol.FunctionApp.DEPLOY.getPath());
+    }
+
+    @Override
+    public @NotNull @NonNls String getId() {
+        return message("function.deploy.factory.name");
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/deploy/ui/FunctionDeploymentPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/deploy/ui/FunctionDeploymentPanel.java
@@ -21,6 +21,8 @@ import com.microsoft.azure.toolkit.intellij.legacy.function.runner.component.tab
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.core.FunctionUtils;
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.deploy.FunctionDeployConfiguration;
 import com.microsoft.intellij.CommonConst;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -193,6 +195,9 @@ public class FunctionDeploymentPanel extends AzureSettingPanel<FunctionDeployCon
     }
 
     private void fillModules() {
-        Arrays.stream(FunctionUtils.listFunctionModules(project)).forEach(module -> cbFunctionModule.addItem(module));
+        AzureTaskManager.getInstance()
+                .runOnPooledThreadAsObservable(new AzureTask<>(() -> FunctionUtils.listFunctionModules(project)))
+                .subscribe(modules -> AzureTaskManager.getInstance().runLater(() ->
+                        Arrays.stream(modules).forEach(cbFunctionModule::addItem), AzureTask.Modality.ANY));
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunConfigurationFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunConfigurationFactory.java
@@ -11,6 +11,7 @@ import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.intellij.common.AzureIcons;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureIconSymbol;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -41,5 +42,10 @@ public class FunctionRunConfigurationFactory extends ConfigurationFactory {
     @Override
     public Icon getIcon() {
         return AzureIcons.getIcon(AzureIconSymbol.FunctionApp.RUN.getPath());
+    }
+
+    @Override
+    public @NotNull @NonNls String getId() {
+        return FACTORY_NAME;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/ui/FunctionRunPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/ui/FunctionRunPanel.java
@@ -16,6 +16,9 @@ import com.microsoft.azure.toolkit.intellij.legacy.function.runner.component.tab
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.core.FunctionUtils;
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.localrun.FunctionRunConfiguration;
 import com.microsoft.azure.toolkit.lib.legacy.function.FunctionCoreToolsCombobox;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
+import com.microsoft.azure.toolkit.lib.function.FunctionCoreToolsCombobox;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -144,6 +147,9 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
     }
 
     private void fillModules() {
-        Arrays.stream(FunctionUtils.listFunctionModules(project)).forEach(module -> cbFunctionModule.addItem(module));
+        AzureTaskManager.getInstance()
+                .runOnPooledThreadAsObservable(new AzureTask<>(() -> FunctionUtils.listFunctionModules(project)))
+                .subscribe(modules -> AzureTaskManager.getInstance().runLater(() ->
+                        Arrays.stream(modules).forEach(cbFunctionModule::addItem), AzureTask.Modality.ANY));
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/intellij/util/MavenRunTaskUtil.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/intellij/util/MavenRunTaskUtil.java
@@ -62,9 +62,9 @@ public class MavenRunTaskUtil {
               .map(ArtifactType::findById)
               .filter(Objects::nonNull)
               .flatMap(type ->
-                  AzureTaskManager.getInstance()
-                      .readAsObservable(new AzureTask<>(()-> ArtifactManager.getInstance(project).getArtifactsByType(type)))
-                      .toBlocking().single().stream())
+                      AzureTaskManager.getInstance()
+                              .readAsObservable(new AzureTask<>(() -> ArtifactManager.getInstance(project).getArtifactsByType(type)))
+                              .toBlocking().single().stream())
             .collect(Collectors.toList());
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/docker/pushimage/PushImageRunConfigurationFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/docker/pushimage/PushImageRunConfigurationFactory.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.toolkit.intellij.common.AzureIcons;
 
 import com.microsoft.azure.toolkit.intellij.docker.AzureDockerSupportConfigurationType;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureIconSymbol;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
@@ -42,5 +43,10 @@ public class PushImageRunConfigurationFactory extends ConfigurationFactory {
     @Override
     public Icon getIcon() {
         return AzureIcons.getIcon(AzureIconSymbol.DockerSupport.PUSH_IMAGE.getPath());
+    }
+
+    @Override
+    public @NotNull @NonNls String getId() {
+        return FACTORY_NAME;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/docker/webapponlinux/WebAppOnLinuxDeployConfigurationFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/docker/webapponlinux/WebAppOnLinuxDeployConfigurationFactory.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.toolkit.intellij.docker.AzureDockerSupportConfigurati
 
 import com.microsoft.intellij.helpers.AzureIconLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureIconSymbol;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
@@ -43,5 +44,10 @@ public class WebAppOnLinuxDeployConfigurationFactory extends ConfigurationFactor
     @Override
     public Icon getIcon() {
         return AzureIconLoader.loadIcon(AzureIconSymbol.DockerSupport.RUN_ON_WEB_APP);
+    }
+
+    @Override
+    public @NotNull @NonNls String getId() {
+        return FACTORY_NAME;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/kotlin/com/microsoft/azure/hdinsight/spark/run/action/SparkRunConfigurationAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/kotlin/com/microsoft/azure/hdinsight/spark/run/action/SparkRunConfigurationAction.kt
@@ -29,6 +29,8 @@ import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder
 import com.intellij.execution.runners.ProgramRunner
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.UpdateInBackground
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.roots.TestSourcesFilter.isTestSources
 import com.microsoft.azure.hdinsight.common.logger.ILogger
 import com.microsoft.azure.hdinsight.spark.run.configuration.LivySparkBatchJobRunConfiguration
@@ -44,7 +46,7 @@ import com.microsoft.intellij.telemetry.TelemetryKeys
 import com.microsoft.intellij.util.runInReadAction
 import javax.swing.Icon
 
-abstract class SparkRunConfigurationAction : AzureAnAction, ILogger {
+abstract class SparkRunConfigurationAction : AzureAnAction, ILogger, UpdateInBackground {
     constructor(icon: Icon?) : super(icon)
     constructor(text: String?) : super(text)
     constructor(text: String?, description: String?, icon: Icon?) : super(text, description, icon)
@@ -64,10 +66,12 @@ abstract class SparkRunConfigurationAction : AzureAnAction, ILogger {
         val runManagerEx = RunManagerEx.getInstanceEx(project)
         val selectedConfigSettings = runManagerEx.selectedConfiguration
 
+        ProgressManager.checkCanceled();
         val mainClass = actionEvent.dataContext.getSparkConfigurationContext()?.getSparkMainClassWithElement()
         if (mainClass?.containingFile?.let { isTestSources(it.virtualFile, project) } == true) {
             return
         }
+        ProgressManager.checkCanceled();
 
         presentation.apply {
             when {


### PR DESCRIPTION
- Move long running operations out of EDT
- Run read actions in EDT only
- Override outdated default implementation of `getId` of run configuration