### PR TITLE
Declare dependency support for azure functions java library

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/resources/META-INF/azure-sdk-reference-book.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/resources/META-INF/azure-sdk-reference-book.xml
@@ -4,6 +4,7 @@
         <!-- `displayName` is currently not used for bug: https://youtrack.jetbrains.com/issue/IDEA-275873 -->
         <dependencySupport displayName="Azure SDK client libraries(Track 2)" coordinate="com.azure:azure-core" kind="java"/>
         <dependencySupport displayName="Azure SDK client libraries" coordinate="com.microsoft.azure:azure-client-runtime" kind="java"/>
+        <dependencySupport displayName="Library for Azure Java Functions" coordinate="com.microsoft.azure.functions:azure-functions-java-library" kind="java"/>
     </extensions>
     <actions>
         <action id="AzureToolkit.OpenSdkReferenceBook"


### PR DESCRIPTION
Declare dependency support for azure functions java library so that intellij will recommend toolkit for Java azure functions users