### PR TITLE
Fix the no-callback issue when maven package goal fails and use correct func in function extension install

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/src/com/microsoft/azuretools/appservice/ui/WebAppDeployDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/src/com/microsoft/azuretools/appservice/ui/WebAppDeployDialog.java
@@ -883,7 +883,6 @@ public class WebAppDeployDialog extends AppServiceBaseDialog {
                         CountDownLatch countDownLatch = new CountDownLatch(1);
                         action.launch(MavenUtils.getPomFile(project).getParent(), () -> {
                             countDownLatch.countDown();
-                            return null;
                         });
                         countDownLatch.await();
                     }

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/main/java/com/microsoft/azuretools/container/handlers/DockerRunHandler.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/main/java/com/microsoft/azuretools/container/handlers/DockerRunHandler.java
@@ -67,7 +67,6 @@ public class DockerRunHandler extends AzureAbstractHandler {
                 action.launch(container, () -> {
                     // TODO: callback after mvn package done. IMPORTANT
                     buildAndRun(event);
-                    return null;
                 });
             } else {
                 WarUtil.export(project, destinationPath);

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/main/java/com/microsoft/azuretools/container/handlers/PublishHandler.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/main/java/com/microsoft/azuretools/container/handlers/PublishHandler.java
@@ -48,7 +48,6 @@ public class PublishHandler extends AzureAbstractHandler {
                     container = MavenUtils.getPomFile(project).getParent();
                     action.launch(container, () -> {
                         buildAndRun(event);
-                        return null;
                     });
                 } else {
                     destinationPath = Paths.get(basePath, Constant.DOCKERFILE_FOLDER, project.getName() + ".war").normalize().toString();

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/main/java/com/microsoft/azuretools/container/handlers/PushImageHandler.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.container/src/main/java/com/microsoft/azuretools/container/handlers/PushImageHandler.java
@@ -43,7 +43,6 @@ public class PushImageHandler extends AzureAbstractHandler {
                 IContainer container = MavenUtils.getPomFile(project).getParent();
                 action.launch(container, () -> {
                     buildAndRun();
-                    return null;
                 });
             } else {
                 destinationPath = Paths.get(basePath, Constant.DOCKERFILE_FOLDER, project.getName() + ".war")

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azure/toolkit/eclipse/common/artifact/AzureArtifactManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azure/toolkit/eclipse/common/artifact/AzureArtifactManager.java
@@ -69,7 +69,8 @@ public class AzureArtifactManager {
                 try {
                     action.launch(container, () -> {
                         sink.success(Status.OK_STATUS);
-                        return null;
+                    }, () -> {
+                        sink.error(new AzureToolkitRuntimeException("Fail to build the maven project: " + ((MavenProject) ref).getName()));
                     });
                 } catch (CoreException e) {
                     sink.error(e);

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/actions/MavenExecuteAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.core/src/com/microsoft/azuretools/core/actions/MavenExecuteAction.java
@@ -35,8 +35,6 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
 
-import java.util.concurrent.Callable;
-
 public class MavenExecuteAction {
 
     private final String goalName;
@@ -47,7 +45,11 @@ public class MavenExecuteAction {
         this.goalName = goal;
     }
 
-    public void launch(IContainer basecon, Callable<?> callback) throws CoreException {
+    public void launch(IContainer basecon, Runnable callback) throws CoreException {
+        launch(basecon, callback, null);
+    }
+
+    public void launch(IContainer basecon, Runnable callback, Runnable onError) throws CoreException {
         if (basecon == null) {
             return;
         }
@@ -70,7 +72,9 @@ public class MavenExecuteAction {
                             DebugPlugin.getDefault().removeDebugEventListener(this);
                             try {
                                 if (process.getExitValue() == 0) {
-                                    callback.call();
+                                    callback.run();
+                                } else if (onError != null) {
+                                    onError.run();
                                 }
                             } catch (Exception e) {
                                 e.printStackTrace();


### PR DESCRIPTION
1. use correct func in function extension install
2. avoid generating azure function staging folder two times
3. add the ability to show log of 'func extension install' to console
4. re-show the console when task has been finished
5. fix the no-callback issue when maven build fail