### PR TITLE
Fix project has been disposed exception during initialize what's new

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzurePlugin.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzurePlugin.java
@@ -150,6 +150,9 @@ public class AzurePlugin implements StartupActivity.DumbAware {
     private void initializeWhatsNew(Project project) {
         EventUtil.executeWithLog(SYSTEM, SHOW_WHATS_NEW,
                 operation -> {
+                    if (project.isDisposed()) {
+                        return;
+                    }
                     final AnAction action = ActionManager.getInstance().getAction(WhatsNewAction.ID);
                     final DataContext context = dataId -> CommonDataKeys.PROJECT.getName().equals(dataId) ? project : null;
                     AzureTaskManager.getInstance().runLater(() -> ActionUtil.invokeAction(action, context, "AzurePluginStartupActivity", null, null));


### PR DESCRIPTION
Return if project has been disposed when initialize what's new, fixes https://github.com/microsoft/azure-tools-for-java/issues/4739