### PR TITLE
Fix `setValue` does not work in eclipse function creation wizard

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/src/com/microsoft/azure/toolkit/eclipse/function/wizard/ProjectArtifactPage.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/src/com/microsoft/azure/toolkit/eclipse/function/wizard/ProjectArtifactPage.java
@@ -43,7 +43,7 @@ public class ProjectArtifactPage extends AzWizardPageWrapper implements AzureFor
         FunctionProjectPage previousPage = (FunctionProjectPage) getWizard().getPreviousPage(this);
 
         if (StringUtils.isBlank(txtArtifact.getValue())) {
-            this.txtArtifact.setValue(previousPage.getProjectName());
+            this.txtArtifact.setValue(previousPage.getProjectName(), true);
         }
     }
 
@@ -82,10 +82,11 @@ public class ProjectArtifactPage extends AzWizardPageWrapper implements AzureFor
 
     @Override
     public void setValue(@Nonnull FunctionArtifactModel value) {
-        this.txtGroupId.setValue(value.getGroupId());
-        this.txtArtifact.setValue(value.getArtifactId());
-        this.txtVersion.setValue(value.getVersion());
-        this.txtPackageName.setValue(value.getPackageName());
+        // todo: Diff user input and defualt values in SWT input components
+        this.txtGroupId.setValue(value.getGroupId(), true);
+        this.txtArtifact.setValue(value.getArtifactId(), true);
+        this.txtVersion.setValue(value.getVersion(), true);
+        this.txtPackageName.setValue(value.getPackageName(), true);
     }
 
     @Override


### PR DESCRIPTION
Fix `setValue` does not work in eclipse function creation wizard, [AB#1904318](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1904318)