### PR TITLE
[Issue #1904838] Add getId for DockerHostRunConfigurationFactory to replace the deprecated implementation

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/docker/dockerhost/DockerHostRunConfigurationFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/docker/dockerhost/DockerHostRunConfigurationFactory.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.toolkit.intellij.common.AzureIcons;
 
 import com.microsoft.azure.toolkit.intellij.docker.AzureDockerSupportConfigurationType;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureIconSymbol;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
@@ -42,5 +43,10 @@ public class DockerHostRunConfigurationFactory extends ConfigurationFactory {
     @Override
     public Icon getIcon() {
         return AzureIcons.getIcon(AzureIconSymbol.DockerSupport.RUN.getPath());
+    }
+
+    @Override
+    public @NotNull @NonNls String getId() {
+        return FACTORY_NAME;
     }
 }


### PR DESCRIPTION
Add getId for DockerHostRunConfigurationFactory to replace the deprecated implementation, [AB#1904838](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1904838)