### PR TITLE
[Issue #1905124]Resolve dependency conflicts for docker client in azure toolkit for intellij

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     compile project(':azure-intellij-plugin-lib')
     compile 'com.microsoft.azure:azure-toolkit-appservice-lib:' + azureToolkitVersion
     compile 'com.microsoft.azure:azure-toolkit-ide-appservice-lib:' + azureToolkitVersion
-    compile 'com.spotify:docker-client:8.16.0'
     compile 'org.codehaus.plexus:plexus-archiver:4.2.6'
     compile 'org.codehaus.plexus:plexus-component-api:1.0-alpha-33'
     compile group: 'com.neovisionaries', name: 'nv-websocket-client', version: '2.14'

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/docker/dockerhost/DockerHostRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/docker/dockerhost/DockerHostRunState.java
@@ -5,7 +5,6 @@
 
 package com.microsoft.azure.toolkit.intellij.docker.dockerhost;
 
-import com.google.common.collect.ImmutableList;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.process.ProcessOutputTypes;
@@ -14,15 +13,16 @@ import com.intellij.openapi.util.Key;
 import com.microsoft.azure.toolkit.intellij.docker.utils.Constant;
 import com.microsoft.azure.toolkit.intellij.docker.utils.DockerProgressHandler;
 import com.microsoft.azure.toolkit.intellij.docker.utils.DockerUtil;
+import com.microsoft.azure.toolkit.intellij.legacy.common.AzureRunProfileState;
 import com.microsoft.azuretools.core.mvp.model.container.pojo.DockerHostRunSetting;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetrywrapper.Operation;
 import com.microsoft.azuretools.telemetrywrapper.TelemetryManager;
-import com.microsoft.azure.toolkit.intellij.legacy.common.AzureRunProfileState;
 import com.microsoft.intellij.RunProcessHandler;
 import com.microsoft.intellij.util.MavenRunTaskUtil;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.messages.Container;
+import com.spotify.docker.client.shaded.com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.model.MavenConstants;


### PR DESCRIPTION
### Description
IntelliJ runtime introduced docker-client shaded, which conflicts with the docker-client declared in intellij app service plugin, unify to use docker client shaded in this PR.

[AB#1905124](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1905124)