### PR TITLE
Fix issues founded in regression

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/deploy/ui/FunctionDeploymentPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/deploy/ui/FunctionDeploymentPanel.java
@@ -13,6 +13,7 @@ import com.intellij.packaging.artifacts.Artifact;
 import com.intellij.ui.HyperlinkLabel;
 import com.intellij.ui.ListCellRendererWrapper;
 import com.microsoft.azure.toolkit.ide.appservice.function.FunctionAppConfig;
+import com.microsoft.azure.toolkit.intellij.common.AzureComboBox;
 import com.microsoft.azure.toolkit.intellij.legacy.common.AzureSettingPanel;
 import com.microsoft.azure.toolkit.intellij.legacy.function.FunctionAppComboBox;
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.component.table.AppSettingsTable;
@@ -136,6 +137,7 @@ public class FunctionDeploymentPanel extends AzureSettingPanel<FunctionDeployCon
         }
         if (!StringUtils.isAllEmpty(configuration.getFunctionId(), configuration.getAppName())) {
             appSettingsFunctionApp = configuration.getConfig();
+            functionAppComboBox.setValue(new AzureComboBox.ItemReference<>(item -> FunctionAppConfig.isSameApp(item, configuration.getConfig())));
             functionAppComboBox.setConfigModel(configuration.getConfig());
         }
         final Module previousModule = configuration.getModule();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/VMCreationDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/VMCreationDialog.java
@@ -278,6 +278,7 @@ public class VMCreationDialog extends AzureDialog<DraftVirtualMachine> implement
         txtMaximumPrice.setVisible(enableAzureSpotInstance);
         txtMaximumPrice.setRequired(enableAzureSpotInstance);
         txtMaximumPrice.setValidator(enableAzureSpotInstance ? this::validateMaximumPricing : null);
+        txtMaximumPrice.validateValueAsync(); // trigger revalidate after reset validator
         txtMaximumPrice.onDocumentChanged(); // trigger revalidate after reset validator
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageComboBox.java
@@ -19,6 +19,7 @@ public class ImageComboBox extends AzureComboBox<AzureImage> {
 
     public void setImageSku(AzureImageSku imageSku) {
         this.imageSku = imageSku;
+        this.clear();
         this.refreshItems();
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageOfferComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageOfferComboBox.java
@@ -19,6 +19,7 @@ public class ImageOfferComboBox extends AzureComboBox<AzureImageOffer> {
 
     public void setPublisher(AzureImagePublisher publisher) {
         this.publisher = publisher;
+        this.clear();
         refreshItems();
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImagePublisherComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImagePublisherComboBox.java
@@ -29,11 +29,13 @@ public class ImagePublisherComboBox extends AzureComboBox<AzureImagePublisher> {
 
     public void setSubscription(Subscription subscription) {
         this.subscription = subscription;
+        this.clear();
         this.refreshItems();
     }
 
     public void setRegion(Region region) {
         this.region = region;
+        this.clear();
         this.refreshItems();
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageSkuComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageSkuComboBox.java
@@ -19,6 +19,7 @@ public class ImageSkuComboBox extends AzureComboBox<AzureImageSku> {
 
     public void setOffer(AzureImageOffer offer) {
         this.offer = offer;
+        this.clear();
         this.refreshItems();
     }
 


### PR DESCRIPTION
- Revalidate pricing input after azure spot was enabled in VM creation dialog, [AB#1907790](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1907790)
- Clear selection after parent resource changes in VM image selection dialog, [AB#1907794](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1907794)