### PR TITLE
Resolve regression issues for app services

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/AppServiceInfoBasicPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/AppServiceInfoBasicPanel.java
@@ -102,6 +102,7 @@ public class AppServiceInfoBasicPanel<T extends AppServiceConfig> extends JPanel
 
     @Override
     public void setValue(final T config) {
+        this.config = config;
         this.textName.setValue(config.getName());
         this.selectorRuntime.setValue(config.getRuntime());
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/action/SSHIntoWebAppAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/action/SSHIntoWebAppAction.java
@@ -6,10 +6,12 @@
 package com.microsoft.azure.toolkit.intellij.legacy.appservice.action;
 
 import com.intellij.openapi.project.Project;
+import com.microsoft.azure.toolkit.lib.appservice.model.OperatingSystem;
 import com.microsoft.azure.toolkit.lib.appservice.service.impl.WebApp;
 import com.microsoft.azure.toolkit.lib.common.action.Action;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import com.microsoft.azure.toolkit.lib.legacy.appservice.TunnelProxy;
@@ -57,6 +59,10 @@ public class SSHIntoWebAppAction {
         final AzureString title = title("webapp.connect_ssh.app", webAppName);
         AzureTaskManager.getInstance().runInBackground(new AzureTask(project, title, false,
             () -> {
+                if (webApp.getRuntime().getOperatingSystem() == OperatingSystem.WINDOWS) {
+                    AzureMessager.getMessager().warning(message("webapp.ssh.windowsNotSupport"));
+                    return;
+                }
                 final TunnelProxy proxy = new TunnelProxy(webApp);
 
                 int localPort;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/FunctionAppCreationDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/FunctionAppCreationDialog.java
@@ -6,16 +6,17 @@
 package com.microsoft.azure.toolkit.intellij.legacy.function;
 
 import com.intellij.openapi.project.Project;
-import com.microsoft.azure.toolkit.ide.appservice.model.ApplicationInsightsConfig;
+import com.microsoft.azure.toolkit.ide.appservice.function.FunctionAppConfig;
 import com.microsoft.azure.toolkit.ide.appservice.model.MonitorConfig;
-import com.microsoft.azure.toolkit.intellij.legacy.appservice.AppServiceInfoBasicPanel;
 import com.microsoft.azure.toolkit.intellij.common.AzureFormPanel;
 import com.microsoft.azure.toolkit.intellij.common.ConfigDialog;
+import com.microsoft.azure.toolkit.intellij.legacy.appservice.AppServiceInfoBasicPanel;
 import com.microsoft.azure.toolkit.lib.appservice.model.Runtime;
-import com.microsoft.azure.toolkit.ide.appservice.function.FunctionAppConfig;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
 import javax.swing.*;
+import java.util.Optional;
 
 import static com.microsoft.azure.toolkit.intellij.common.AzureBundle.message;
 
@@ -54,14 +55,16 @@ public class FunctionAppCreationDialog extends ConfigDialog<FunctionAppConfig> {
 
     private void createUIComponents() {
         // TODO: place custom component creation code here
-        basicPanel = new AppServiceInfoBasicPanel<FunctionAppConfig>(project, () -> FunctionAppConfig.getFunctionAppDefaultConfig(project.getName())) {
+        basicPanel = new AppServiceInfoBasicPanel<>(project, () -> FunctionAppConfig.getFunctionAppDefaultConfig(project.getName())) {
             @Override
             public FunctionAppConfig getValue() {
                 // Create AI instance with same name by default
                 final FunctionAppConfig config = super.getValue();
-                final MonitorConfig monitorConfig = MonitorConfig.builder().build();
-                monitorConfig.setApplicationInsightsConfig(ApplicationInsightsConfig.builder().name(config.getName()).newCreate(true).build());
-                config.setMonitorConfig(monitorConfig);
+                Optional.ofNullable(config.getMonitorConfig()).map(MonitorConfig::getApplicationInsightsConfig).ifPresent(insightConfig -> {
+                    if (insightConfig.isNewCreate() && !StringUtils.equals(insightConfig.getName(), config.getName())) {
+                        insightConfig.setName(config.getName());
+                    }
+                });
                 return config;
             }
         };

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/deploy/ui/FunctionDeploymentPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/deploy/ui/FunctionDeploymentPanel.java
@@ -13,6 +13,7 @@ import com.intellij.packaging.artifacts.Artifact;
 import com.intellij.ui.HyperlinkLabel;
 import com.intellij.ui.ListCellRendererWrapper;
 import com.microsoft.azure.toolkit.ide.appservice.function.FunctionAppConfig;
+import com.microsoft.azure.toolkit.intellij.common.AzureComboBox;
 import com.microsoft.azure.toolkit.intellij.legacy.common.AzureSettingPanel;
 import com.microsoft.azure.toolkit.intellij.legacy.function.FunctionAppComboBox;
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.component.table.AppSettingsTable;
@@ -136,6 +137,7 @@ public class FunctionDeploymentPanel extends AzureSettingPanel<FunctionDeployCon
         }
         if (!StringUtils.isAllEmpty(configuration.getFunctionId(), configuration.getAppName())) {
             appSettingsFunctionApp = configuration.getConfig();
+            functionAppComboBox.setValue(new AzureComboBox.ItemReference<>(item -> FunctionAppConfig.isSameApp(item, configuration.getConfig())));
             functionAppComboBox.setConfigModel(configuration.getConfig());
         }
         final Module previousModule = configuration.getModule();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/resources/com/microsoft/intellij/ui/messages/messages.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/resources/com/microsoft/intellij/ui/messages/messages.properties
@@ -1529,6 +1529,7 @@ webapp.ssh.hint.sshConnectionDone=Complete to execute ssh connection. output mes
 webapp.ssh.hint.startSSH=Start to perform SSH into web app ({0})....
 webapp.ssh.hint.SSHDone=End to perform SSH into Web App ({0})
 webapp.ssh.hint.passwordNotReady=password input is not ready. ready processing is stopped because of timeout.
+webapp.ssh.windowsNotSupport=Azure SSH is only supported for Linux web apps.
 webapp.ssh.error.title=SSH into Web App Error
 webapp.ssh.error.message=Failed to SSH into Web App. Please try again.
 webapp.ssh.error.notSupport.Windows=Azure SSH is only supported for Linux web apps

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/VMCreationDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/VMCreationDialog.java
@@ -278,6 +278,7 @@ public class VMCreationDialog extends AzureDialog<DraftVirtualMachine> implement
         txtMaximumPrice.setVisible(enableAzureSpotInstance);
         txtMaximumPrice.setRequired(enableAzureSpotInstance);
         txtMaximumPrice.setValidator(enableAzureSpotInstance ? this::validateMaximumPricing : null);
+        txtMaximumPrice.validateValueAsync(); // trigger revalidate after reset validator
         txtMaximumPrice.onDocumentChanged(); // trigger revalidate after reset validator
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageComboBox.java
@@ -19,6 +19,7 @@ public class ImageComboBox extends AzureComboBox<AzureImage> {
 
     public void setImageSku(AzureImageSku imageSku) {
         this.imageSku = imageSku;
+        this.clear();
         this.refreshItems();
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageOfferComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageOfferComboBox.java
@@ -19,6 +19,7 @@ public class ImageOfferComboBox extends AzureComboBox<AzureImageOffer> {
 
     public void setPublisher(AzureImagePublisher publisher) {
         this.publisher = publisher;
+        this.clear();
         refreshItems();
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImagePublisherComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImagePublisherComboBox.java
@@ -29,11 +29,13 @@ public class ImagePublisherComboBox extends AzureComboBox<AzureImagePublisher> {
 
     public void setSubscription(Subscription subscription) {
         this.subscription = subscription;
+        this.clear();
         this.refreshItems();
     }
 
     public void setRegion(Region region) {
         this.region = region;
+        this.clear();
         this.refreshItems();
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageSkuComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/ImageSkuComboBox.java
@@ -19,6 +19,7 @@ public class ImageSkuComboBox extends AzureComboBox<AzureImageSku> {
 
     public void setOffer(AzureImageOffer offer) {
         this.offer = offer;
+        this.clear();
         this.refreshItems();
     }
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/AppServiceActionsContributor.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/AppServiceActionsContributor.java
@@ -56,7 +56,7 @@ public class AppServiceActionsContributor implements IActionsContributor {
 
         final ActionView.Builder sshView = new ActionView.Builder("SSH into Web App")
                 .title(s -> Optional.ofNullable(s).map(r -> title("webapp.connect_ssh.app", ((IAppService) r).name())).orElse(null))
-                .enabled(s -> s instanceof IAppService<?>);
+                .enabled(s -> s instanceof IAppService<?> && StringUtils.equalsIgnoreCase(((IAppService<?>) s).getStatus(), IAzureBaseResource.Status.RUNNING));
         am.registerAction(SSH_INTO_WEBAPP, new Action<>(sshView));
     }
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/file/AppServiceFileNode.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/file/AppServiceFileNode.java
@@ -20,6 +20,9 @@ import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.time.DateTimeException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -117,9 +120,18 @@ public class AppServiceFileNode extends Node<AppServiceFile> {
 
         @Override
         public String getDescription() {
-            return file.getType() == AppServiceFile.Type.DIRECTORY ?
-                    String.format("Type: %s Date modified: %s", file.getMime(), file.getMtime()) :
-                    String.format("Type: %s Size: %s Date modified: %s", file.getMime(), FileUtils.byteCountToDisplaySize(file.getSize()), file.getMtime());
+            final String modifiedDateTime = formatDateTime(file.getMtime());
+            return file.getType() == AppServiceFile.Type.DIRECTORY ? String.format("Type: %s Date modified: %s", file.getMime(), modifiedDateTime) :
+                    String.format("Type: %s Size: %s Date modified: %s", file.getMime(), FileUtils.byteCountToDisplaySize(file.getSize()), modifiedDateTime);
+        }
+
+        private static String formatDateTime(@Nullable final String dateTime) {
+            try {
+                return StringUtils.isEmpty(dateTime) ? "Unknown" : DateTimeFormatter.RFC_1123_DATE_TIME.format(OffsetDateTime.parse(dateTime));
+            } catch (DateTimeException dateTimeException) {
+                // swallow exception for parse datetime, return unknown in this case
+                return "Unknown";
+            }
         }
 
         @Override

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/function/FunctionAppConfig.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/function/FunctionAppConfig.java
@@ -6,6 +6,8 @@
 package com.microsoft.azure.toolkit.ide.appservice.function;
 
 import com.microsoft.azure.toolkit.ide.appservice.model.AppServiceConfig;
+import com.microsoft.azure.toolkit.ide.appservice.model.ApplicationInsightsConfig;
+import com.microsoft.azure.toolkit.ide.appservice.model.MonitorConfig;
 import com.microsoft.azure.toolkit.ide.appservice.webapp.model.DraftServicePlan;
 import com.microsoft.azure.toolkit.ide.common.model.DraftResourceGroup;
 import com.microsoft.azure.toolkit.lib.Azure;
@@ -60,6 +62,8 @@ public class FunctionAppConfig extends AppServiceConfig {
         final String planName = StringUtils.substring(String.format("sp-%s", appName), 0, SP_NAME_MAX_LENGTH);
         final DraftServicePlan plan = new DraftServicePlan(subscription, planName, region, FunctionAppConfig.DEFAULT_RUNTIME.getOperatingSystem(),
                 PricingTier.CONSUMPTION);
+        final ApplicationInsightsConfig insightsConfig = ApplicationInsightsConfig.builder().name(appName).newCreate(true).build();
+        final MonitorConfig monitorConfig = MonitorConfig.builder().applicationInsightsConfig(insightsConfig).build();
         return FunctionAppConfig.builder()
                 .subscription(subscription)
                 .resourceGroup(group)
@@ -67,6 +71,7 @@ public class FunctionAppConfig extends AppServiceConfig {
                 .servicePlan(plan)
                 .runtime(FunctionAppConfig.DEFAULT_RUNTIME)
                 .pricingTier(PricingTier.CONSUMPTION)
+                .monitorConfig(monitorConfig)
                 .region(region).build();
     }
 
@@ -83,6 +88,12 @@ public class FunctionAppConfig extends AppServiceConfig {
                 .map(AppServicePlanEntity::getResourceGroup).orElseGet(config::getResourceGroupName));
         Optional.ofNullable(config.getRuntime()).ifPresent(runtime -> result.runtime(
                 new RuntimeConfig().os(runtime.getOperatingSystem()).javaVersion(runtime.getJavaVersion()).webContainer(runtime.getWebContainer())));
+        final ApplicationInsightsConfig insightsConfig = Optional.ofNullable(config.getMonitorConfig()).map(MonitorConfig::getApplicationInsightsConfig).orElse(null);
+        result.disableAppInsights(insightsConfig == null);
+        if (insightsConfig != null) {
+            result.appInsightsInstance(insightsConfig.getName());
+            result.appInsightsKey(insightsConfig.getInstrumentationKey());
+        }
         result.appSettings(config.getAppSettings());
         return result;
     }

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/function/node/FunctionsNode.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/function/node/FunctionsNode.java
@@ -16,10 +16,12 @@ import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class FunctionsNode extends Node<FunctionApp> {
@@ -33,8 +35,12 @@ public class FunctionsNode extends Node<FunctionApp> {
         this.addChildren(ignore -> functionApp.listFunctions().stream()
                         .sorted(Comparator.comparing(FunctionEntity::getName)).collect(Collectors.toList()),
                 (function, functionsNode) -> new Node<>(function)
-                        .view(new NodeView.Static(function.getName(), "/icons/function-trigger.png"))
+                        .view(new NodeView.Static(function.getName(), "/icons/function-trigger.png", getFunctionTriggerType(function)))
                         .actions(FunctionAppActionsContributor.FUNCTION_ACTION));
+    }
+
+    private static String getFunctionTriggerType(@Nonnull FunctionEntity functionEntity) {
+        return Optional.ofNullable(functionEntity.getTrigger()).map(FunctionEntity.BindingEntity::getType).map(StringUtils::capitalize).orElse("Unknown");
     }
 
     static class FunctionsNodeView implements NodeView {

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/webapp/WebAppActionsContributor.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/webapp/WebAppActionsContributor.java
@@ -61,7 +61,6 @@ public class WebAppActionsContributor implements IActionsContributor {
                 AppServiceActionsContributor.SSH_INTO_WEBAPP,
                 AppServiceActionsContributor.START_STREAM_LOG,
                 AppServiceActionsContributor.STOP_STREAM_LOG
-                // todo: add profile actions like log streaming
         );
         am.registerGroup(WEBAPP_ACTIONS, webAppActionGroup);
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/webapp/WebAppExplorerContributor.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/webapp/WebAppExplorerContributor.java
@@ -58,7 +58,7 @@ public class WebAppExplorerContributor implements IExplorerContributor {
                     .subscribe(ignore -> AzureEventBus.emit("resource.status_changed.resource", resource));
             return null;
         }
-        return resource.getRuntime().getOperatingSystem() == OperatingSystem.LINUX ? AzureIcon.Modifier.LINUX : null;
+        return resource.getRuntime().getOperatingSystem() != OperatingSystem.WINDOWS ? AzureIcon.Modifier.LINUX : null;
     }
 
     private static List<WebApp> listWebApps(AzureWebApp webAppModule) {


### PR DESCRIPTION
- Clear selection after parent resource changes in VM image selection dialog, [AB#1907794](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1907794)
- Revalidate pricing input after azure spot was enabled in VM creation dialog, [AB#1907790](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1907790)
- Set item reference for function comobo box when reset from configuration, [AB#1909349](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1909349)
- Keep the reference of config in `setValue` of `AppServiceInfoBasicPanel` , in case insights/service plan configuration will be dropped when switch to simple mode in app service creation dialog, [AB#1907762](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1907762)
- Disable ssh into webapp for stopped app service, [AB#1904982](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1904982)
- Refine the date format for app service file explorer, [AB#1908647](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1908647)
- Add description for function trigger node, [AB#1908655](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1908655)