### PR TITLE
fix for CVE-2021-22569

### DIFF
--- a/Utils/spark-tools/pom.xml
+++ b/Utils/spark-tools/pom.xml
@@ -101,6 +101,10 @@
                         <groupId>com.sun.jersey.contribs</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.google.protobuf</groupId>
+                        <artifactId>protobuf-java</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
         </dependencies>

--- a/Utils/spark-tools/spark-v2.3/spark-v2.3.0/pom.xml
+++ b/Utils/spark-tools/spark-v2.3/spark-v2.3.0/pom.xml
@@ -201,6 +201,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.3/spark-v2.3.2/pom.xml
+++ b/Utils/spark-tools/spark-v2.3/spark-v2.3.2/pom.xml
@@ -201,6 +201,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Exclude protobuf-java from spark-sql & hadoop-client to fix  [CVE-2021-22569](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/79032?typeId=119493)