### PR TITLE
[Task #1916310] Support customizing port for Azure Functions Core tools when run Function project

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/core/FunctionUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/core/FunctionUtils.java
@@ -568,4 +568,14 @@ public class FunctionUtils {
         }
         return -1;
     }
+
+    public static int getFreePort() {
+        try {
+            ServerSocket serverSocket = new ServerSocket(0);
+            serverSocket.close();
+            return serverSocket.getLocalPort();
+        } catch (IOException e) {
+            return -1;
+        }
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/core/FunctionUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/core/FunctionUtils.java
@@ -54,6 +54,7 @@ import org.jetbrains.idea.maven.project.MavenProjectsManager;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -69,6 +70,8 @@ import java.util.stream.Collectors;
 import static com.microsoft.azure.toolkit.intellij.common.AzureBundle.message;
 
 public class FunctionUtils {
+    private static final int MAX_PORT = 65535;
+
     public static final String FUNCTION_JAVA_LIBRARY_ARTIFACT_ID = "azure-functions-java-library";
     private static final String AZURE_FUNCTION_ANNOTATION_CLASS =
             "com.microsoft.azure.functions.annotation.FunctionName";
@@ -543,5 +546,26 @@ public class FunctionUtils {
             return false;
         }
         return cme.getCompilerOutputUrl() == null && cme.getCompilerOutputUrlForTests() != null;
+    }
+
+    public static int findFreePortForApi(int startPort) {
+        ServerSocket socket = null;
+        for (int port = startPort; port <= MAX_PORT; port++) {
+            try {
+                socket = new ServerSocket(port);
+                return socket.getLocalPort();
+            } catch (IOException e) {
+                // swallow this exception
+            } finally {
+                if (socket != null) {
+                    try {
+                        socket.close();
+                    } catch (IOException e) {
+                        // swallow this exception
+                    }
+                }
+            }
+        }
+        return -1;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/core/FunctionUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/core/FunctionUtils.java
@@ -558,7 +558,6 @@ public class FunctionUtils {
                 // otherwise the code will not work correctly on that platform
                 serverSocket.setReuseAddress(false);
                 serverSocket.bind(new InetSocketAddress(InetAddress.getByName("localhost"), port), 1);
-                serverSocket.close();
                 return serverSocket.getLocalPort();
             } catch (Exception ex) {
                 continue;
@@ -568,9 +567,7 @@ public class FunctionUtils {
     }
 
     public static int getFreePort() {
-        try {
-            ServerSocket serverSocket = new ServerSocket(0);
-            serverSocket.close();
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
             return serverSocket.getLocalPort();
         } catch (IOException e) {
             return -1;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunConfiguration.java
@@ -165,6 +165,14 @@ public class FunctionRunConfiguration extends AzureRunConfigurationBase<Function
         this.myModule.setModule(module);
     }
 
+    public int getFuncPort() {
+        return this.functionRunModel.getFuncPort();
+    }
+
+    public void setFuncPort(int funcPort) {
+        this.functionRunModel.setFuncPort(funcPort);
+    }
+
     public void initializeDefaults(Module module) {
         if (module == null) {
             return;
@@ -216,6 +224,9 @@ public class FunctionRunConfiguration extends AzureRunConfigurationBase<Function
         final File func = new File(getFuncPath());
         if (!func.exists() || !func.isFile() || !func.getName().contains("func")) {
             throw new ConfigurationException(message("function.run.validate.invalidFuncPath"));
+        }
+        if (getFuncPort() <= 0 || getFuncPort() >= 65535) {
+            throw new ConfigurationException(message("function.validate_run_configuration.invalidPort"));
         }
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunModel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunModel.java
@@ -16,6 +16,7 @@ public class FunctionRunModel extends IntelliJFunctionContext {
     private String funcPath;
     private String hostJsonPath;
     private String localSettingsJsonPath;
+    private int funcPort;
 
     public Artifact getArtifact() {
         return artifact;
@@ -65,4 +66,11 @@ public class FunctionRunModel extends IntelliJFunctionContext {
         this.localSettingsJsonPath = localSettingsJsonPath;
     }
 
+    public int getFuncPort() {
+        return funcPort;
+    }
+
+    public void setFuncPort(int funcPort) {
+        this.funcPort = funcPort;
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunModel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunModel.java
@@ -7,7 +7,11 @@ package com.microsoft.azure.toolkit.intellij.legacy.function.runner.localrun;
 
 import com.intellij.packaging.artifacts.Artifact;
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.IntelliJFunctionContext;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 public class FunctionRunModel extends IntelliJFunctionContext {
 
     private Artifact artifact;
@@ -17,60 +21,4 @@ public class FunctionRunModel extends IntelliJFunctionContext {
     private String hostJsonPath;
     private String localSettingsJsonPath;
     private int funcPort;
-
-    public Artifact getArtifact() {
-        return artifact;
-    }
-
-    public void setArtifact(Artifact artifact) {
-        this.artifact = artifact;
-    }
-
-    public String getDebugOptions() {
-        return debugOptions;
-    }
-
-    public void setDebugOptions(String debugOptions) {
-        this.debugOptions = debugOptions;
-    }
-
-    public String getStagingFolder() {
-        return stagingFolder;
-    }
-
-    public void setStagingFolder(String stagingFolder) {
-        this.stagingFolder = stagingFolder;
-    }
-
-    public String getFuncPath() {
-        return funcPath;
-    }
-
-    public void setFuncPath(String funcPath) {
-        this.funcPath = funcPath;
-    }
-
-    public String getHostJsonPath() {
-        return hostJsonPath;
-    }
-
-    public void setHostJsonPath(String hostJsonPath) {
-        this.hostJsonPath = hostJsonPath;
-    }
-
-    public String getLocalSettingsJsonPath() {
-        return localSettingsJsonPath;
-    }
-
-    public void setLocalSettingsJsonPath(String localSettingsJsonPath) {
-        this.localSettingsJsonPath = localSettingsJsonPath;
-    }
-
-    public int getFuncPort() {
-        return funcPort;
-    }
-
-    public void setFuncPort(int funcPort) {
-        this.funcPort = funcPort;
-    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunState.java
@@ -13,6 +13,7 @@ import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.impl.RunManagerImpl;
 import com.intellij.execution.impl.RunnerAndConfigurationSettingsImpl;
+import com.intellij.execution.process.OSProcessUtil;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessOutputTypes;
@@ -389,7 +390,7 @@ public class FunctionRunState extends AzureRunProfileState<FunctionApp> {
 
     private static void stopProcessIfAlive(final Process proc) {
         if (proc != null && proc.isAlive()) {
-            proc.destroy();
+            OSProcessUtil.killProcessTree(proc);
         }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/ui/FunctionRunPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/ui/FunctionRunPanel.form
@@ -80,7 +80,7 @@
               <component id="bcdd" class="javax.swing.JTextField" binding="txtPort">
                 <constraints>
                   <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="1" indent="0" use-parent-layout="false">
-                    <preferred-size width="50" height="-1"/>
+                    <preferred-size width="60" height="-1"/>
                   </grid>
                 </constraints>
                 <properties/>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/ui/FunctionRunPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/ui/FunctionRunPanel.form
@@ -16,7 +16,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="6573" binding="settings" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="6573" binding="settings" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -34,10 +34,9 @@
               </component>
               <component id="a6210" class="com.microsoft.azure.toolkit.lib.legacy.function.FunctionCoreToolsCombobox" binding="txtFunc" custom-create="true">
                 <constraints>
-                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                    <preferred-size width="150" height="-1"/>
-                  </grid>
+                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
+                <properties/>
               </component>
               <component id="ae00f" class="javax.swing.JLabel">
                 <constraints>
@@ -57,19 +56,35 @@
               </component>
               <component id="fbdb1" class="javax.swing.JComboBox" binding="cbFunctionModule">
                 <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
               </component>
               <grid id="c7fd0" binding="pnlAppSettings" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
                 <children/>
               </grid>
+              <component id="238aa" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Port:"/>
+                </properties>
+              </component>
+              <component id="bcdd" class="javax.swing.JTextField" binding="txtPort">
+                <constraints>
+                  <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="50" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
             </children>
           </grid>
         </children>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/ui/FunctionRunPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/ui/FunctionRunPanel.java
@@ -15,18 +15,15 @@ import com.microsoft.azure.toolkit.intellij.legacy.function.runner.component.tab
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.component.table.AppSettingsTableUtils;
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.core.FunctionUtils;
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.localrun.FunctionRunConfiguration;
-import com.microsoft.azure.toolkit.lib.legacy.function.FunctionCoreToolsCombobox;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
+import com.microsoft.azure.toolkit.lib.legacy.function.FunctionCoreToolsCombobox;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.project.MavenProject;
 
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JPanel;
+import javax.swing.*;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,12 +32,13 @@ import java.util.UUID;
 import static com.microsoft.azure.toolkit.intellij.common.AzureBundle.message;
 
 public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration> {
-
+    private static final int DEFAULT_FUNC_PORT = 7071;
     private JPanel settings;
     private JPanel pnlMain;
     private FunctionCoreToolsCombobox txtFunc;
     private JPanel pnlAppSettings;
     private JComboBox<Module> cbFunctionModule;
+    private JTextField txtPort;
     private AppSettingsTable appSettingsTable;
     private String appSettingsKey = UUID.randomUUID().toString();
 
@@ -95,6 +93,8 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
                 break;
             }
         }
+        int funcPort = configuration.getFuncPort() <= 0 ? FunctionUtils.findFreePortForApi(DEFAULT_FUNC_PORT) : configuration.getFuncPort();
+        txtPort.setText(String.valueOf(funcPort));
     }
 
     @Override
@@ -105,6 +105,11 @@ public class FunctionRunPanel extends AzureSettingPanel<FunctionRunConfiguration
         // save app settings storage key instead of real value
         configuration.setAppSettings(Collections.EMPTY_MAP);
         configuration.setAppSettingsKey(appSettingsKey);
+        try {
+            configuration.setFuncPort(Integer.valueOf(txtPort.getText()));
+        } catch (final NumberFormatException e) {
+            configuration.setFuncPort(-1);
+        }
     }
 
     @NotNull

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/resources/com/microsoft/intellij/ui/messages/messages.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/resources/com/microsoft/intellij/ui/messages/messages.properties
@@ -1402,6 +1402,7 @@ function.run.configuration.title=Run Functions
 function.run.validate.noModule=Please specify module
 function.run.validate.noFuncPath=Please specify function cli path
 function.run.validate.invalidFuncPath=Please specify correct function cli path
+function.validate_run_configuration.invalidPort=Please specify valid port for func, which should between 0 and 65535
 function.run.hint.skipInstallExtensionHttp=Skip install Function extension for HTTP Trigger Functions
 function.run.hint.skipInstallExtensionBundle=Extension bundle specified, skip install extension
 function.run.hint.port=Using port : {0}


### PR DESCRIPTION
### Issue to resolve
Currently toolkit will detect free port for function core tools automatically during run functions locally, however, this did not works well in mac for two issues:
- Azure Functions local process not killed properly on Mac
- Logic to determine port is free did not work correctly

### What this PR do
- Support specify port for function core tools in function run configuration
- Migrate to use `OSProcessUtil` to kill `func` and its child process
- Fix logic to determine port, refers https://stackoverflow.com/questions/434718/sockets-discover-port-availability-using-java
- Add action to retry with free port when meet port in use issue during run function locally