### PR TITLE
[#1912357] Support opening files of AppService's file explorer in editor by double clicking.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/component/Tree.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/component/Tree.java
@@ -5,9 +5,14 @@
 
 package com.microsoft.azure.toolkit.intellij.common.component;
 
+import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.ActionPlaces;
 import com.intellij.openapi.actionSystem.ActionPopupMenu;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.DataProvider;
+import com.intellij.openapi.actionSystem.EmptyAction;
 import com.intellij.ui.AnimatedIcon;
 import com.intellij.ui.ComponentUtil;
 import com.intellij.ui.LoadingNode;
@@ -115,6 +120,10 @@ public class Tree extends SimpleTree implements DataProvider {
                             menu.setTargetComponent(tree);
                             menu.getComponent().show(tree, e.getX(), e.getY());
                         }
+                    } else if (e.getClickCount() == 2) {
+                        final DataContext context = DataManager.getInstance().getDataContext(tree);
+                        final AnActionEvent event = AnActionEvent.createFromAnAction(new EmptyAction(), e, ActionPlaces.UNKNOWN, context);
+                        ((TreeNode<?>) node).inner.doubleClick(event);
                     }
                 }
             }

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/file/AppServiceFileNode.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/file/AppServiceFileNode.java
@@ -58,8 +58,11 @@ public class AppServiceFileNode extends Node<AppServiceFile> {
         this.file = data;
         this.appService = data.getApp();
         final String actionGroupId = data.getType() == AppServiceFile.Type.DIRECTORY ?
-                AppServiceFileActionsContributor.APP_SERVICE_DIRECTORY_ACTIONS : AppServiceFileActionsContributor.APP_SERVICE_FILE_ACTIONS;
+            AppServiceFileActionsContributor.APP_SERVICE_DIRECTORY_ACTIONS : AppServiceFileActionsContributor.APP_SERVICE_FILE_ACTIONS;
         this.actions(actionGroupId);
+        if (data.getType() != AppServiceFile.Type.DIRECTORY) {
+            this.doubleClickAction(AppServiceFileActionsContributor.APP_SERVICE_FILE_VIEW);
+        }
         this.view(new AppServiceFileLabelView(data));
     }
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/Node.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/Node.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.toolkit.ide.common.component;
 
+import com.microsoft.azure.toolkit.lib.common.action.Action;
 import com.microsoft.azure.toolkit.lib.common.action.ActionGroup;
 import com.microsoft.azure.toolkit.lib.common.action.AzureActionManager;
 import lombok.AccessLevel;
@@ -39,6 +40,7 @@ public class Node<D> {
     @Nullable
     private ActionGroup actions;
     private int order;
+    private Action<D> doubleClickAction;
 
     public Node(@Nonnull D data) {
         this(data, null);
@@ -74,6 +76,17 @@ public class Node<D> {
 
     public boolean hasChildren() {
         return !this.childrenBuilders.isEmpty();
+    }
+
+    public void doubleClick(final Object event) {
+        if (this.doubleClickAction != null) {
+            this.doubleClickAction.handle(this.data, event);
+        }
+    }
+
+    public Node<D> doubleClickAction(Action.Id<D> actionId) {
+        this.doubleClickAction = AzureActionManager.getInstance().getAction(actionId);
+        return this;
     }
 
     public Node<D> actions(String groupId) {


### PR DESCRIPTION
[AB#1912357](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1912357): Support opening files of AppService's file explorer in editor by double clicking.