### PR TITLE
fix miscellaneous bugs related to Resource Management and inherited from last sprint.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/FunctionCoreToolsCombobox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/FunctionCoreToolsCombobox.java
@@ -50,11 +50,11 @@ public class FunctionCoreToolsCombobox extends AzureComboBox<String> {
     private static final int MAX_HISTORY_SIZE = 15;
     private final Set<String> funcCoreToolsPathList = new LinkedHashSet<>();
 
-    private Condition<? super VirtualFile> fileFilter;
-    private Project project;
+    private final Condition<? super VirtualFile> fileFilter;
+    private final Project project;
 
     private String lastSelected;
-    private boolean includeSettings;
+    private final boolean includeSettings;
     private boolean pendingOpenAzureSettings = false;
 
     public FunctionCoreToolsCombobox(Project project, boolean includeSettings) {
@@ -62,13 +62,8 @@ public class FunctionCoreToolsCombobox extends AzureComboBox<String> {
         this.project = project;
         this.includeSettings = includeSettings;
         final List<String> exePostfix = Arrays.asList("exe|bat|cmd|sh|bin|run".split("\\|"));
-        this.fileFilter = file ->
-            Comparing.equal(file.getNameWithoutExtension(), "func", file.isCaseSensitive())
-                && (file.getExtension() == null || exePostfix.contains(
-                file.isCaseSensitive() ? file.getExtension() : StringUtils.lowerCase(file.getExtension())
-            )
-
-            );
+        this.fileFilter = file -> Comparing.equal(file.getNameWithoutExtension(), "func", file.isCaseSensitive()) &&
+            (file.getExtension() == null || exePostfix.contains(file.isCaseSensitive() ? file.getExtension() : StringUtils.lowerCase(file.getExtension())));
         reset();
         if (includeSettings) {
             this.setRenderer(SimpleListCellRenderer.create((label, value, index) -> {
@@ -161,7 +156,7 @@ public class FunctionCoreToolsCombobox extends AzureComboBox<String> {
                 this.addItem(selectFile);
             }
             this.setSelectedItem(selectFile);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             AzureMessager.getMessager().error(e);
         }
     }
@@ -171,12 +166,12 @@ public class FunctionCoreToolsCombobox extends AzureComboBox<String> {
         final String history = propertiesComponent.getValue(AZURE_TOOLKIT_FUNCTION_CORE_TOOLS_HISTORY);
         if (history != null) {
             final String[] items = history.split("\n");
-            List<String> result = new ArrayList<>();
-            for (String item : items) {
+            final List<String> result = new ArrayList<>();
+            for (final String item : items) {
                 if (StringUtils.isNotBlank(item) && new File(item).exists()) {
                     try {
                         result.add(Paths.get(item).toRealPath().toString());
-                    } catch (Exception ignore) {
+                    } catch (final Exception ignore) {
                         // ignore since the history data is not important
                     }
                 }
@@ -188,9 +183,7 @@ public class FunctionCoreToolsCombobox extends AzureComboBox<String> {
 
     private void saveHistory() {
         final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance();
-        final List<String> subList = funcCoreToolsPathList.stream().skip(Math.max(funcCoreToolsPathList.size() - MAX_HISTORY_SIZE, 0))
-            .collect(Collectors.toList());
         propertiesComponent.setValue(AZURE_TOOLKIT_FUNCTION_CORE_TOOLS_HISTORY, StringUtils.join(
-            subList.toArray(), "\n"));
+            funcCoreToolsPathList.stream().skip(Math.max(funcCoreToolsPathList.size() - MAX_HISTORY_SIZE, 0)).toArray(), "\n"));
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/FunctionCoreToolsCombobox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/FunctionCoreToolsCombobox.java
@@ -64,7 +64,7 @@ public class FunctionCoreToolsCombobox extends AzureComboBox<String> {
         final List<String> exePostfix = Arrays.asList("exe|bat|cmd|sh|bin|run".split("\\|"));
         this.fileFilter = file -> Comparing.equal(file.getNameWithoutExtension(), "func", file.isCaseSensitive()) &&
             (file.getExtension() == null || exePostfix.contains(file.isCaseSensitive() ? file.getExtension() : StringUtils.lowerCase(file.getExtension())));
-        reset();
+        AzureTaskManager.getInstance().runOnPooledThread(this::reset);
         if (includeSettings) {
             this.setRenderer(SimpleListCellRenderer.create((label, value, index) -> {
                 label.setText(value);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/properties/AzResourcePropertiesEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/properties/AzResourcePropertiesEditor.java
@@ -44,13 +44,17 @@ public abstract class AzResourcePropertiesEditor<T extends AzResourceBase> exten
         final Object source = event.getSource();
         if (source instanceof AzResourceBase && ((AzResourceBase) source).getId().equals(this.resource.getId())) {
             if (StringUtils.equalsAnyIgnoreCase(((AzResourceBase) source).getStatus(), "deleted", "removed")) {
-                IntellijShowPropertiesViewAction.closePropertiesView(resource, project);
-                final String message = String.format("Close properties view of \"%s\" because the resource is deleted.", this.resource.getName());
-                AzureMessager.getMessager().warning(message);
+                onResourceDeleted();
             } else {
                 this.debouncer.debounce();
             }
         }
+    }
+
+    protected void onResourceDeleted() {
+        IntellijShowPropertiesViewAction.closePropertiesView(resource, project);
+        final String message = String.format("Close properties view of \"%s\" because the resource is deleted.", this.resource.getName());
+        AzureMessager.getMessager().warning(message);
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/explorer/RedisCacheExplorer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/explorer/RedisCacheExplorer.java
@@ -8,6 +8,8 @@ package com.microsoft.azure.toolkit.intellij.redis.explorer;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.microsoft.azure.toolkit.intellij.common.properties.AzResourcePropertiesEditor;
+import com.microsoft.azure.toolkit.intellij.common.properties.IntellijShowPropertiesViewAction;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import com.microsoft.azure.toolkit.redis.RedisCache;
 import org.apache.commons.lang3.tuple.Pair;
@@ -388,5 +390,12 @@ public class RedisCacheExplorer extends AzResourcePropertiesEditor<RedisCache> {
             default:
                 return null;
         }
+    }
+
+    @Override
+    protected void onResourceDeleted() {
+        IntellijShowPropertiesViewAction.closePropertiesView(this.redis, project);
+        final String message = String.format("Close redis cache explorer of \"%s\" because the resource is deleted.", this.redis.getName());
+        AzureMessager.getMessager().warning(message);
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.java
@@ -92,6 +92,17 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
         this.numCpu.addActionListener((e) -> debouncer.debounce());
         this.numMemory.addActionListener((e) -> debouncer.debounce());
         this.numInstance.addChangeListener((e) -> debouncer.debounce());
+
+        this.txtTestEndpoint.setVisible(false);
+        this.lblTestEndpoint.setVisible(false);
+        this.txtTestEndpoint.setHyperlinkTarget(null);
+        final DefaultComboBoxModel<Integer> numCpuModel = new DefaultComboBoxModel<>(new Integer[]{1});
+        final DefaultComboBoxModel<Integer> numMemoryModel = new DefaultComboBoxModel<>(new Integer[]{1, 2});
+        numCpuModel.setSelectedItem(1);
+        numMemoryModel.setSelectedItem(1);
+        this.numCpu.setModel(numCpuModel);
+        this.numMemory.setModel(numMemoryModel);
+
     }
 
     public void reset() {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
fix miscellaneous bugs

Does this close any currently open issues?
------------------------------------------
[AB#1913532](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1913532): [Test] Log isn't right after delete redis caches with redis exporer opening
[AB#1916304](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1916304): [github] Opening IntelliJ IDEA settings takes 60+ seconds with Azure Toolkit plug-in enabled
[AB#1896893](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1896893): [Test] One more "Test endpoint" in Create Spring Cloud app dialog
[AB#1911888](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1911888): [Test] vCPU and Memory have no default values when new a spring cloud app


Has this been tested?
---------------------------
- [ ] Tested
