### PR TITLE
#6382: error occurs when run a configuration with Azure resource connected but not signed in.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/appservice/actions/AppServiceFileAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/appservice/actions/AppServiceFileAction.java
@@ -38,6 +38,7 @@ import com.microsoft.azure.toolkit.lib.common.operation.AzureOperationBundle;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import lombok.SneakyThrows;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -92,6 +93,10 @@ public class AppServiceFileAction {
             }
             indicator.setText2("Loading file content");
             final String failure = String.format("Can not open file (%s). Try downloading it first and open it manually.", virtualFile.getName());
+            if (target.getSize() > 10 * FileUtils.ONE_MB) {
+                AzureTaskManager.getInstance().runLater(() -> Messages.showWarningDialog(failure, "Open File"));
+                return;
+            }
             appService
                     .getFileContent(file.getPath())
                     .doOnComplete(() -> AzureTaskManager.getInstance().runLater(() -> {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/runner/webappconfig/slimui/WebAppDeployConfigurationPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/runner/webappconfig/slimui/WebAppDeployConfigurationPanel.java
@@ -202,7 +202,7 @@ public class WebAppDeployConfigurationPanel extends JPanel implements AzureFormP
             chkDeployToSlot.setEnabled(true);
             Mono.fromCallable(() -> Azure.az(AzureWebApp.class).get(selectedWebApp.getResourceId()).deploymentSlots())
                     .subscribeOn(Schedulers.boundedElastic())
-                    .subscribe(slots -> fillDeploymentSlots(slots, selectedWebApp));
+                    .subscribe(slots -> AzureTaskManager.getInstance().runLater(()-> fillDeploymentSlots(slots, selectedWebApp)));
         }
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/runner/webappconfig/slimui/WebAppDeployConfigurationPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/runner/webappconfig/slimui/WebAppDeployConfigurationPanel.java
@@ -26,6 +26,7 @@ import com.microsoft.azure.toolkit.lib.appservice.model.Runtime;
 import com.microsoft.azure.toolkit.lib.appservice.model.WebContainer;
 import com.microsoft.azure.toolkit.lib.appservice.service.impl.WebAppDeploymentSlot;
 import com.microsoft.azure.toolkit.lib.common.form.AzureFormInput;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import com.microsoft.azuretools.core.mvp.model.webapp.AzureWebAppMvpModel;
 import com.microsoft.intellij.ui.util.UIUtils;
@@ -202,7 +203,7 @@ public class WebAppDeployConfigurationPanel extends JPanel implements AzureFormP
             chkDeployToSlot.setEnabled(true);
             Mono.fromCallable(() -> Azure.az(AzureWebApp.class).get(selectedWebApp.getResourceId()).deploymentSlots())
                     .subscribeOn(Schedulers.boundedElastic())
-                    .subscribe(slots -> AzureTaskManager.getInstance().runLater(()-> fillDeploymentSlots(slots, selectedWebApp)));
+                    .subscribe(slots -> AzureTaskManager.getInstance().runLater(()-> fillDeploymentSlots(slots, selectedWebApp), AzureTask.Modality.ANY));
         }
     }
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/resources/bundles/com/microsoft/azure/toolkit/operation.properties
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/resources/bundles/com/microsoft/azure/toolkit/operation.properties
@@ -202,7 +202,7 @@ connector.initialize_explorer=initialize Azure Resource Connector tool window
 connector.refresh_connections=refresh resource connections
 connector.remove_connection=remove resource connection
 connector.show_properties.explorer=show properties of connected Azure resource
-connector.prepare_before_run=prepare before run configuration
+connector.prepare_before_run=connect Azure resource before run configuration
 connector.update_database_password.database=update password of database ({0})
 
 container.open_portal.container=open registered container({0}) in portal


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
fixed 2 bugs:
> #6354: should update UI in dispatch thread.

use `AzureTaskManager.runLater` to call UI-update method.

> #6382: error occurs when run a configuration with Azure resource connected but not signed in.

catch the exception(so that the exception won't be caught by IDE's fallback exception handler and show a red dot at the bottom right) and show as an error notification message.
The cause would be highlighted on the notification. 

Does this close any currently open issues?
------------------------------------------
#6354: should update UI in dispatch thread.
#6382: error occurs when run a configuration with Azure resource connected but not signed in.

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
