### PR TITLE
bump up version of azure-toolkit-libs and azure-toolkit-ide-libs to prepare for 202202 release.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/META-INF/MANIFEST.MF
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/META-INF/MANIFEST.MF
@@ -54,4 +54,4 @@ Export-Package: com.microsoft.azuretools.appservice,
  com.microsoft.azuretools.appservice.handlers,
  com.microsoft.azuretools.appservice.ui
 Bundle-ClassPath: .,
- target/lib/azure-toolkit-ide-appservice-lib-0.17.0-SNAPSHOT.jar
+ target/lib/azure-toolkit-ide-appservice-lib-0.17.0.jar

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/pom.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-toolkit-ide-appservice-lib</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>0.17.0</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.springcloud/META-INF/MANIFEST.MF
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.springcloud/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
- target/lib/azure-toolkit-ide-springcloud-lib-0.17.0-SNAPSHOT.jar
+ target/lib/azure-toolkit-ide-springcloud-lib-0.17.0.jar
 Import-Package: com.microsoft.azuretools.core.actions,
  org.eclipse.core.expressions,
  org.eclipse.jface.text.hyperlink,

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.springcloud/pom.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.springcloud/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-toolkit-ide-springcloud-lib</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>0.17.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-arm/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-arm/build.gradle
@@ -3,7 +3,7 @@ intellij {
 
 dependencies {
     compile project(':azure-intellij-plugin-lib')
-    compile 'com.microsoft.azure:azure-toolkit-resource-lib:0.17.0-SNAPSHOT'
-    compile 'com.microsoft.azure:azure-toolkit-ide-common-lib:0.17.0-SNAPSHOT'
-    compile 'com.microsoft.azure:azure-toolkit-ide-arm-lib:0.17.0-SNAPSHOT'
+    compile 'com.microsoft.azure:azure-toolkit-resource-lib:0.17.0'
+    compile 'com.microsoft.azure:azure-toolkit-ide-common-lib:0.17.0'
+    compile 'com.microsoft.azure:azure-toolkit-ide-arm-lib:0.17.0'
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "io.freefair.aspectj.post-compile-weaving" version "6.0.0-m2"
 }
 ext {
-    azureToolkitVersion = "0.17.0-SNAPSHOT"
+    azureToolkitVersion = "0.17.0"
 }
 group 'com.microsoft.azure.toolkit'
 apply plugin: 'java'
@@ -75,7 +75,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'io.freefair.aspectj.post-compile-weaving'
     ext {
-        azureToolkitVersion = "0.17.0-SNAPSHOT"
+        azureToolkitVersion = "0.17.0"
     }
 
     sourceCompatibility = javaVersion

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/build.gradle
@@ -4,9 +4,9 @@ intellij {
 dependencies {
     compile project(':azure-intellij-plugin-lib')
     compile project(':azure-intellij-resource-connector-lib')
-    compile 'com.microsoft.azure:azure-toolkit-resource-lib:0.17.0-SNAPSHOT'
-    compile 'com.microsoft.azure:azure-toolkit-redis-lib:0.17.0-SNAPSHOT'
-    compile 'com.microsoft.azure:azure-toolkit-ide-common-lib:0.17.0-SNAPSHOT'
-    compile 'com.microsoft.azure:azure-toolkit-ide-redis-lib:0.17.0-SNAPSHOT'
+    compile 'com.microsoft.azure:azure-toolkit-resource-lib:0.17.0'
+    compile 'com.microsoft.azure:azure-toolkit-redis-lib:0.17.0'
+    compile 'com.microsoft.azure:azure-toolkit-ide-common-lib:0.17.0'
+    compile 'com.microsoft.azure:azure-toolkit-ide-redis-lib:0.17.0'
     compile 'redis.clients:jedis:3.6.3'
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     implementation project(":azure-intellij-plugin-lib")
 
     implementation 'com.microsoft.graph:microsoft-graph:3.7.0'
-    implementation "com.microsoft.azure:azure-toolkit-auth-lib:0.17.0-SNAPSHOT"
+    implementation "com.microsoft.azure:azure-toolkit-auth-lib:0.17.0"
     implementation "com.azure.resourcemanager:azure-resourcemanager-authorization:2.5.0"
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 ext {
-    azureToolkitVersion = "0.17.0-SNAPSHOT"
+    azureToolkitVersion = "0.17.0"
 }
 
 compileKotlin {
@@ -82,7 +82,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'io.freefair.aspectj.post-compile-weaving'
     ext {
-        azureToolkitVersion = "0.17.0-SNAPSHOT"
+        azureToolkitVersion = "0.17.0"
     }
 
     sourceCompatibility = javaVersion

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-arm-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-arm-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-database-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-database-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-redis-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-redis-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-springcloud-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-springcloud-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-storage-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-storage-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-vm-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-vm-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>0.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-ide-libs</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>0.17.0</version>
     <packaging>pom</packaging>
     <name>Libs for Azure Toolkit for IDEs</name>
     <description>Wrapped libs of Microsoft Azure Toolkits for IDEs</description>
@@ -48,7 +48,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <azure.toolkit-lib.version>0.17.0-SNAPSHOT</azure.toolkit-lib.version>
+        <azure.toolkit-lib.version>0.17.0</azure.toolkit-lib.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/Utils/azuretools-core/pom.xml
+++ b/Utils/azuretools-core/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <artifact.name>${project.artifactId}-${project.version}.jar</artifact.name>
         <checkstyle.skip>true</checkstyle.skip>
-        <azure-toolkit-ide-common-lib.version>0.17.0-SNAPSHOT</azure-toolkit-ide-common-lib.version>
+        <azure-toolkit-ide-common-lib.version>0.17.0</azure-toolkit-ide-common-lib.version>
     </properties>
     <profiles>
         <profile>

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -48,8 +48,8 @@
         <mockito.version>2.22.0</mockito.version>
         <powermock.version>1.7.0RC4</powermock.version>
         <rx.version>1.3.8</rx.version>
-        <azure.toolkit-lib.version>0.17.0-SNAPSHOT</azure.toolkit-lib.version>
-        <azure.toolkit-ide-lib.version>0.17.0-SNAPSHOT</azure.toolkit-ide-lib.version>
+        <azure.toolkit-lib.version>0.17.0</azure.toolkit-lib.version>
+        <azure.toolkit-ide-lib.version>0.17.0</azure.toolkit-ide-lib.version>
         <powermock.version>2.0.9</powermock.version>
         <jetty.version>9.4.40.v20210413</jetty.version>
     </properties>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
remove `SNAPSHOT` from the version number of `azure-toolkit-libs` and `azure-toolkit-ide-libs`

Does this close any currently open issues?
------------------------------------------
N/P

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/P

Has this been tested?
---------------------------
- [ ] Tested
