### PR TITLE
IllegalArgumentException when switching subscriptions

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
@@ -47,6 +47,7 @@ import javax.swing.table.TableColumn;
 import java.awt.*;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -135,12 +136,8 @@ public class SubscriptionsDialog extends AzureDialogWrapper {
 
     private void setSubscriptions() {
         DefaultTableModel model = (DefaultTableModel) table.getModel();
-        sdl.sort((sub1, sub2) -> {
-            if (sub1.isSelected() != sub2.isSelected()) {
-                return sub1.isSelected() ? -1 : 0;
-            }
-            return StringUtils.compareIgnoreCase(sub1.getSubscriptionName(), sub2.getSubscriptionName());
-        });
+        sdl.sort((sub1, sub2) -> StringUtils.compareIgnoreCase(sub1.getSubscriptionName(), sub2.getSubscriptionName()));
+        sdl.sort(Comparator.comparing(SubscriptionDetail::isSelected));
         for (SubscriptionDetail sd : sdl) {
             model.addRow(new Object[]{sd.isSelected(), sd.getSubscriptionName(), sd.getSubscriptionId()});
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
@@ -38,8 +38,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableModel;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
the buggy implementation of comparator breaks the `transitivity`

Does this close any currently open issues?
------------------------------------------
[AB#1921654](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1921654): IllegalArgumentException when switching subscriptions


Has this been tested?
---------------------------
- [ ] Tested
