### PR TITLE
bump version of utils and intellij plugin to 3.62.0

### DIFF
--- a/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml
+++ b/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>com.microsoft.azuretools</groupId>
     <artifactId>utils</artifactId>
-    <version>3.62.0-SNAPSHOT</version>
+    <version>3.62.0</version>
   </parent>
   <groupId>com.microsoft.azuretools</groupId>
   <artifactId>com.microsoft.azuretools.sdk.lib</artifactId>
@@ -39,7 +39,7 @@
   </organization>
 
   <properties>
-    <azuretool.version>3.62.0-SNAPSHOT</azuretool.version>
+    <azuretool.version>3.62.0</azuretool.version>
     <azuretool.sdk.version>3.31.0.qualifier</azuretool.sdk.version>
   </properties>
   <dependencies>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
              xmlns:xi="http://www.w3.org/2001/XInclude">
   <id>com.microsoft.tooling.msservices.intellij.azure</id>
   <name>Azure Toolkit</name>
-  <version>3.62.0-SNAPSHOT</version>
+  <version>3.62.0</version>
   <vendor email="java@microsoft.com" url="http://www.microsoft.com">Microsoft</vendor>
 
   <description>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/build.gradle
@@ -15,13 +15,13 @@ dependencies {
     compile group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '9.3.1.jre8-preview'
 
     // TODO(andxu): remove the legacy dependencies
-    compile 'com.microsoft.azuretools:azuretools-core:3.62.0-SNAPSHOT', {
+    compile 'com.microsoft.azuretools:azuretools-core:3.62.0', {
         exclude group: "com.microsoft.azure", module: "azure-client-authentication"
         exclude group: "com.microsoft.azure", module: "azure-client-runtime"
         exclude group: "javax.xml.bind", module: "jaxb-api"
     }
 
-    compile 'com.microsoft.azuretools:azure-explorer-common:3.62.0-SNAPSHOT', {
+    compile 'com.microsoft.azuretools:azure-explorer-common:3.62.0', {
         exclude group: "com.microsoft.azure", module: "azure-client-authentication"
         exclude group: "com.microsoft.azure", module: "azure-client-runtime"
         exclude group: "javax.xml.bind", module: "jaxb-api"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -204,17 +204,17 @@ dependencies {
         exclude group: "com.squareup.okhttp3", module: "logging-interceptor"
     }
 
-    compile 'com.microsoft.azuretools:azuretools-core:3.62.0-SNAPSHOT', {
+    compile 'com.microsoft.azuretools:azuretools-core:3.62.0', {
         exclude group: "com.microsoft.azure", module: "azure-client-authentication"
         exclude group: "com.microsoft.azure", module: "azure-client-runtime"
         exclude group: "javax.xml.bind", module: "jaxb-api"
     }
-    compile 'com.microsoft.azuretools:azure-explorer-common:3.62.0-SNAPSHOT', {
+    compile 'com.microsoft.azuretools:azure-explorer-common:3.62.0', {
         exclude group: "com.microsoft.azure", module: "azure-client-authentication"
         exclude group: "com.microsoft.azure", module: "azure-client-runtime"
         exclude group: "javax.xml.bind", module: "jaxb-api"
     }
-    compile 'com.microsoft.azuretools:hdinsight-node-common:3.62.0-SNAPSHOT', {
+    compile 'com.microsoft.azuretools:hdinsight-node-common:3.62.0', {
         exclude group: "com.microsoft.azure", module: "azure-client-authentication"
         exclude group: "com.microsoft.azure", module: "azure-client-runtime"
         exclude group: "javax.xml.bind", module: "jaxb-api"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
              xmlns:xi="http://www.w3.org/2001/XInclude">
   <id>com.microsoft.tooling.msservices.intellij.azure</id>
   <name>Azure Toolkit for IntelliJ</name>
-  <version>3.62.0-SNAPSHOT</version>
+  <version>3.62.0</version>
   <vendor email="java@microsoft.com" url="http://www.microsoft.com">Microsoft</vendor>
 
   <description><![CDATA[

--- a/Utils/azure-explorer-common/pom.xml
+++ b/Utils/azure-explorer-common/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../pom.xml</relativePath>
         <groupId>com.microsoft.azuretools</groupId>
         <artifactId>utils</artifactId>
-        <version>3.62.0-SNAPSHOT</version>
+        <version>3.62.0</version>
     </parent>
     <artifactId>azure-explorer-common</artifactId>
     <properties>

--- a/Utils/azuretools-core/pom.xml
+++ b/Utils/azuretools-core/pom.xml
@@ -29,7 +29,7 @@
         <relativePath>../pom.xml</relativePath>
         <groupId>com.microsoft.azuretools</groupId>
         <artifactId>utils</artifactId>
-        <version>3.62.0-SNAPSHOT</version>
+        <version>3.62.0</version>
     </parent>
     <artifactId>azuretools-core</artifactId>
     <properties>

--- a/Utils/hdinsight-node-common/pom.xml
+++ b/Utils/hdinsight-node-common/pom.xml
@@ -4,7 +4,7 @@
         <relativePath>../pom.xml</relativePath>
         <groupId>com.microsoft.azuretools</groupId>
         <artifactId>utils</artifactId>
-        <version>3.62.0-SNAPSHOT</version>
+        <version>3.62.0</version>
     </parent>
     <artifactId>hdinsight-node-common</artifactId>
     <properties>

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -27,11 +27,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azuretools</groupId>
     <artifactId>utils</artifactId>
-    <version>3.62.0-SNAPSHOT</version>
+    <version>3.62.0</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}-${project.version}</name>
     <properties>
-        <azuretool.version>3.62.0-SNAPSHOT</azuretool.version>
+        <azuretool.version>3.62.0</azuretool.version>
         <azure.version>1.41.2</azure.version>
         <kotlin.version>1.3.72</kotlin.version>
         <kotlin.jvmTargetVersion>1.8</kotlin.jvmTargetVersion>

--- a/Utils/spark-localrun-mock/pom.xml
+++ b/Utils/spark-localrun-mock/pom.xml
@@ -4,7 +4,7 @@
         <relativePath>../pom.xml</relativePath>
         <groupId>com.microsoft.azuretools</groupId>
         <artifactId>utils</artifactId>
-        <version>3.62.0-SNAPSHOT</version>
+        <version>3.62.0</version>
     </parent>
     <groupId>com.microsoft.azuretools</groupId>
     <artifactId>spark-localrun-mock</artifactId>

--- a/Utils/spark-tools/pom.xml
+++ b/Utils/spark-tools/pom.xml
@@ -4,7 +4,7 @@
         <relativePath>../pom.xml</relativePath>
         <groupId>com.microsoft.azuretools</groupId>
         <artifactId>utils</artifactId>
-        <version>3.62.0-SNAPSHOT</version>
+        <version>3.62.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spark-tools</artifactId>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
remove `SNAPSHOT` from version number of intellij plugin and utils.

Has this been tested?
---------------------------
- [ ] Tested
