### PR TITLE
Fix new HDInsight project option is missing in EAP 2022.1 issue

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/hdinsight/projects/HDInsightModuleBuilder.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/hdinsight/projects/HDInsightModuleBuilder.java
@@ -5,8 +5,6 @@
 
 package com.microsoft.azure.hdinsight.projects;
 
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.HDINSIGHT;
-
 import com.intellij.ide.util.projectWizard.*;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.module.ModifiableModuleModel;
@@ -36,10 +34,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.*;
+
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.HDINSIGHT;
 
 public class HDInsightModuleBuilder extends JavaModuleBuilder implements ModuleBuilderListener {
     private HDInsightProjectTemplate selectedTemplate;
@@ -125,7 +126,7 @@ public class HDInsightModuleBuilder extends JavaModuleBuilder implements ModuleB
     @Override
     public void moduleCreated(@NotNull Module module) {
         Artifact artifact = createDefaultArtifact(module);
-        switch(this.selectedExternalSystem) {
+        switch (this.selectedExternalSystem) {
             case MAVEN:
                 new MavenProjectGenerator(module, this.selectedTemplate.getTemplateType(), sparkVersion)
                         .generate()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/hdinsight/projects/HDInsightModuleBuilder.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/hdinsight/projects/HDInsightModuleBuilder.java
@@ -56,6 +56,11 @@ public class HDInsightModuleBuilder extends JavaModuleBuilder implements ModuleB
     }
 
     @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
     public String getBuilderId() {
         return "HDInsight";
     }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix the following option is missing issue
![image](https://user-images.githubusercontent.com/32627233/155490153-85dbbca2-6ace-49ed-9325-24586a3b68fc.png)



Does this close any currently open issues?
------------------------------------------
N/A


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Has this been tested?
---------------------------
- [ ] Tested
