### PR TITLE
user standard netty-handler instead of redhat's

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
@@ -47,6 +47,7 @@ import javax.swing.table.TableColumn;
 import java.awt.*;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -135,12 +136,8 @@ public class SubscriptionsDialog extends AzureDialogWrapper {
 
     private void setSubscriptions() {
         DefaultTableModel model = (DefaultTableModel) table.getModel();
-        sdl.sort((sub1, sub2) -> {
-            if (sub1.isSelected() != sub2.isSelected()) {
-                return sub1.isSelected() ? -1 : 0;
-            }
-            return StringUtils.compareIgnoreCase(sub1.getSubscriptionName(), sub2.getSubscriptionName());
-        });
+        sdl.sort((sub1, sub2) -> StringUtils.compareIgnoreCase(sub1.getSubscriptionName(), sub2.getSubscriptionName()));
+        sdl.sort(Comparator.comparing(SubscriptionDetail::isSelected));
         for (SubscriptionDetail sd : sdl) {
             model.addRow(new Object[]{sd.isSelected(), sd.getSubscriptionName(), sd.getSubscriptionId()});
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
@@ -38,8 +38,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableModel;

--- a/Utils/AzureAuthenticationFilter/build.gradle
+++ b/Utils/AzureAuthenticationFilter/build.gradle
@@ -26,7 +26,7 @@ install {
 }
 
 dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.18'
+    compile 'org.slf4j:slf4j-api:1.7.32'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.0'
     compile 'javax:javaee-api:6.0'
     compile 'commons-codec:commons-codec:1.10'

--- a/Utils/AzureWebApplication/build.gradle
+++ b/Utils/AzureWebApplication/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile 'org.springframework.session:spring-session-data-redis:1.1.1.RELEASE'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.0'
     compile 'commons-codec:commons-codec:1.10'
-    compile 'org.slf4j:slf4j-api:1.7.18'
+    compile 'org.slf4j:slf4j-api:1.7.32'
     compile 'com-microsoft-azure:azure-oidc:1.0.0'
     providedCompile 'javax:javaee-api:6.0'
 }

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/pom.xml
@@ -24,13 +24,5 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/Utils/hdinsight-node-common/pom.xml
+++ b/Utils/hdinsight-node-common/pom.xml
@@ -456,10 +456,5 @@
             <artifactId>spark-localrun-mock</artifactId>
             <version>0.1.1</version>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>4.1.68.Final-redhat-00001</version>
-        </dependency>
     </dependencies>
 </project>

--- a/Utils/hdinsight-node-common/pom.xml
+++ b/Utils/hdinsight-node-common/pom.xml
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.33</version>
+            <version>1.7.32</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -235,19 +235,6 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>Redhat GA</id>
-            <name>Redhat GA Repository</name>
-            <url>https://maven.repository.redhat.com/ga/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/Utils/spark-localrun-mock/pom.xml
+++ b/Utils/spark-localrun-mock/pom.xml
@@ -329,10 +329,5 @@
             <artifactId>xml-apis</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>4.1.68.Final-redhat-00001</version>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
remove dependency on `io.netty:netty-handler:4.1.68.Final-redhat-00001` and use standard `io.netty:netty-handler:4.1.70.Final`


Has this been tested?
---------------------------
- [ ] Tested
