### PR TITLE
redis explorer is not closed automatically after resource is deleted.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/properties/AzResourcePropertiesEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/properties/AzResourcePropertiesEditor.java
@@ -23,11 +23,13 @@ public abstract class AzResourcePropertiesEditor<T extends AzResourceBase> exten
     private final T resource;
     private final TailingDebouncer debouncer;
     protected final Project project;
+    protected final AzureResourceEditorViewManager manager;
 
     public AzResourcePropertiesEditor(@Nonnull final VirtualFile virtualFile, @Nonnull T resource, @Nonnull final Project project) {
         super(virtualFile);
         this.resource = resource;
         this.project = project;
+        this.manager = virtualFile.getUserData(AzureResourceEditorViewManager.AZURE_RESOURCE_EDITOR_MANAGER_KEY);
         this.listener = new AzureEventBus.EventListener<>(this::onEvent);
         AzureEventBus.on("resource.status_changed.resource", listener);
         this.debouncer = new TailingDebouncer(this::rerender, 500);
@@ -52,7 +54,7 @@ public abstract class AzResourcePropertiesEditor<T extends AzResourceBase> exten
     }
 
     protected void onResourceDeleted() {
-        IntellijShowPropertiesViewAction.closePropertiesView(resource, project);
+        this.manager.closeEditor(resource, project);
         final String message = String.format("Close properties view of \"%s\" because the resource is deleted.", this.resource.getName());
         AzureMessager.getMessager().warning(message);
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/properties/AzureResourceEditorViewManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/properties/AzureResourceEditorViewManager.java
@@ -29,6 +29,7 @@ public class AzureResourceEditorViewManager {
     private static final String UNABLE_TO_OPEN_EDITOR_WINDOW = "Unable to open new editor window";
     private static final String CANNOT_GET_FILE_EDITOR_MANAGER = "Cannot get FileEditorManager";
     public static final Key<AzResourceBase> AZURE_RESOURCE_KEY = new Key<>("AzureResource");
+    public static final Key<AzureResourceEditorViewManager> AZURE_RESOURCE_EDITOR_MANAGER_KEY = new Key<>("AzureResourceEditorManager");
     private final Function<AzResourceBase, FileType> getFileType;
 
     public void showEditor(@Nonnull AzResourceBase resource, @Nonnull Project project) {
@@ -43,6 +44,7 @@ public class AzureResourceEditorViewManager {
             itemVirtualFile.setFileType(getFileType.apply(resource));
         }
         itemVirtualFile.putUserData(AZURE_RESOURCE_KEY, resource);
+        itemVirtualFile.putUserData(AZURE_RESOURCE_EDITOR_MANAGER_KEY, this);
         AzureTaskManager.getInstance().runLater(() -> manager.openFile(itemVirtualFile, true, true));
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/explorer/RedisCacheExplorer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/explorer/RedisCacheExplorer.java
@@ -394,7 +394,7 @@ public class RedisCacheExplorer extends AzResourcePropertiesEditor<RedisCache> {
 
     @Override
     protected void onResourceDeleted() {
-        IntellijShowPropertiesViewAction.closePropertiesView(this.redis, project);
+        this.manager.closeEditor(this.redis, project);
         final String message = String.format("Close redis cache explorer of \"%s\" because the resource is deleted.", this.redis.getName());
         AzureMessager.getMessager().warning(message);
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/explorer/RedisCacheExplorer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/explorer/RedisCacheExplorer.java
@@ -8,7 +8,6 @@ package com.microsoft.azure.toolkit.intellij.redis.explorer;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.microsoft.azure.toolkit.intellij.common.properties.AzResourcePropertiesEditor;
-import com.microsoft.azure.toolkit.intellij.common.properties.IntellijShowPropertiesViewAction;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import com.microsoft.azure.toolkit.redis.RedisCache;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
the problem is RedisExplorer is not a normal properties editor, it can not be closed as properties editor.


Does this close any currently open issues?
------------------------------------------
[AB#1919439](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1919439): [Test] Exception during deleting redis caches with redis explorer opening

Has this been tested?
---------------------------
- [ ] Tested
