### PR TITLE
Fix dependencies for gradle function project

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunState.java
@@ -11,7 +11,6 @@ import com.intellij.execution.ExecutorRegistry;
 import com.intellij.execution.ProgramRunnerUtil;
 import com.intellij.execution.RunManagerEx;
 import com.intellij.execution.RunnerAndConfigurationSettings;
-import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.impl.RunManagerImpl;
@@ -106,14 +105,12 @@ public class FunctionRunState extends AzureRunProfileState<Boolean> {
     private void launchDebugger(final Project project, int debugPort) {
         final Runnable runnable = () -> {
             final RunManagerImpl manager = new RunManagerImpl(project);
-            final ConfigurationFactory configFactory = RemoteConfigurationType.getInstance().getConfigurationFactories()[0];
-            final RemoteConfiguration remoteConfig = new RemoteConfiguration(project, configFactory);
+            final RemoteConfiguration remoteConfig = (RemoteConfiguration) RemoteConfigurationType.getInstance().createTemplateConfiguration(project);
             remoteConfig.PORT = String.valueOf(debugPort);
             remoteConfig.HOST = "localhost";
             remoteConfig.USE_SOCKET_TRANSPORT = true;
             remoteConfig.SERVER_MODE = false;
             remoteConfig.setName("azure functions");
-
             final RunnerAndConfigurationSettings configuration = new RunnerAndConfigurationSettingsImpl(manager, remoteConfig, false);
             manager.setTemporaryConfiguration(configuration);
             ExecutionUtil.runConfiguration(configuration, ExecutorRegistry.getInstance().getExecutorById(ToolWindowId.DEBUG));


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
We used to use `ExternalProjectDataCache.getRootExternalProject` to get gradle function project module and get its dependencies for local run and deploy, however, this did not works for function in gradle inter-module. To solve this issue, this PR will list sub modules of current project and get correspond `ExternalProject` for target inter-moudle, this PR also fix the method to get artifact for gradle project dependency.

Does this close any currently open issues?
------------------------------------------
fixes #6376

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Has this been tested?
---------------------------
- [x] Tested
