### PR TITLE
Fix linked cluster not shown in HDInsight nodes issue

### DIFF
--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/RefreshableNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/RefreshableNode.java
@@ -69,6 +69,12 @@ public abstract class RefreshableNode extends Node {
         }
     }
 
+    // Sub-classes are expected to override this method if they wish to refresh items when user
+    // doesn't sign in. By default, we disable node refresh when user doesn't sign in.
+    protected boolean refreshEnabledWhenNotSignIn() {
+        return false;
+    }
+
     // Sub-classes are expected to override this method if they wish to
     // refresh items synchronously. The default implementation does nothing.
     protected abstract void refreshItems() throws AzureCmdException;
@@ -82,7 +88,9 @@ public abstract class RefreshableNode extends Node {
             setLoading(true);
             try {
                 removeAllChildNodes();
-                if (AuthMethodManager.getInstance().isSignedIn() || this instanceof AzureModule) {
+                if (AuthMethodManager.getInstance().isSignedIn()
+                        || this instanceof AzureModule
+                        || refreshEnabledWhenNotSignIn()) {
                     if (forceRefresh) {
                         refreshFromAzure();
                     }

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/HDInsightRootModuleImpl.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/HDInsightRootModuleImpl.java
@@ -47,6 +47,13 @@ public class HDInsightRootModuleImpl extends HDInsightRootModule {
     }
 
     @Override
+    protected boolean refreshEnabledWhenNotSignIn() {
+        // HDInsight cluster users should be accessible to their linked clusters
+        // when not sign in their Azure accounts
+        return true;
+    }
+
+    @Override
     protected void refreshItems() throws AzureCmdException {
         synchronized (this) {
             ClusterManagerEx.getInstance().getCachedClusters().stream()

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterModule.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/sqlbigdata/serverexplore/SqlBigDataClusterModule.java
@@ -37,6 +37,13 @@ public class SqlBigDataClusterModule extends RefreshableNode implements ILogger 
     }
 
     @Override
+    protected boolean refreshEnabledWhenNotSignIn() {
+        // SQL Server big data cluster user should be accessible to their linked clusters
+        // when not sign in their Azure accounts
+        return true;
+    }
+
+    @Override
     protected void refreshItems() throws AzureCmdException {
         synchronized (this) {
             List<IClusterDetail> clusterDetailList = ClusterManagerEx.getInstance().getClusterDetails().stream()


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This is to fix the bug found in the test. Repro steps of the bug:
1. Not sign in Azure account
2. Link an HDInsight cluster
3. After the cluster is linked, the cluster node is not shown automatically under the HDInsight root node. Even if we force refresh the HDInsight root node, the cluster is still not shown.
4. Sign in Azure account, we can find now the cluster is showing under HDInsight root node.


Does this close any currently open issues?
------------------------------------------
N/A


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Has this been tested?
---------------------------
- [ ] Tested
