### PR TITLE
Link and import after create a function Gradle project

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/wizard/module/FunctionsModuleInfoStep.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/wizard/module/FunctionsModuleInfoStep.java
@@ -26,8 +26,8 @@ import java.util.function.Predicate;
 
 @Slf4j
 public class FunctionsModuleInfoStep extends ModuleWizardStep implements Disposable {
-    private static final String MAVEN_TOOL = "Maven";
-    private static final String GRADLE_TOOL = "Gradle";
+    public static final String MAVEN_TOOL = "Maven";
+    public static final String GRADLE_TOOL = "Gradle";
 
     private JPanel panel;
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/resources/azurefunction/templates/project/build_gradle.template
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/resources/azurefunction/templates/project/build_gradle.template
@@ -1,5 +1,5 @@
 plugins {
-  id "com.microsoft.azure.azurefunctions" version "1.8.2"
+    id "com.microsoft.azure.azurefunctions" version "1.8.2"
 }
 apply plugin: "java"
 
@@ -7,9 +7,9 @@ group '$(groupId)'
 version '$(version)'
 
 dependencies {
-  implementation 'com.microsoft.azure.functions:azure-functions-java-library:1.4.2'
-  testCompile 'org.mockito:mockito-core:2.23.4'
-  testCompile 'org.junit.jupiter:junit-jupiter-api:5.4.2'
+    implementation 'com.microsoft.azure.functions:azure-functions-java-library:1.4.2'
+    testImplementation 'org.mockito:mockito-core:2.23.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
 }
 
 sourceCompatibility = '1.8'


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Currently we just create the project but did not import it after create a gradle function project, this PR will trigger IntelliJ to link and import the project after creation.


Does this close any currently open issues?
------------------------------------------
#6377

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
`FunctionsModuleBuilder` did not handle the difference of module and project, we may need refactor and resolve this issue in our later release.

Has this been tested?
---------------------------
- [x] Tested
