### PR TITLE
bumpup version of azure-toolkit-libs to `0.19.0-SNAPSHOT`

### DIFF
--- a/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml
+++ b/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml
@@ -41,7 +41,7 @@
   <properties>
     <azuretool.version>3.63.0-SNAPSHOT</azuretool.version>
     <azuretool.sdk.version>3.31.0.qualifier</azuretool.sdk.version>
-    <azure.toolkit-lib.version>0.18.0-SNAPSHOT</azure.toolkit-lib.version>
+    <azure.toolkit-lib.version>0.19.0-SNAPSHOT</azure.toolkit-lib.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/META-INF/MANIFEST.MF
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/META-INF/MANIFEST.MF
@@ -54,4 +54,4 @@ Export-Package: com.microsoft.azuretools.appservice,
  com.microsoft.azuretools.appservice.handlers,
  com.microsoft.azuretools.appservice.ui
 Bundle-ClassPath: .,
- target/lib/azure-toolkit-ide-appservice-lib-0.18.0-SNAPSHOT.jar
+ target/lib/azure-toolkit-ide-appservice-lib-0.19.0-SNAPSHOT.jar

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/pom.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.appservice/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-toolkit-ide-appservice-lib</artifactId>
-      <version>0.18.0-SNAPSHOT</version>
+      <version>0.19.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.springcloud/META-INF/MANIFEST.MF
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.springcloud/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
- target/lib/azure-toolkit-ide-springcloud-lib-0.18.0-SNAPSHOT.jar
+ target/lib/azure-toolkit-ide-springcloud-lib-0.19.0-SNAPSHOT.jar
 Import-Package: com.microsoft.azuretools.core.actions,
  org.eclipse.core.expressions,
  org.eclipse.jface.text.hyperlink,

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.springcloud/pom.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.springcloud/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-toolkit-ide-springcloud-lib</artifactId>
-      <version>0.18.0-SNAPSHOT</version>
+      <version>0.19.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "io.freefair.aspectj.post-compile-weaving" version "6.0.0-m2"
 }
 ext {
-    azureToolkitVersion = "0.18.0-SNAPSHOT"
+    azureToolkitVersion = "0.19.0-SNAPSHOT"
 }
 group 'com.microsoft.azure.toolkit'
 apply plugin: 'java'
@@ -75,7 +75,7 @@ subprojects {
     apply plugin: 'io.freefair.aspectj.post-compile-weaving'
     apply plugin: 'io.spring.dependency-management'
     ext {
-        azureToolkitVersion = "0.18.0-SNAPSHOT"
+        azureToolkitVersion = "0.19.0-SNAPSHOT"
     }
 
     sourceCompatibility = javaVersion

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 ext {
-    azureToolkitVersion = "0.18.0-SNAPSHOT"
+    azureToolkitVersion = "0.19.0-SNAPSHOT"
 }
 
 compileKotlin {
@@ -83,7 +83,7 @@ subprojects {
     apply plugin: 'io.freefair.aspectj.post-compile-weaving'
     apply plugin: 'io.spring.dependency-management'
     ext {
-        azureToolkitVersion = "0.18.0-SNAPSHOT"
+        azureToolkitVersion = "0.19.0-SNAPSHOT"
     }
 
     sourceCompatibility = javaVersion

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.19.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-arm-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-arm-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.19.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.19.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-database-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-database-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.19.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-redis-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-redis-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.19.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-springcloud-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-springcloud-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.19.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-storage-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-storage-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.19.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-vm-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-vm-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-ide-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.19.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Utils/azure-toolkit-ide-libs/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-ide-libs</artifactId>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.19.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Libs for Azure Toolkit for IDEs</name>
     <description>Wrapped libs of Microsoft Azure Toolkits for IDEs</description>
@@ -48,7 +48,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <azure.toolkit-lib.version>0.18.0-SNAPSHOT</azure.toolkit-lib.version>
+        <azure.toolkit-lib.version>0.19.0-SNAPSHOT</azure.toolkit-lib.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/Utils/azuretools-core/pom.xml
+++ b/Utils/azuretools-core/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <artifact.name>${project.artifactId}-${project.version}.jar</artifact.name>
         <checkstyle.skip>true</checkstyle.skip>
-        <azure-toolkit-ide-common-lib.version>0.18.0-SNAPSHOT</azure-toolkit-ide-common-lib.version>
+        <azure-toolkit-ide-common-lib.version>0.19.0-SNAPSHOT</azure-toolkit-ide-common-lib.version>
     </properties>
     <profiles>
         <profile>

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -37,8 +37,8 @@
         <kotlin.jvmTargetVersion>1.8</kotlin.jvmTargetVersion>
         <findsecbugs.version>1.11.0</findsecbugs.version>
         <rx.version>1.3.8</rx.version>
-        <azure.toolkit-lib.version>0.18.0-SNAPSHOT</azure.toolkit-lib.version>
-        <azure.toolkit-ide-lib.version>0.18.0-SNAPSHOT</azure.toolkit-ide-lib.version>
+        <azure.toolkit-lib.version>0.19.0-SNAPSHOT</azure.toolkit-lib.version>
+        <azure.toolkit-ide-lib.version>0.19.0-SNAPSHOT</azure.toolkit-ide-lib.version>
         <powermock.version>2.0.9</powermock.version>
         <jetty.version>9.4.40.v20210413</jetty.version>
     </properties>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
bumpup version of azure-toolkit-libs to `0.19.0-SNAPSHOT`


Does this close any currently open issues?
------------------------------------------
N/P

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/P

Any other comments?
-------------------
N/P

Has this been tested?
---------------------------
- [ ] Tested
