### PR TITLE
#1928170: shortcuts don't work before right clicking to show context menu on Azure Explorer nodes.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/action/IntellijAzureActionManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/action/IntellijAzureActionManager.java
@@ -235,8 +235,23 @@ public class IntellijAzureActionManager extends AzureActionManager {
             }
 
             @Override
+            public Object start() {
+                return "ctrl F1";
+            }
+
+            @Override
+            public Object restart() {
+                return Action.Id.of(IdeActions.ACTION_RERUN);
+            }
+
+            @Override
             public Object stop() {
                 return Action.Id.of(IdeActions.ACTION_STOP_PROGRAM);
+            }
+
+            @Override
+            public Object deploy() {
+                return Action.Id.of(IdeActions.ACTION_DEFAULT_RUNNER);
             }
         };
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/ServerExplorerToolWindowFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/ServerExplorerToolWindowFactory.java
@@ -110,6 +110,7 @@ public class ServerExplorerToolWindowFactory implements ToolWindowFactory, Prope
                 .map(m -> new com.microsoft.azure.toolkit.intellij.common.component.Tree.TreeNode<>(m, tree)).collect(Collectors.toList());
         modules.stream().sorted(Comparator.comparing(treeNode -> treeNode.getLabel())).forEach(azureRoot::add);
         azureModule.setClearResourcesListener(() -> modules.forEach(m -> m.clearChildren()));
+        com.microsoft.azure.toolkit.intellij.common.component.Tree.installSelectionListener(tree);
         com.microsoft.azure.toolkit.intellij.common.component.Tree.installExpandListener(tree);
         com.microsoft.azure.toolkit.intellij.common.component.Tree.installPopupMenu(tree);
         treeModel.reload();

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/action/ResourceCommonActionsContributor.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/action/ResourceCommonActionsContributor.java
@@ -103,7 +103,7 @@ public class ResourceCommonActionsContributor implements IActionsContributor {
             .title(s -> Optional.ofNullable(s).map(r -> title("resource.open_portal_url.resource", ((IAzureBaseResource<?, ?>) r).name())).orElse(null))
             .enabled(s -> s instanceof IAzureBaseResource);
         final Action<IAzureBaseResource<?, ?>> openPortalUrlAction = new Action<>(openPortalUrl, openPortalUrlView);
-        openPortalUrlAction.setShortcuts("control alt P");
+        openPortalUrlAction.setShortcuts("control alt O");
         am.registerAction(OPEN_PORTAL_URL, openPortalUrlAction);
 
         // register commands

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/ide/springcloud/SpringCloudActionsContributor.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/ide/springcloud/SpringCloudActionsContributor.java
@@ -35,13 +35,17 @@ public class SpringCloudActionsContributor implements IActionsContributor {
         final ActionView.Builder openPublicUrlView = new ActionView.Builder("Access Public Endpoint", "/icons/action/browser.svg")
                 .title(s -> Optional.ofNullable(s).map(r -> title("springcloud.open_public_url.app", ((SpringCloudApp) r).name())).orElse(null))
                 .enabled(s -> s instanceof SpringCloudApp && ((SpringCloudApp) s).isPublicEndpointEnabled());
-        am.registerAction(OPEN_PUBLIC_URL, new Action<>(openPublicUrl, openPublicUrlView));
+        final Action<SpringCloudApp> openPublicUrlAction = new Action<>(openPublicUrl, openPublicUrlView);
+        openPublicUrlAction.setShortcuts("control alt P");
+        am.registerAction(OPEN_PUBLIC_URL, openPublicUrlAction);
 
         final Consumer<SpringCloudApp> openTestUrl = s -> am.getAction(ResourceCommonActionsContributor.OPEN_URL).handle(s.getTestUrl());
         final ActionView.Builder openTestUrlView = new ActionView.Builder("Access Test Endpoint", "/icons/action/browser.svg")
                 .title(s -> Optional.ofNullable(s).map(r -> title("springcloud.open_test_url.app", ((SpringCloudApp) r).name())).orElse(null))
                 .enabled(s -> s instanceof SpringCloudApp);
-        am.registerAction(OPEN_TEST_URL, new Action<>(openTestUrl, openTestUrlView));
+        final Action<SpringCloudApp> openTestUrlAction = new Action<>(openTestUrl, openTestUrlView);
+        openTestUrlAction.setShortcuts("control alt T");
+        am.registerAction(OPEN_TEST_URL, openTestUrlAction);
 
         final ActionView.Builder streamLogView = new ActionView.Builder("Streaming Log", "/icons/action/log.svg")
                 .title(s -> Optional.ofNullable(s).map(r -> title("springcloud.open_stream_log.app", ((SpringCloudApp) r).name())).orElse(null))


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Shortcuts were registered when user right clicks to show context menu, which means shortcuts won't work if
user never right clicks a node. 
**This fix changes to register shortcuts on node selection.**

register shortcuts for more actions.

Does this close any currently open issues?
------------------------------------------
[AB#1928170](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1928170): shortcuts don't work before right clicking to show context menu on Azure Explorer nodes.


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
![GetImage](https://user-images.githubusercontent.com/69189193/157363059-42b7910e-fee3-4680-aa5d-61d0a8d02e08.png)


Any other comments?
-------------------
N/P

Has this been tested?
---------------------------
- [x] Tested
