### PR TITLE
upgrade hadoop-common version

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -253,7 +253,7 @@
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
-                <version>2.8.5</version>
+                <version>2.10.1</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>

--- a/Utils/spark-tools/pom.xml
+++ b/Utils/spark-tools/pom.xml
@@ -22,7 +22,7 @@
         <scala.version>${scala.version.major}.${scala.version.minor}</scala.version>
         <build.copyDependenciesPhase>none</build.copyDependenciesPhase>
         <CodeCacheSize>512m</CodeCacheSize>
-        <hadoop.version>2.8.5</hadoop.version>
+        <hadoop.version>2.10.1</hadoop.version>
         <test.exclude.tags></test.exclude.tags>
     </properties>
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Upgrades hadoop-common from version 2.8.5 to 2.10.1 to fix this vulnerability [issue](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/81212?typeId=119493) 


Does this close any currently open issues?
------------------------------------------

[119493](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/81212?typeId=119493) In Apache Hadoop 3.2.0 to 3.2.1, 3.0.0-alpha1 to 3.1.3, and 2.0.0-alpha to 2.10.0, WebHDFS client might send SPNEGO authorization header to remote URL without proper verification.


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
-  [ ] Tested
