### PR TITLE
[Favorites #7] expand its parent and focus on newly added node

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ResourceConnectionExplorer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ResourceConnectionExplorer.java
@@ -61,7 +61,7 @@ public class ResourceConnectionExplorer extends Tree {
             connection.subscribe(CONNECTION_CHANGED, (p, conn, action) -> {
                 final Resource<?> consumer = conn.getConsumer();
                 if ((consumer instanceof ModuleResource) && ((ModuleResource) consumer).getModuleName().equals(module.getName())) {
-                    this.view().refreshChildren();
+                    this.view().refreshChildren(true);
                 }
             });
             connection.subscribe(CONNECTIONS_REFRESHED, () -> this.view().refreshChildren());

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureModuleLabelView.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureModuleLabelView.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.toolkit.lib.common.model.AzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -57,11 +58,13 @@ public class AzureModuleLabelView<T extends AzResourceModule<?, ?, ?>> implement
     }
 
     public void onEvent(AzureEvent<Object> event) {
+        final String type = event.getType();
         final Object source = event.getSource();
+        final boolean childrenChanged = StringUtils.equalsIgnoreCase(type, "module.children_changed.module");
         if (source instanceof AzResourceModule) {
             final AzureTaskManager tm = AzureTaskManager.getInstance();
             if (Objects.equals(source, this.module)) {
-                tm.runLater(this::refreshChildren);
+                tm.runLater(() -> this.refreshChildren(childrenChanged));
             }
         }
     }

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureResourceLabelView.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureResourceLabelView.java
@@ -95,7 +95,7 @@ public class AzureResourceLabelView<T extends IAzureBaseResource<?, ?>> implemen
                 });
             } else if (StringUtils.equalsAny(type,
                 "resource.children_changed.resource")) {
-                tm.runLater(this::refreshChildren);
+                tm.runLater(() -> this.refreshChildren(true));
             }
         }
     }

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureServiceLabelView.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureServiceLabelView.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent.Stage;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -63,11 +64,13 @@ public class AzureServiceLabelView<T extends AzService> implements NodeView {
     }
 
     public void onEvent(AzureEvent<Object> event) {
+        final String type = event.getType();
         final Object source = event.getSource();
+        final boolean childrenChanged = StringUtils.equalsAnyIgnoreCase(type, "module.children_changed.module", "service.children_changed.service");
         final AzureTaskManager tm = AzureTaskManager.getInstance();
         if (source instanceof AzService && ((AzService) source).getName().equals(this.service.getName())) {
             if (!(event instanceof AzureOperationEvent) || (((AzureOperationEvent) event).getStage() == Stage.AFTER)) {
-                tm.runLater(this::refreshChildren);
+                tm.runLater(() -> this.refreshChildren(childrenChanged));
             }
         }
     }

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/NodeView.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/NodeView.java
@@ -23,8 +23,8 @@ public interface NodeView extends IView.Label {
         this.refresh();
     }
 
-    default void refreshChildren() {
-        Optional.ofNullable(this.getRefresher()).ifPresent(Refresher::refreshChildren);
+    default void refreshChildren(boolean... incremental) {
+        Optional.ofNullable(this.getRefresher()).ifPresent(r -> r.refreshChildren(incremental));
     }
 
     default AzureIcon getIcon() {
@@ -44,7 +44,7 @@ public interface NodeView extends IView.Label {
         default void refreshView() {
         }
 
-        default void refreshChildren() {
+        default void refreshChildren(boolean... incremental) {
         }
     }
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteNodeView.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteNodeView.java
@@ -52,8 +52,8 @@ public class FavoriteNodeView implements NodeView {
     }
 
     @Override
-    public void refreshChildren() {
-        view.refreshChildren();
+    public void refreshChildren(boolean... incremental) {
+        view.refreshChildren(incremental);
     }
 
     @Override


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
1. distinguish `refresh` and `add/delete` action
2. focus on newly added resource node if it's `adding` a resource node.

Has this been tested?
---------------------------
- [x] Tested
