### PR TITLE
[Favorites #5] add `Unpin All` and `Refresh` actions on Favorites root node.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/AzureExplorer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/AzureExplorer.java
@@ -12,11 +12,8 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.microsoft.azure.toolkit.ide.common.IExplorerNodeProvider;
-import com.microsoft.azure.toolkit.ide.common.component.AzureModuleLabelView;
-import com.microsoft.azure.toolkit.ide.common.component.AzureResourceLabelView;
 import com.microsoft.azure.toolkit.ide.common.component.Node;
 import com.microsoft.azure.toolkit.ide.common.component.NodeView;
-import com.microsoft.azure.toolkit.ide.common.favorite.FavoriteNodeView;
 import com.microsoft.azure.toolkit.ide.common.favorite.Favorites;
 import com.microsoft.azure.toolkit.intellij.common.component.Tree;
 import com.microsoft.azure.toolkit.lib.Azure;
@@ -34,7 +31,6 @@ import java.util.stream.Collectors;
 public class AzureExplorer extends Tree {
     private static final AzureExplorerNodeProviderManager manager = new AzureExplorerNodeProviderManager();
     public static final String AZURE_ICON = "/icons/Common/Azure.svg";
-    public static final String FAVORITE_ICON = "/icons/Common/favorite.svg";
 
     private AzureExplorer() {
         super();
@@ -47,16 +43,8 @@ public class AzureExplorer extends Tree {
         return new Node<>(Azure.az(), new NodeView.Static(getTitle(), AZURE_ICON)).lazy(false).addChildren(modules);
     }
 
-    public static Node<Favorites> buildFavoriteRoot() {
-        final AzureModuleLabelView<Favorites> view = new AzureModuleLabelView<>(Favorites.getInstance(), "Favorites", FAVORITE_ICON);
-        return new Node<>(Favorites.getInstance(), view).lazy(false)
-            .addChildren(Favorites::list, (o, parent) -> {
-                final Node<?> node = manager.createNode(o.getResource(), parent);
-                if (Objects.nonNull(node) && node.view() instanceof AzureResourceLabelView) {
-                    node.view(new FavoriteNodeView((AzureResourceLabelView<?>) node.view()));
-                }
-                return node;
-            });
+    public static Node<?> buildFavoriteRoot() {
+        return Favorites.buildFavoriteRoot(manager);
     }
 
     private static String getTitle() {

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/action/ResourceCommonActionsContributor.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/action/ResourceCommonActionsContributor.java
@@ -5,9 +5,8 @@
 
 package com.microsoft.azure.toolkit.ide.common.action;
 
-import com.microsoft.azure.toolkit.ide.common.favorite.FavoriteDraft;
-import com.microsoft.azure.toolkit.ide.common.favorite.Favorites;
 import com.microsoft.azure.toolkit.ide.common.IActionsContributor;
+import com.microsoft.azure.toolkit.ide.common.favorite.Favorites;
 import com.microsoft.azure.toolkit.lib.AzService;
 import com.microsoft.azure.toolkit.lib.common.action.Action;
 import com.microsoft.azure.toolkit.lib.common.action.ActionView;
@@ -163,13 +162,12 @@ public class ResourceCommonActionsContributor implements IActionsContributor {
             "/icons/Common/pin.svg" : "/icons/Common/unpin.svg");
         final Action<AbstractAzResource<?, ?, ?>> pinAction = new Action<>((r) -> {
             if (favorites.exists(r.getId(), null)) {
-                favorites.delete(r.getId(), null);
+                favorites.unpin(r.getId());
             } else {
-                final FavoriteDraft draft = favorites.create(r.getId(), null);
-                draft.setResource(r);
-                draft.commit();
+                favorites.pin(r.getId());
             }
         }, pinView);
+        pinAction.setShortcuts("F11");
         am.registerAction(PIN, pinAction);
     }
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteDraft.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteDraft.java
@@ -10,7 +10,6 @@ import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import lombok.Getter;
-import lombok.Setter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -20,8 +19,6 @@ public class FavoriteDraft extends Favorite implements AzResource.Draft<Favorite
     @Getter
     @Nullable
     private final Favorite origin;
-    @Setter
-    private AbstractAzResource<?, ?, ?> resource;
 
     FavoriteDraft(@Nonnull String resourceId, @Nonnull Favorites module) {
         super(resourceId, module);
@@ -35,7 +32,6 @@ public class FavoriteDraft extends Favorite implements AzResource.Draft<Favorite
 
     @Override
     public void reset() {
-        this.resource = null;
     }
 
     @Nonnull
@@ -46,20 +42,14 @@ public class FavoriteDraft extends Favorite implements AzResource.Draft<Favorite
         type = AzureOperation.Type.SERVICE
     )
     public AbstractAzResource<?, ?, ?> createResourceInAzure() {
-        Favorites.getInstance().favorites.add(0, this.resource.getId());
-        Favorites.getInstance().persist();
-        return this.resource;
+        Favorites.getInstance().favorites.add(0, this.getName());
+        return Objects.requireNonNull(Favorites.getInstance().loadResourceFromAzure(this.getName(), null));
     }
 
     @Nonnull
     @Override
     public AbstractAzResource<?, ?, ?> updateResourceInAzure(@Nonnull AbstractAzResource<?, ?, ?> origin) {
         throw new AzureToolkitRuntimeException("not supported");
-    }
-
-    @Override
-    public AbstractAzResource<?, ?, ?> getResource() {
-        return Objects.nonNull(this.resource) ? this.resource : super.getResource();
     }
 
     @Override

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/Favorites.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/Favorites.java
@@ -54,7 +54,6 @@ public class Favorites extends AbstractAzResourceModule<Favorite, AzResource.Non
         super(NAME, AzResource.NONE);
         AzureEventBus.on("account.logout.account", (e) -> {
             this.clear();
-            this.favorites.clear();
             this.refresh();
         });
         AzureEventBus.on("account.login.account", (e) -> this.refresh());


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
1. add `Unpin All` and `Refresh` actions on Favorites root node.
2. simplify implementation of favorites related action by shortcuts.

Does this close any currently open issues?
------------------------------------------
[AB#1930314](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1930314): add `Unpin All` and `Refresh` actions on Favorites root node.

Has this been tested?
---------------------------
- [ ] Tested
