### PR TITLE
[Favorites #2] implement the skeleton of favorites feature based on mod

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureIcons.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureIcons.java
@@ -27,6 +27,7 @@ public class AzureIcons {
 
     private static final Map<String, Icon> icons = new ConcurrentHashMap<>() {
         {
+            put("/icons/Common/favorite.svg", AllIcons.Nodes.Favorite);
             put("/icons/action/restart.svg", AllIcons.Actions.Restart);
             put("/icons/action/start.svg", AllIcons.Actions.Execute);
             put("/icons/action/stop.svg", AllIcons.Actions.Suspend);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureIcons.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureIcons.java
@@ -27,6 +27,8 @@ public class AzureIcons {
 
     private static final Map<String, Icon> icons = new ConcurrentHashMap<>() {
         {
+            put("/icons/Common/pin.svg", AllIcons.Nodes.Favorite);
+            put("/icons/Common/unpin.svg", AllIcons.Nodes.NotFavoriteOnHover);
             put("/icons/Common/favorite.svg", AllIcons.Nodes.Favorite);
             put("/icons/action/restart.svg", AllIcons.Actions.Restart);
             put("/icons/action/start.svg", AllIcons.Actions.Execute);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/AzureExplorer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/AzureExplorer.java
@@ -22,6 +22,7 @@ import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -29,20 +30,26 @@ import java.util.stream.Collectors;
 
 public class AzureExplorer extends Tree {
     private static final AzureExplorerNodeProviderManager manager = new AzureExplorerNodeProviderManager();
-    public static final String ICON = "/icons/Common/Azure.svg";
+    public static final String AZURE_ICON = "/icons/Common/Azure.svg";
+    public static final String FAVORITE_ICON = "/icons/Common/favorite.svg";
 
     private AzureExplorer() {
         super();
-        this.root = buildRoot();
+        this.root = buildAzureRoot();
         this.init(this.root);
     }
 
-    private Node<Azure> buildRoot() {
+    private static Node<Azure> buildAzureRoot() {
         final List<Node<?>> modules = getModules();
-        return new Node<>(Azure.az(), new NodeView.Static(getTitle(), ICON)).lazy(false).addChildren(modules);
+        return new Node<>(Azure.az(), new NodeView.Static(getTitle(), AZURE_ICON)).lazy(false).addChildren(modules);
     }
 
-    private String getTitle() {
+    public static Node<String> buildFavoriteRoot() {
+        final List<Node<?>> favorites = Collections.emptyList();
+        return new Node<>("Favorites", new NodeView.Static("Favorites", FAVORITE_ICON)).lazy(false).addChildren(favorites);
+    }
+
+    private static String getTitle() {
         try {
             final AzureAccount az = Azure.az(AzureAccount.class);
             final Account account = az.account();
@@ -53,6 +60,11 @@ public class AzureExplorer extends Tree {
         } catch (final Exception ignored) {
         }
         return "Azure";
+    }
+
+    @Nonnull
+    public static List<Node<?>> getFavorites() {
+        return manager.getRootNodes();
     }
 
     @Nonnull

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/pom.xml
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/pom.xml
@@ -21,8 +21,61 @@
             <artifactId>azure-toolkit-common-lib</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-toolkit-auth-lib</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <!-- https://mvnrepository.com/artifact/org.codehaus.mojo/aspectj-maven-plugin -->
+                <!-- http://www.quabr.com/62976155/aspectj-maven-plugin-1-11-missing-tools-jar-issue-with-jdk-11 -->
+                <groupId>com.nickwongdev</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.12.6</version>
+                <configuration>
+                    <showWeaveInfo>false</showWeaveInfo>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <Xlint>ignore</Xlint>
+                    <complianceLevel>1.8</complianceLevel>
+                    <encoding>UTF-8</encoding>
+                    <verbose>false</verbose>
+                    <outxml>true</outxml>
+                    <forceAjcCompile>true</forceAjcCompile>
+                    <sources/><!-- this is important!-->
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile-with-aspectj</id>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <weaveDirectories>
+                                <weaveDirectory>${project.build.directory}/classes</weaveDirectory>
+                            </weaveDirectories>
+                        </configuration>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile-with-aspectj</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <weaveDirectories>
+                                <weaveDirectory>${project.build.directory}/test-classes</weaveDirectory>
+                            </weaveDirectories>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureModuleLabelView.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureModuleLabelView.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.ide.common.component;
+
+import com.microsoft.azure.toolkit.lib.common.event.AzureEvent;
+import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
+import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
+import com.microsoft.azure.toolkit.lib.common.model.AzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class AzureModuleLabelView<T extends AzResourceModule<?, ?, ?>> implements NodeView {
+    @Nonnull
+    @Getter
+    private final T module;
+    @Getter
+    private final String label;
+    @Getter
+    private final String iconPath;
+    private final AzureEventBus.EventListener<Object, AzureEvent<Object>> listener;
+    @Getter
+    private String description;
+    @Nullable
+    @Setter
+    @Getter
+    private Refresher refresher;
+
+    public AzureModuleLabelView(@Nonnull T module) {
+        this(module, module.getName());
+    }
+
+    public AzureModuleLabelView(@Nonnull T module, String label) {
+        this(module, label, String.format("/icons/%s.svg", module.getClass().getSimpleName().toLowerCase()));
+    }
+
+    public AzureModuleLabelView(@Nonnull T module, String label, String iconPath) {
+        this.module = module;
+        this.label = label;
+        this.iconPath = iconPath;
+        this.listener = new AzureEventBus.EventListener<>(this::onEvent);
+        AzureEventBus.on("module.refresh.module", listener);
+        AzureEventBus.on("module.children_changed.module", listener);
+        this.refreshView();
+    }
+
+    public void dispose() {
+        AzureEventBus.off("module.refresh.module", listener);
+        AzureEventBus.off("module.children_changed.module", listener);
+        this.refresher = null;
+    }
+
+    public void onEvent(AzureEvent<Object> event) {
+        final String type = event.getType();
+        final Object source = event.getSource();
+        if (source instanceof AzResourceModule) {
+            final AzResourceModule<?, ?, ?> sourceModule = (AzResourceModule<?, ?, ?>) source;
+            if (Objects.equals(sourceModule.getParent(), this.module.getParent()) &&
+                Objects.equals(sourceModule.getName(), this.module.getName())) {
+                final AzureTaskManager tm = AzureTaskManager.getInstance();
+                switch (type) {
+                    case "module.refresh.module":
+                        if (((AzureOperationEvent) event).getStage() == AzureOperationEvent.Stage.AFTER) {
+                            tm.runLater(this::refreshChildren);
+                        }
+                        break;
+                    case "module.children_changed.module":
+                        tm.runLater(this::refreshChildren);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureServiceLabelView.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureServiceLabelView.java
@@ -16,6 +16,7 @@ import lombok.Setter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+// TODO: merge with AzureModuleLabelView
 public class AzureServiceLabelView<T extends AzService> implements NodeView {
     @Nonnull
     @Getter

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/Favorite.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/Favorite.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.ide.common.favorite;
+
+import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.common.model.AzResourceModule;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+
+public class Favorite extends AbstractAzResource<Favorite, AzResource.None, AbstractAzResource<?, ?, ?>> {
+    public static final String RG = "FAVORITES_RESOURCE_GROUP";
+
+    protected Favorite(@Nonnull String resourceId, @Nonnull Favorites module) {
+        super(resourceId, ResourceId.fromString(resourceId).resourceGroupName(), module);
+    }
+
+    /**
+     * copy constructor
+     */
+    protected Favorite(@Nonnull Favorite origin) {
+        super(origin);
+    }
+
+    protected Favorite(@Nonnull AbstractAzResource<?, ?, ?> remote, @Nonnull Favorites module) {
+        // favorite's name is exactly the id of the resource.
+        super(remote.getId(), remote.getResourceGroupName(), module);
+        this.setRemote(remote);
+    }
+
+    public AbstractAzResource<?, ?, ?> getResource() {
+        return this.getRemote();
+    }
+
+    @Nonnull
+    @Override
+    public List<AzResourceModule<?, Favorite, ?>> getSubModules() {
+        return Collections.emptyList();
+    }
+
+    @Nonnull
+    @Override
+    public String loadStatus(@Nonnull AbstractAzResource<?, ?, ?> remote) {
+        return remote.exists() ? Status.RUNNING : Status.DELETED;
+    }
+}

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteDraft.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteDraft.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.ide.common.favorite;
+
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class FavoriteDraft extends Favorite implements AzResource.Draft<Favorite, AbstractAzResource<?, ?, ?>> {
+    @Getter
+    @Nullable
+    private final Favorite origin;
+    @Setter
+    private AbstractAzResource<?, ?, ?> resource;
+
+    FavoriteDraft(@Nonnull String resourceId, @Nonnull Favorites module) {
+        super(resourceId, module);
+        this.origin = null;
+    }
+
+    FavoriteDraft(@Nonnull Favorite origin) {
+        super(origin);
+        this.origin = origin;
+    }
+
+    @Override
+    public void reset() {
+        this.resource = null;
+    }
+
+    @Nonnull
+    @Override
+    @AzureOperation(
+        name = "resource.create_resource.resource|type",
+        params = {"this.getName()", "this.getResourceTypeName()"},
+        type = AzureOperation.Type.SERVICE
+    )
+    public AbstractAzResource<?, ?, ?> createResourceInAzure() {
+        // TODO: persist.
+        Favorites.storage.add(0, this.resource.getId());
+        return this.resource;
+    }
+
+    @Nonnull
+    @Override
+    public AbstractAzResource<?, ?, ?> updateResourceInAzure(@Nonnull AbstractAzResource<?, ?, ?> origin) {
+        throw new AzureToolkitRuntimeException("not supported");
+    }
+
+    @Override
+    public AbstractAzResource<?, ?, ?> getResource() {
+        return Objects.nonNull(this.resource) ? this.resource : super.getResource();
+    }
+
+    @Override
+    public boolean isModified() {
+        return false;
+    }
+}

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteNodeView.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteNodeView.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.ide.common.favorite;
+
+import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
+import com.microsoft.azure.toolkit.ide.common.component.AzureResourceLabelView;
+import com.microsoft.azure.toolkit.ide.common.component.NodeView;
+import com.microsoft.azure.toolkit.ide.common.icon.AzureIcon;
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
+import com.microsoft.azure.toolkit.lib.common.entity.IAzureBaseResource;
+import com.microsoft.azure.toolkit.lib.common.model.Subscription;
+import lombok.RequiredArgsConstructor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class FavoriteNodeView implements NodeView {
+
+    @Nonnull
+    private final AzureResourceLabelView<?> view;
+
+    @Override
+    public String getTips() {
+        final IAzureBaseResource<?, ?> resource = view.getResource();
+        final ResourceId id = ResourceId.fromString(resource.getId());
+        final Subscription subs = Azure.az(AzureAccount.class).account().getSubscription(id.subscriptionId());
+        final String rg = id.resourceGroupName();
+        final String type = id.resourceType();
+        return String.format("Type:%s | Subscription: %s | Resource Group:%s", type, subs.getName(), rg) +
+            Optional.ofNullable(id.parent()).map(p -> " | Parent:" + p.name()).orElse("");
+    }
+
+    @Override
+    public String getDescription() {
+        return view.getDescription();
+    }
+
+    @Override
+    public void refresh() {
+        view.refresh();
+    }
+
+    @Override
+    public void refreshView() {
+        view.refreshView();
+    }
+
+    @Override
+    public void refreshChildren() {
+        view.refreshChildren();
+    }
+
+    @Override
+    public AzureIcon getIcon() {
+        return view.getIcon();
+    }
+
+    @Override
+    public void setRefresher(Refresher refresher) {
+        view.setRefresher(refresher);
+    }
+
+    @Override
+    @Nullable
+    public Refresher getRefresher() {
+        return view.getRefresher();
+    }
+
+    @Override
+    public String getLabel() {
+        return view.getLabel();
+    }
+
+    @Override
+    public String getIconPath() {
+        return view.getIconPath();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return view.isEnabled();
+    }
+
+    @Override
+    public void dispose() {
+        view.dispose();
+    }
+}

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/Favorites.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/Favorites.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.ide.common.favorite;
+
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+@Slf4j
+public class Favorites extends AbstractAzResourceModule<Favorite, AzResource.None, AbstractAzResource<?, ?, ?>> {
+    @Getter
+    private static final Favorites instance = new Favorites();
+
+    // TODO: use platform storage API instead.
+    public static final List<String> storage = new LinkedList<>(Arrays.asList(
+        "/subscriptions/685ba005-af8d-4b04-8f16-a7bf38b2eb5a/resourceGroups/wangmi-rg-test/" +
+            "providers/Microsoft.AppPlatform/Spring/wangmi-asc-basic/apps/springcloud-app-not-exist",
+        "/subscriptions/685ba005-af8d-4b04-8f16-a7bf38b2eb5a/resourceGroups/wangmi-rg-test/" +
+            "providers/Microsoft.AppPlatform/Spring/wangmi-asc-basic/apps/springcloud-app-20220308235135",
+        "/subscriptions/685ba005-af8d-4b04-8f16-a7bf38b2eb5a/resourceGroups/wangmi-rg-test/" +
+            "providers/Microsoft.AppPlatform/Spring/wangmi-asc-basic/apps/springcloud-app-20220308214445",
+        "/subscriptions/685ba005-af8d-4b04-8f16-a7bf38b2eb5a/resourceGroups/wangmi-rg-test/" +
+            "providers/Microsoft.AppPlatform/Spring/wangmi-asc-basic"
+    ));
+
+    private Favorites() {
+        super("toolkitFavorites", AzResource.NONE);
+    }
+
+    @Nonnull
+    @Override
+    public synchronized List<Favorite> list() {
+        final List<Favorite> result = new LinkedList<>(super.list());
+        result.sort(Comparator.comparing(item -> storage.indexOf(item.getName())));
+        return result;
+    }
+
+    @Nonnull
+    @Override
+    protected Stream<AbstractAzResource<?, ?, ?>> loadResourcesFromAzure() {
+        return storage.stream().map(id -> Azure.az().getOrDraftById(id)).filter(Objects::nonNull)
+            .map(c -> ((AbstractAzResource<?, ?, ?>) c));
+    }
+
+    @Nullable
+    @Override
+    protected AbstractAzResource<?, ?, ?> loadResourceFromAzure(@Nonnull String resourceId, @Nullable String resourceGroup) {
+        if (storage.contains(resourceId)) {
+            return Azure.az().getOrDraftById(resourceId);
+        }
+        return null;
+    }
+
+    @Override
+    protected void deleteResourceFromAzure(@Nonnull String resourceId) {
+        storage.remove(resourceId);
+    }
+
+    @Nonnull
+    @Override
+    protected Favorite newResource(@Nonnull AbstractAzResource<?, ?, ?> remote) {
+        return new Favorite(remote, this);
+    }
+
+    @Nonnull
+    @Override
+    protected AzResource.Draft<Favorite, AbstractAzResource<?, ?, ?>> newDraftForCreate(@Nonnull String name, @Nullable String resourceGroup) {
+        return new FavoriteDraft(name, this);
+    }
+
+    @Nonnull
+    @Override
+    public String getResourceTypeName() {
+        return "Favorites";
+    }
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
[AB#1927824](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1927824): add Favorites root node at the top of AzureExplorer
[AB#1930315](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1930315): implement Mark/Unmark As Favorite action
[AB#1927829](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1927829): render favorite node with proper information


Has this been tested?
---------------------------
- [x] Tested
