### PR TITLE
Favorite/7 bugfixes

### DIFF
--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteDraft.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteDraft.java
@@ -43,6 +43,7 @@ public class FavoriteDraft extends Favorite implements AzResource.Draft<Favorite
     )
     public AbstractAzResource<?, ?, ?> createResourceInAzure() {
         Favorites.getInstance().favorites.add(0, this.getName());
+        Favorites.getInstance().persist();
         return Objects.requireNonNull(Favorites.getInstance().loadResourceFromAzure(this.getName(), null));
     }
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteNodeView.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteNodeView.java
@@ -11,7 +11,7 @@ import com.microsoft.azure.toolkit.ide.common.component.NodeView;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcon;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
-import com.microsoft.azure.toolkit.lib.common.entity.IAzureBaseResource;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 import lombok.RequiredArgsConstructor;
 
@@ -27,12 +27,12 @@ public class FavoriteNodeView implements NodeView {
 
     @Override
     public String getTips() {
-        final IAzureBaseResource<?, ?> resource = view.getResource();
+        final AbstractAzResource<?, ?, ?> resource = (AbstractAzResource<?, ?, ?>) view.getResource();
         final ResourceId id = ResourceId.fromString(resource.getId());
         final Subscription subs = Azure.az(AzureAccount.class).account().getSubscription(id.subscriptionId());
         final String rg = id.resourceGroupName();
-        final String type = id.resourceType();
-        return String.format("Type:%s | Subscription: %s | Resource Group:%s", type, subs.getName(), rg) +
+        final String typeName = resource.getModule().getResourceTypeName();
+        return String.format("Type:%s | Subscription: %s | Resource Group:%s", typeName, subs.getName(), rg) +
             Optional.ofNullable(id.parent()).map(p -> " | Parent:" + p.name()).orElse("");
     }
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteNodeView.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/FavoriteNodeView.java
@@ -27,6 +27,9 @@ public class FavoriteNodeView implements NodeView {
 
     @Override
     public String getTips() {
+        if (!Azure.az(AzureAccount.class).isSignedIn()) {
+            return "";
+        }
         final AbstractAzResource<?, ?, ?> resource = (AbstractAzResource<?, ?, ?>) view.getResource();
         final ResourceId id = ResourceId.fromString(resource.getId());
         final Subscription subs = Azure.az(AzureAccount.class).account().getSubscription(id.subscriptionId());

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/Favorites.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/favorite/Favorites.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.toolkit.lib.common.action.ActionGroup;
 import com.microsoft.azure.toolkit.lib.common.action.ActionView;
 import com.microsoft.azure.toolkit.lib.common.action.AzureActionManager;
 import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
@@ -92,7 +93,7 @@ public class Favorites extends AbstractAzResourceModule<Favorite, AzResource.Non
                 this.favorites = new LinkedList<>();
             }
         }
-        return this.favorites.stream().map(id -> Azure.az().getOrDraftById(id)).filter(Objects::nonNull)
+        return this.favorites.stream().map(id -> Azure.az().getById(id)).filter(Objects::nonNull)
             .map(c -> ((AbstractAzResource<?, ?, ?>) c));
     }
 
@@ -100,7 +101,7 @@ public class Favorites extends AbstractAzResourceModule<Favorite, AzResource.Non
     @Override
     protected AbstractAzResource<?, ?, ?> loadResourceFromAzure(@Nonnull String name, @Nullable String resourceGroup) {
         if (this.favorites.contains(name)) {
-            return Azure.az().getOrDraftById(name);
+            return Azure.az().getById(name);
         }
         return null;
     }
@@ -183,6 +184,8 @@ public class Favorites extends AbstractAzResourceModule<Favorite, AzResource.Non
                 final Node<?> node = manager.createNode(o.getResource(), parent);
                 if (Objects.nonNull(node) && node.view() instanceof AzureResourceLabelView) {
                     node.view(new FavoriteNodeView((AzureResourceLabelView<?>) node.view()));
+                } else if (Objects.isNull(node)) {
+                    throw new AzureToolkitRuntimeException("failed to render Favorite node from " + o.getResource());
                 }
                 return node;
             });


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
> #1930348: [Test] AzureToolkitAuthenticationException after sign out when there is a resource in Favorites list

stop reading auth protected info if signed out. (Nodes are re-rendered when user sign out)

> #1930354: [Test] Type showing for different resources in favorite list starts with different format

use "resource type name" instead of "resource type"

> #1930325: [Test] Failed to pin resources under Resource Management to Favorite

this bug happens because "Resource Group" and "Deployment" have different resource ids from other common resources. 

Does this close any currently open issues?
------------------------------------------
[AB#1930348](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1930348): [Test] AzureToolkitAuthenticationException after sign out when there is a resource in Favorites list
[AB#1930354](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1930354): [Test] Type showing for different resources in favorite list starts with different format
[AB#1930325](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1930325): [Test] Fail to pin resources under Resource Management to Favorite

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
![image](https://user-images.githubusercontent.com/69189193/158609526-68e707f1-772f-4b86-a45c-0dd1caeabbef.png)

Any other comments?
-------------------
N/P

Has this been tested?
---------------------------
- [ ] Tested
