### PR TITLE
exclude com.fasterxml.woodstox under utils/pom.xml to fix CVE issue

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -254,6 +254,12 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
                 <version>2.10.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.woodstox</groupId>
+                        <artifactId>woodstox-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -255,7 +255,7 @@
                 <artifactId>hadoop-common</artifactId>
                 <version>2.10.1</version>
                 <exclusions>
-                    <exclusion>
+                    <exclusion><!--WS-2018-0629-->
                         <groupId>com.fasterxml.woodstox</groupId>
                         <artifactId>woodstox-core</artifactId>
                     </exclusion>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
exclude com.fasterxml.woodstox under utils/pom.xml to fix this [cve issue ](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/82804?typeId=119493)


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
