### PR TITLE
[#1926172] focus proper input once dialog is opened, so that user can input/operate directly by keyboard/shortcuts without additional mouse operation

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/AppServiceInfoAdvancedPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/AppServiceInfoAdvancedPanel.java
@@ -114,9 +114,9 @@ public class AppServiceInfoAdvancedPanel<T extends AppServiceConfig> extends JPa
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
+            this.textName,
             this.selectorSubscription,
             this.selectorGroup,
-            this.textName,
             this.selectorRuntime,
             this.selectorRegion,
             this.selectorApplication,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/jfr/RunFlightRecorderDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/jfr/RunFlightRecorderDialog.java
@@ -6,18 +6,17 @@
 package com.microsoft.azure.toolkit.intellij.legacy.appservice.jfr;
 
 import com.intellij.openapi.project.Project;
-import com.microsoft.azure.toolkit.intellij.legacy.appservice.ProcessComboBox;
 import com.microsoft.azure.toolkit.intellij.common.AzureDialog;
+import com.microsoft.azure.toolkit.intellij.legacy.appservice.ProcessComboBox;
 import com.microsoft.azure.toolkit.lib.appservice.AppServiceAppBase;
-import com.microsoft.azure.toolkit.lib.legacy.appservice.jfr.FlightRecorderConfiguration;
 import com.microsoft.azure.toolkit.lib.appservice.model.ProcessInfo;
 import com.microsoft.azure.toolkit.lib.common.form.AzureForm;
 import com.microsoft.azure.toolkit.lib.common.form.AzureFormInput;
+import com.microsoft.azure.toolkit.lib.legacy.appservice.jfr.FlightRecorderConfiguration;
 
 import javax.annotation.Nullable;
 import javax.swing.*;
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class RunFlightRecorderDialog extends AzureDialog<FlightRecorderConfiguration>
@@ -28,7 +27,7 @@ public class RunFlightRecorderDialog extends AzureDialog<FlightRecorderConfigura
     private ProcessComboBox processComboBox1;
     private DurationPanel durationPanel;
 
-    private AppServiceAppBase<?, ?, ?> appService;
+    private final AppServiceAppBase<?, ?, ?> appService;
 
     public RunFlightRecorderDialog(final Project project, AppServiceAppBase<?, ?, ?> appService) {
         super(project);
@@ -43,7 +42,7 @@ public class RunFlightRecorderDialog extends AzureDialog<FlightRecorderConfigura
 
     @Override
     protected String getDialogTitle() {
-        return null;
+        return "Flight Recorder";
     }
 
     @Nullable
@@ -57,7 +56,7 @@ public class RunFlightRecorderDialog extends AzureDialog<FlightRecorderConfigura
         final FlightRecorderConfiguration.FlightRecorderConfigurationBuilder builder =
                 FlightRecorderConfiguration.builder();
         builder.duration(this.durationPanel.getValue());
-        ProcessInfo pi = this.processComboBox1.getValue();
+        final ProcessInfo pi = this.processComboBox1.getValue();
         if (pi != null) {
             builder.pid(pi.getId());
             builder.processName(pi.getName());
@@ -73,8 +72,8 @@ public class RunFlightRecorderDialog extends AzureDialog<FlightRecorderConfigura
 
     @Override
     public List<AzureFormInput<?>> getInputs() {
-        List<AzureFormInput<?>> res = new ArrayList<>(this.durationPanel.getInputs());
-        res.addAll(Collections.singletonList(this.processComboBox1));
+        final List<AzureFormInput<?>> res = new LinkedList<>(this.durationPanel.getInputs());
+        res.add(0, this.processComboBox1);
         return res;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/FunctionAppConfigFormPanelAdvance.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/FunctionAppConfigFormPanelAdvance.java
@@ -18,7 +18,7 @@ import com.microsoft.azure.toolkit.intellij.common.AzureFormPanel;
 import com.microsoft.azure.toolkit.lib.appservice.model.Runtime;
 import com.microsoft.azure.toolkit.lib.common.form.AzureFormInput;
 import com.microsoft.azure.toolkit.ide.appservice.function.FunctionAppConfig;
-import org.apache.commons.collections.ListUtils;
+import org.apache.commons.collections4.ListUtils;
 
 import javax.annotation.Nonnull;
 import javax.swing.*;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/component/CreateApplicationInsightsDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/component/CreateApplicationInsightsDialog.java
@@ -94,4 +94,9 @@ public class CreateApplicationInsightsDialog extends AzureDialogWrapper {
             throw new IllegalArgumentException(message("function.applicationInsights.validate.invalidChar", String.join(",", invalidCharacters)));
         }
     }
+
+    @Override
+    public @Nullable JComponent getPreferredFocusedComponent() {
+        return this.txtInsightsName;
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/WebAppConfigFormPanelAdvance.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/WebAppConfigFormPanelAdvance.java
@@ -15,24 +15,22 @@ import com.microsoft.azure.toolkit.lib.appservice.model.OperatingSystem;
 import com.microsoft.azure.toolkit.lib.appservice.model.PricingTier;
 import com.microsoft.azure.toolkit.lib.appservice.model.Runtime;
 import com.microsoft.azure.toolkit.lib.common.form.AzureFormInput;
-import org.apache.commons.collections.ListUtils;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.ListUtils;
 
 import javax.swing.*;
 import java.util.ArrayList;
 import java.util.List;
 
+@RequiredArgsConstructor
 public class WebAppConfigFormPanelAdvance extends JPanel implements AzureFormPanel<WebAppConfig> {
+    private final Project project;
     private JTabbedPane tabPane;
     private JPanel pnlRoot;
-    private Project project;
     private AppServiceInfoAdvancedPanel<WebAppConfig> appServiceConfigPanelAdvanced;
     private AppServiceMonitorPanel appServiceMonitorPanel;
     private JPanel pnlMonitoring;
     private JPanel pnlAppService;
-
-    public WebAppConfigFormPanelAdvance(final Project project) {
-        this.project = project;
-    }
 
     @Override
     public void setVisible(final boolean visible) {
@@ -67,7 +65,7 @@ public class WebAppConfigFormPanelAdvance extends JPanel implements AzureFormPan
 
     private void createUIComponents() {
         // TODO: place custom component creation code here
-        appServiceConfigPanelAdvanced = new AppServiceInfoAdvancedPanel(project, WebAppConfig::getWebAppDefaultConfig);
+        appServiceConfigPanelAdvanced = new AppServiceInfoAdvancedPanel<>(project, WebAppConfig::getWebAppDefaultConfig);
         final List<PricingTier> validPricing = new ArrayList<>(PricingTier.WEB_APP_PRICING);
         appServiceConfigPanelAdvanced.setValidPricingTier(validPricing, WebAppConfig.DEFAULT_PRICING_TIER);
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-arm/src/main/java/com/microsoft/azure/toolkit/intellij/arm/creation/CreateDeploymentDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-arm/src/main/java/com/microsoft/azure/toolkit/intellij/arm/creation/CreateDeploymentDialog.java
@@ -231,4 +231,10 @@ public class CreateDeploymentDialog extends AzureDialogWrapper {
         this.subscriptionCombobox = new SubscriptionComboBox();
         this.regionCb = new RegionComboBox();
     }
+
+    @Nullable
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return this.deploymentNameTextField;
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-arm/src/main/java/com/microsoft/azure/toolkit/intellij/arm/update/UpdateDeploymentDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-arm/src/main/java/com/microsoft/azure/toolkit/intellij/arm/update/UpdateDeploymentDialog.java
@@ -123,4 +123,10 @@ public class UpdateDeploymentDialog extends AzureDialogWrapper {
     protected JComponent createCenterPanel() {
         return contentPane;
     }
+
+    @Nullable
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return this.templateTextField;
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/component/PasswordDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/component/PasswordDialog.java
@@ -161,8 +161,6 @@ public class PasswordDialog extends AzureDialog<Password> implements AzureForm<P
 
     @Override
     public List<AzureFormInput<?>> getInputs() {
-        final AzureFormInput<?>[] inputs = {this.passwordSaveComboBox};
-        return Arrays.asList(inputs);
+        return List.of(this.passwordSaveComboBox);
     }
-
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/connection/SqlDatabaseResourcePanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/connection/SqlDatabaseResourcePanel.java
@@ -249,10 +249,10 @@ public class SqlDatabaseResourcePanel<T extends IDatabase> implements AzureFormJ
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
-            this.subscriptionComboBox,
             this.serverComboBox,
             this.databaseComboBox,
-            this.usernameComboBox
+            this.usernameComboBox,
+            this.subscriptionComboBox
         };
         return Arrays.asList(inputs);
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/mysql/creation/MySqlCreationAdvancedPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/mysql/creation/MySqlCreationAdvancedPanel.java
@@ -168,8 +168,8 @@ public class MySqlCreationAdvancedPanel extends JPanel implements AzureFormPanel
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
-            this.serverNameTextField,
             this.adminUsernameTextField,
+            this.serverNameTextField,
             this.subscriptionComboBox,
             this.resourceGroupComboBox,
             this.regionComboBox,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/mysql/creation/MySqlCreationBasicPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/mysql/creation/MySqlCreationBasicPanel.java
@@ -104,8 +104,8 @@ public class MySqlCreationBasicPanel extends JPanel implements AzureFormPanel<Da
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
-            serverNameTextField,
             adminUsernameTextField,
+            serverNameTextField,
             passwordFieldInput,
             confirmPasswordFieldInput
         };

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/postgre/creation/PostgreSqlCreationAdvancedPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/postgre/creation/PostgreSqlCreationAdvancedPanel.java
@@ -168,8 +168,8 @@ public class PostgreSqlCreationAdvancedPanel extends JPanel implements AzureForm
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
-            this.serverNameTextField,
             this.adminUsernameTextField,
+            this.serverNameTextField,
             this.subscriptionComboBox,
             this.resourceGroupComboBox,
             this.regionComboBox,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/postgre/creation/PostgreSqlCreationBasicPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/postgre/creation/PostgreSqlCreationBasicPanel.java
@@ -104,8 +104,8 @@ public class PostgreSqlCreationBasicPanel extends JPanel implements AzureFormPan
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
-            serverNameTextField,
             adminUsernameTextField,
+            serverNameTextField,
             passwordFieldInput,
             confirmPasswordFieldInput
         };

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/sqlserver/creation/SqlServerCreationAdvancedPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/sqlserver/creation/SqlServerCreationAdvancedPanel.java
@@ -158,8 +158,8 @@ public class SqlServerCreationAdvancedPanel extends JPanel implements AzureFormP
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
-            this.serverNameTextField,
             this.adminUsernameTextField,
+            this.serverNameTextField,
             this.subscriptionComboBox,
             this.resourceGroupComboBox,
             this.regionComboBox,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/sqlserver/creation/SqlServerCreationBasicPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/sqlserver/creation/SqlServerCreationBasicPanel.java
@@ -104,8 +104,8 @@ public class SqlServerCreationBasicPanel extends JPanel implements AzureFormPane
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
-            serverNameTextField,
             adminUsernameTextField,
+            serverNameTextField,
             passwordFieldInput,
             confirmPasswordFieldInput
         };

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureDialog.java
@@ -55,14 +55,10 @@ public abstract class AzureDialog<T> extends DialogWrapper {
     @Nullable
     @Override
     public JComponent getPreferredFocusedComponent() {
-        final JComponent dft = super.getPreferredFocusedComponent();
-        if (Objects.isNull(dft)) {
-            return this.getForm().getInputs().stream()
-                .filter(i -> i instanceof AzureFormInputComponent)
-                .map(i -> ((AzureFormInputComponent<?>) i).getInputComponent())
-                .findFirst().orElse(null);
-        }
-        return dft;
+        return this.getForm().getInputs().stream()
+            .filter(i -> i instanceof AzureFormInputComponent)
+            .map(i -> ((AzureFormInputComponent<?>) i).getInputComponent())
+            .findFirst().orElseGet(super::getPreferredFocusedComponent);
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureDialog.java
@@ -11,7 +11,9 @@ import com.microsoft.azure.toolkit.lib.common.form.AzureForm;
 import com.microsoft.azure.toolkit.lib.common.form.AzureValidationInfo;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import lombok.extern.java.Log;
+import org.jetbrains.annotations.Nullable;
 
+import javax.swing.*;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -48,6 +50,19 @@ public abstract class AzureDialog<T> extends DialogWrapper {
 
     public void close() {
         this.doCancelAction();
+    }
+
+    @Nullable
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        final JComponent dft = super.getPreferredFocusedComponent();
+        if (Objects.isNull(dft)) {
+            return this.getForm().getInputs().stream()
+                .filter(i -> i instanceof AzureFormInputComponent)
+                .map(i -> ((AzureFormInputComponent<?>) i).getInputComponent())
+                .findFirst().orElse(null);
+        }
+        return dft;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/ConfigDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/ConfigDialog.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.toolkit.lib.common.form.AzureForm;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import lombok.extern.java.Log;
 
+import javax.annotation.Nullable;
 import javax.swing.*;
 
 @Log

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/EnvironmentVariablesTextFieldWithBrowseButton.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/EnvironmentVariablesTextFieldWithBrowseButton.java
@@ -180,6 +180,11 @@ public class EnvironmentVariablesTextFieldWithBrowseButton extends TextFieldWith
         }
 
         @Override
+        public @Nullable JComponent getPreferredFocusedComponent() {
+            return environmentVariableTable.getTableView();
+        }
+
+        @Override
         protected void doOKAction() {
             environmentVariableTable.stopEditing();
             environmentVariables = environmentVariableTable.getEnv();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/connection/RedisResourcePanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/connection/RedisResourcePanel.java
@@ -74,8 +74,8 @@ public class RedisResourcePanel implements AzureFormJPanel<Resource<RedisCache>>
     @Override
     public List<AzureFormInput<?>> getInputs() {
         return Arrays.asList(
-                this.subscriptionComboBox,
-                this.redisComboBox
+            this.redisComboBox,
+            this.subscriptionComboBox
         );
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/creation/RedisCreationDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/creation/RedisCreationDialog.java
@@ -166,9 +166,9 @@ public class RedisCreationDialog extends AzureDialog<RedisConfig> implements Azu
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
+            this.redisNameTextField,
             this.subscriptionComboBox,
             this.resourceGroupComboBox,
-            this.redisNameTextField,
             this.pricingComboBox,
             this.regionComboBox
         };

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.form
@@ -99,7 +99,7 @@
           </component>
         </children>
       </grid>
-      <grid id="d4252" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="d4252" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="1" use-parent-layout="false"/>
@@ -122,7 +122,7 @@
           <grid id="da7cf" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>
@@ -172,7 +172,7 @@
           <grid id="a28b7" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>
@@ -218,33 +218,6 @@
               <text value="Runtime: "/>
             </properties>
           </component>
-          <grid id="81f63" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-            <margin top="0" left="0" bottom="0" right="0"/>
-            <constraints>
-              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties/>
-            <border type="none"/>
-            <children>
-              <component id="fefff" class="javax.swing.JRadioButton" binding="useJava8" default-binding="true">
-                <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <selected value="true"/>
-                  <text value="Java 8"/>
-                </properties>
-              </component>
-              <component id="9d535" class="javax.swing.JRadioButton" binding="useJava11">
-                <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <text value="Java 11"/>
-                </properties>
-              </component>
-            </children>
-          </grid>
           <component id="19915" class="javax.swing.JLabel">
             <constraints>
               <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
@@ -260,7 +233,7 @@
           </component>
           <component id="76d4b" class="javax.swing.JTextField" binding="txtJvmOptions">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="4" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -282,7 +255,7 @@
           </component>
           <component id="c58f3" class="com.microsoft.azure.toolkit.intellij.common.EnvironmentVariablesTextFieldWithBrowseButton" binding="envTable">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
@@ -300,12 +273,34 @@
           </component>
           <component id="5aaff" class="com.intellij.ui.HyperlinkLabel" binding="txtTestEndpoint">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="1" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <maximum-size width="1000" height="-1"/>
               </grid>
             </constraints>
             <properties/>
           </component>
+          <component id="fefff" class="javax.swing.JRadioButton" binding="useJava8" default-binding="true">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="true"/>
+              <text value="Java 8"/>
+            </properties>
+          </component>
+          <component id="9d535" class="javax.swing.JRadioButton" binding="useJava11">
+            <constraints>
+              <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Java 11"/>
+            </properties>
+          </component>
+          <hspacer id="74f59">
+            <constraints>
+              <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
         </children>
       </grid>
     </children>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/creation/AbstractSpringCloudAppInfoPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/creation/AbstractSpringCloudAppInfoPanel.java
@@ -85,7 +85,7 @@ public abstract class AbstractSpringCloudAppInfoPanel extends JPanel implements 
             final SpringCloudCluster c = this.getSelectorCluster().getValue();
             final String appName = StringUtils.firstNonBlank(this.getTextName().getName(), this.defaultAppName);
             if (Objects.nonNull(c)) {
-                final SpringCloudApp app = c.apps().updateOrCreate(appName, c.getResourceGroupName());
+                final SpringCloudApp app = c.apps().create(appName, c.getResourceGroupName());
                 this.onAppChanged(app);
             }
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/creation/SpringCloudAppInfoAdvancedPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/creation/SpringCloudAppInfoAdvancedPanel.java
@@ -58,9 +58,9 @@ public class SpringCloudAppInfoAdvancedPanel extends AbstractSpringCloudAppInfoP
     public List<AzureFormInput<?>> getInputs() {
         final List<AzureFormInput<?>> inputs = this.formConfig.getInputs();
         inputs.addAll(Arrays.asList(
-                this.getSelectorSubscription(),
-                this.getSelectorCluster(),
-                this.getTextName()
+            this.getTextName(),
+            this.getSelectorSubscription(),
+            this.getSelectorCluster()
         ));
         return inputs;
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/creation/SpringCloudAppInfoBasicPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/creation/SpringCloudAppInfoBasicPanel.java
@@ -34,9 +34,9 @@ public class SpringCloudAppInfoBasicPanel extends AbstractSpringCloudAppInfoPane
     @Override
     public List<AzureFormInput<?>> getInputs() {
         return Arrays.asList(
-                this.getSelectorSubscription(),
-                this.getSelectorCluster(),
-                this.getTextName()
+            this.getTextName(),
+            this.getSelectorSubscription(),
+            this.getSelectorCluster()
         );
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/deplolyment/SpringCloudDeploymentConfigurationPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/deplolyment/SpringCloudDeploymentConfigurationPanel.java
@@ -166,10 +166,10 @@ public class SpringCloudDeploymentConfigurationPanel extends JPanel implements A
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
+            this.selectorApp,
             this.selectorArtifact,
             this.selectorSubscription,
-            this.selectorCluster,
-            this.selectorApp
+            this.selectorCluster
         };
         return Arrays.asList(inputs);
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-storage/src/main/java/com/microsoft/azure/toolkit/intellij/storage/connection/StorageAccountResourcePanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-storage/src/main/java/com/microsoft/azure/toolkit/intellij/storage/connection/StorageAccountResourcePanel.java
@@ -74,8 +74,8 @@ public class StorageAccountResourcePanel implements AzureFormJPanel<Resource<Sto
     @Override
     public List<AzureFormInput<?>> getInputs() {
         return Arrays.asList(
-                this.subscriptionComboBox,
-                this.accountComboBox
+            this.accountComboBox,
+            this.subscriptionComboBox
         );
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-storage/src/main/java/com/microsoft/azure/toolkit/intellij/storage/creation/BaseStorageAccountCreationDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-storage/src/main/java/com/microsoft/azure/toolkit/intellij/storage/creation/BaseStorageAccountCreationDialog.java
@@ -126,9 +126,9 @@ public class BaseStorageAccountCreationDialog extends AzureDialog<StorageAccount
     @Override
     public List<AzureFormInput<?>> getInputs() {
         final AzureFormInput<?>[] inputs = {
+            this.accountNameTextField,
             this.subscriptionComboBox,
             this.resourceGroupComboBox,
-            this.accountNameTextField,
             this.kindComboBox,
             this.performanceComboBox,
             this.redundancyComboBox,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/VMCreationDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/VMCreationDialog.java
@@ -486,8 +486,8 @@ public class VMCreationDialog extends AzureDialog<VirtualMachineDraft> implement
 
     @Override
     public List<AzureFormInput<?>> getInputs() {
-        return Arrays.asList(cbSubscription, cbImage, cbSize, cbAvailabilityOptions, cbVirtualNetwork, cbSubnet, cbSecurityGroup, cbPublicIp, cbStorageAccount,
-                txtUserName, txtVisualMachineName, passwordFieldInput, confirmPasswordFieldInput, txtCertificate, txtMaximumPrice);
+        return Arrays.asList(txtUserName, txtVisualMachineName, cbSubscription, cbImage, cbSize, cbAvailabilityOptions, cbVirtualNetwork, cbSubnet, cbSecurityGroup, cbPublicIp, cbStorageAccount,
+                passwordFieldInput, confirmPasswordFieldInput, txtCertificate, txtMaximumPrice);
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/VirtualMachineImageDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/VirtualMachineImageDialog.java
@@ -70,7 +70,7 @@ public class VirtualMachineImageDialog extends AzureDialog<VmImage> implements A
 
     @Override
     public List<AzureFormInput<?>> getInputs() {
-        return Arrays.asList(cbPublisher, cbOffer, cbSku, cbImage);
+        return Arrays.asList(cbImage, cbPublisher, cbOffer, cbSku);
     }
 
     private void createUIComponents() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/VirtualNetworkDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/VirtualNetworkDialog.java
@@ -91,7 +91,7 @@ public class VirtualNetworkDialog extends AzureDialog<NetworkDraft> implements A
 
     @Override
     public List<AzureFormInput<?>> getInputs() {
-        return Arrays.asList(txtAddressSpace, txtName, txtSubnetAddressRange, txtSubnetName);
+        return Arrays.asList(txtName, txtAddressSpace, txtSubnetAddressRange, txtSubnetName);
     }
 
     private void createUIComponents() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/java/com/microsoft/azure/toolkit/intellij/connector/aad/ApplicationTemplateForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/java/com/microsoft/azure/toolkit/intellij/connector/aad/ApplicationTemplateForm.java
@@ -165,7 +165,7 @@ class ApplicationTemplateForm implements AzureForm<Application> {
 
     @Override
     public List<AzureFormInput<?>> getInputs() {
-        return List.of(subscriptionBox, applicationsBox);
+        return List.of(applicationsBox, subscriptionBox);
     }
 
     public JPanel getContentPanel() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/java/com/microsoft/azure/toolkit/intellij/connector/aad/RegisterAzureApplicationForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-aad/src/main/java/com/microsoft/azure/toolkit/intellij/connector/aad/RegisterAzureApplicationForm.java
@@ -90,7 +90,7 @@ class RegisterAzureApplicationForm implements AzureFormJPanel<ApplicationRegistr
 
     @Override
     public List<AzureFormInput<?>> getInputs() {
-        return Arrays.asList(subscriptionBox, displayNameInput, callbackUrlsTable, domainInput, clientIdInput);
+        return Arrays.asList(displayNameInput, subscriptionBox, callbackUrlsTable, domainInput, clientIdInput);
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.java
@@ -164,9 +164,9 @@ public class ConnectorDialog extends AzureDialog<Connection<?, ?>> implements Az
     public List<AzureFormInput<?>> getInputs() {
         final ArrayList<AzureFormInput<?>> inputs = new ArrayList<>();
         //noinspection unchecked
-        inputs.addAll(consumerPanel.getInputs());
-        //noinspection unchecked
         inputs.addAll(resourcePanel.getInputs());
+        //noinspection unchecked
+        inputs.addAll(consumerPanel.getInputs());
         return inputs;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.java
@@ -28,6 +28,7 @@ import java.awt.event.ItemEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.microsoft.azure.toolkit.intellij.connector.ResourceDefinition.CONSUMER;
 import static com.microsoft.azure.toolkit.intellij.connector.ResourceDefinition.RESOURCE;
@@ -162,11 +163,11 @@ public class ConnectorDialog extends AzureDialog<Connection<?, ?>> implements Az
 
     @Override
     public List<AzureFormInput<?>> getInputs() {
-        final ArrayList<AzureFormInput<?>> inputs = new ArrayList<>();
+        final List<AzureFormInput<?>> inputs = new ArrayList<>();
         //noinspection unchecked
-        inputs.addAll(resourcePanel.getInputs());
+        Optional.ofNullable(resourcePanel).ifPresent(p -> inputs.addAll(p.getInputs()));
         //noinspection unchecked
-        inputs.addAll(consumerPanel.getInputs());
+        Optional.ofNullable(consumerPanel).ifPresent(p -> inputs.addAll(p.getInputs()));
         return inputs;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/ApplicationInsightsAddDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/ApplicationInsightsAddDialog.java
@@ -13,6 +13,7 @@ import com.microsoft.azuretools.azurecommons.util.WAEclipseHelperMethods;
 import com.microsoft.intellij.AzureSettings;
 import com.microsoft.intellij.ui.components.AzureDialogWrapper;
 import com.microsoft.intellij.util.PluginUtil;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.ArrayList;
@@ -81,5 +82,11 @@ public class ApplicationInsightsAddDialog extends AzureDialogWrapper {
         if (isValid) {
             super.doOKAction();
         }
+    }
+
+    @Nullable
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return this.txtName;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/ApplicationInsightsDetailsDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/ApplicationInsightsDetailsDialog.java
@@ -7,6 +7,7 @@ package com.microsoft.intellij.ui;
 
 import com.microsoft.applicationinsights.preference.ApplicationInsightsResource;
 import com.microsoft.intellij.ui.components.AzureDialogWrapper;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
@@ -47,5 +48,11 @@ public class ApplicationInsightsDetailsDialog extends AzureDialogWrapper {
     @Override
     protected JComponent createCenterPanel() {
         return contentPane;
+    }
+
+    @Nullable
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return this.txtName;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/ApplicationInsightsNewDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/ApplicationInsightsNewDialog.java
@@ -24,6 +24,7 @@ import com.microsoft.intellij.AzurePlugin;
 import com.microsoft.intellij.ui.components.AzureDialogWrapper;
 import com.microsoft.intellij.util.PluginUtil;
 import com.microsoft.tooling.msservices.helpers.azure.sdk.AzureSDKManager;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.ButtonGroup;
 import javax.swing.DefaultComboBoxModel;
@@ -183,5 +184,11 @@ public class ApplicationInsightsNewDialog extends AzureDialogWrapper {
 
     public void setOnCreate(Runnable onCreate) {
         this.onCreate = onCreate;
+    }
+
+    @Nullable
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return this.txtName;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SignInWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SignInWindow.java
@@ -135,4 +135,10 @@ public class SignInWindow extends AzureDialogWrapper {
     protected JComponent createCenterPanel() {
         return contentPane;
     }
+
+    @Nullable
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return this.cliBtn;
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.ui.AnActionButton;
-import com.intellij.ui.TableSpeedSearch;
 import com.intellij.ui.ToolbarDecorator;
 import com.intellij.ui.table.JBTable;
 import com.microsoft.azure.toolkit.lib.Azure;
@@ -149,15 +148,14 @@ public class SubscriptionsDialog extends AzureDialogWrapper {
         model.addColumn("Subscription name");
         model.addColumn("Subscription ID");
 
-        table = new JBTable();
-        table.setModel(model);
+        table = new JBTable(model);
         TableColumn column = table.getColumnModel().getColumn(CHECKBOX_COLUMN);
         column.setHeaderValue(""); // Don't show title text
         column.setMinWidth(23);
         column.setMaxWidth(23);
         JTableUtils.enableBatchSelection(table, CHECKBOX_COLUMN);
         table.getTableHeader().setReorderingAllowed(false);
-        new TableSpeedSearch(table);
+        // new TableSpeedSearch(table);
         AnActionButton refreshAction = new AnActionButton("Refresh", AllIcons.Actions.Refresh) {
             @Override
             public void actionPerformed(AnActionEvent anActionEvent) {
@@ -249,18 +247,14 @@ public class SubscriptionsDialog extends AzureDialogWrapper {
     }
 
     private static class SubscriptionTableModel extends DefaultTableModel {
-        final Class[] columnClass = new Class[]{
-            Boolean.class, String.class, String.class
-        };
-
         @Override
         public boolean isCellEditable(int row, int col) {
-            return (col == CHECKBOX_COLUMN);
+            return col == CHECKBOX_COLUMN;
         }
 
         @Override
-        public Class<?> getColumnClass(int columnIndex) {
-            return columnClass[columnIndex];
+        public Class<?> getColumnClass(int col) {
+            return col == CHECKBOX_COLUMN ? Boolean.class : super.getColumnClass(col);
         }
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/SubscriptionsDialog.java
@@ -51,9 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.ACCOUNT;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.GET_SUBSCRIPTIONS;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.SELECT_SUBSCRIPTIONS;
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.*;
 
 public class SubscriptionsDialog extends AzureDialogWrapper {
     private static final int CHECKBOX_COLUMN = 0;
@@ -242,6 +240,12 @@ public class SubscriptionsDialog extends AzureDialogWrapper {
     @Override
     protected String getDimensionServiceKey() {
         return "SubscriptionsDialog";
+    }
+
+    @Nullable
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return this.table;
     }
 
     private static class SubscriptionTableModel extends DefaultTableModel {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
set the first item of `AzureForm.getInputs() ` as the `preferredFocusedComponent` of `DialogWrapper`

Does this close any currently open issues?
------------------------------------------
[AB#1926172](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1926172): focus proper input once dialog is opened, so that user can input/operate directly by keyboard/shortcuts without additional mouse operation


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
`App name` input is focused in default.
![image](https://user-images.githubusercontent.com/69189193/159659597-5ea9fe5e-f8e5-42c8-881c-d42257e8246a.png)


Any other comments?
-------------------
N/P

Has this been tested?
---------------------------
- [x] Tested
