### PR TITLE
#1932859: [Test]Clicking "Show Properties" after clicking delete a function/web app in Azure Explorer will pop up an error

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/WebAppBasePropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/WebAppBasePropertyView.java
@@ -211,9 +211,9 @@ public abstract class WebAppBasePropertyView extends BaseEditor implements WebAp
     protected abstract WebAppBasePropertyViewPresenter createPresenter();
 
     @Override
-    public void onLoadWebAppProperty(@Nonnull final String sid, @Nonnull final String webAppId,
+    public void onLoadWebAppProperty(@Nonnull final String sid, @Nonnull final String appId,
                                      @Nullable final String slotName) {
-        this.presenter.onLoadWebAppProperty(sid, webAppId, slotName);
+        this.presenter.onLoadWebAppProperty(sid, appId, slotName);
     }
 
     @Nonnull

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/PublicIPAddressComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/PublicIPAddressComboBox.java
@@ -119,7 +119,7 @@ public class PublicIPAddressComboBox extends AzureComboBox<PublicIpAddress> {
 
     private void resetToDraft() {
         final PublicIpAddress value = getValue();
-        if (value != null && Objects.nonNull(subscription) && !value.isDraft()) {
+        if (value != null && Objects.nonNull(subscription) && !value.isDraftForCreating()) {
             final String name = PublicIpAddressDraft.generateDefaultName();
             final String rgName = Optional.ofNullable(resourceGroup).map(ResourceGroup::getName).orElse("<none>");
             this.draft = Azure.az(AzureNetwork.class).publicIpAddresses(subscription.getId()).create(name, rgName);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/VirtualNetworkComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-vm/src/main/java/com/microsoft/azure/toolkit/intellij/vm/creation/component/VirtualNetworkComboBox.java
@@ -70,7 +70,7 @@ public class VirtualNetworkComboBox extends AzureComboBox<Network> {
 
     private void resetToDraft() {
         final Network value = getValue();
-        if (value != null && Objects.nonNull(subscription) && !value.isDraft()) {
+        if (value != null && Objects.nonNull(subscription) && !value.isDraftForCreating()) {
             final String name = NetworkDraft.generateDefaultName();
             final String rgName = Optional.ofNullable(resourceGroup).map(ResourceGroup::getName).orElse("<none>");
             this.draft = Azure.az(AzureNetwork.class).virtualNetworks(subscription.getId()).create(name, rgName);

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyViewPresenter.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppPropertyViewPresenter.java
@@ -19,9 +19,9 @@ import java.util.Set;
 public class WebAppPropertyViewPresenter extends WebAppBasePropertyViewPresenter {
 
     @Override
-    protected WebApp getWebAppBase(@Nonnull final String sid, @Nonnull final String webAppId,
-                                   @Nullable final String name) {
-        return Azure.az(AzureWebApp.class).webApp(webAppId);
+    protected WebApp getWebAppBase(@Nonnull final String sid, @Nonnull final String appId,
+                                   @Nullable final String slotName) {
+        return Azure.az(AzureWebApp.class).webApp(appId);
     }
 
     @Override

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotPropertyViewPresenter.java
@@ -31,9 +31,9 @@ public class DeploymentSlotPropertyViewPresenter extends WebAppBasePropertyViewP
     }
 
     @Override
-    protected WebAppDeploymentSlot getWebAppBase(@Nonnull final String sid, @Nonnull final String webAppId,
-                                                  @Nullable final String name) {
-        final WebApp webApp = Azure.az(AzureWebApp.class).webApp(webAppId);
-        return Objects.requireNonNull(webApp).slots().get(name, webApp.getResourceGroupName());
+    protected WebAppDeploymentSlot getWebAppBase(@Nonnull final String sid, @Nonnull final String appId,
+                                                  @Nullable final String slotName) {
+        final WebApp webApp = Azure.az(AzureWebApp.class).webApp(appId);
+        return Objects.requireNonNull(webApp).slots().get(slotName, webApp.getResourceGroupName());
     }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* `onLoadWebAppProperty.slotName` may be null;
* Exception thrown in reactor won't be caught by our exception handling framework automatically


Does this close any currently open issues?
------------------------------------------
[AB#1932859](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1932859): [Test]Clicking "Show Properties" after clicking delete a function/web app in Azure Explorer will pop up an error


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
