### PR TITLE
[Do Not Merge] Fix URIBuilder behavior change after upgrading httpclient: 4.5.2 -> 4.5.13

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/AzureStorageUri.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/common/AzureStorageUri.java
@@ -135,7 +135,7 @@ abstract public class AzureStorageUri {
      */
     public static String encodeAndNormalizePath(String rawPath) {
         try {
-            String encodedPath = URI.create("/").relativize(new URIBuilder().setPath("/" + rawPath).build()).getRawPath();
+            String encodedPath = URI.create("/").relativize(new URIBuilder().setPath(rawPath).build()).getRawPath();
             return rawPath.startsWith("/") ? "/" + encodedPath : encodedPath;
         } catch (URISyntaxException ex) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Please don't merge this PR unless [#1991 in repo azure-maven-plugins](https://github.com/microsoft/azure-maven-plugins/pull/1991) is merged first.

In order to fix CVE issue [WS-2017-3734](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/12284?typeId=119493), we need to upgrade dependency `org.apache.httpcomponents:httpclient ` from  version `4.5.2` to latest version `4.5.13`. But if we do the upgrade in [Repo azure-maven-plugin](https://github.com/microsoft/azure-maven-plugins/pull/1991) , UT will fail. After debugging, we found the UT failure is caused by behavior  change of `URIBuilder`.

If we pass `"/subPath"` to the following code snippet, `httpclient:4.5.2` will return `/subPath` but `httpclient:4.5.13` will return `//subPath`.

```Java
new URIBuilder().setPath(rawPath).build()
```
We create this PR to fix such behavior change.

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
