### PR TITLE
Fix cve issues: CVE-2014-3643, CVE-2021-28169, CVE-2021-38296

### DIFF
--- a/Utils/hdinsight-node-common/pom.xml
+++ b/Utils/hdinsight-node-common/pom.xml
@@ -385,6 +385,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2021-38296-->
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-network-common</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -40,7 +40,7 @@
         <azure.toolkit-lib.version>0.20.0-SNAPSHOT</azure.toolkit-lib.version>
         <azure.toolkit-ide-lib.version>0.20.0-SNAPSHOT</azure.toolkit-ide-lib.version>
         <powermock.version>2.0.9</powermock.version>
-        <jetty.version>9.4.40.v20210413</jetty.version>
+        <jetty.version>9.4.41.v20210516</jetty.version><!--CVE-2021-28169-->
     </properties>
     <modules>
         <module>azure-toolkit-ide-libs</module>
@@ -258,6 +258,10 @@
                     <exclusion><!--WS-2018-0629-->
                         <groupId>com.fasterxml.woodstox</groupId>
                         <artifactId>woodstox-core</artifactId>
+                    </exclusion>
+                    <exclusion><!--CVE-2014-3643-->
+                        <groupId>com.sun.jersey</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/Utils/spark-localrun-mock/pom.xml
+++ b/Utils/spark-localrun-mock/pom.xml
@@ -266,6 +266,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2021-38296-->
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-network-common</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.1/pom.xml
+++ b/Utils/spark-tools/spark-v2.1/pom.xml
@@ -168,6 +168,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2021-38296-->
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-network-common</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.3/spark-v2.3.0/pom.xml
+++ b/Utils/spark-tools/spark-v2.3/spark-v2.3.0/pom.xml
@@ -181,6 +181,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2021-38296-->
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-network-common</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.3/spark-v2.3.2/pom.xml
+++ b/Utils/spark-tools/spark-v2.3/spark-v2.3.2/pom.xml
@@ -181,6 +181,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2021-38296-->
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-network-common</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix cve issues: 
[CVE-2014-3643](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/34930?typeId=119493): exclude com.sun.jersey: *
[CVE-2021-28169](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/63617?typeId=119493): upgrade jetty-server version from 9.4.40.v20210413 to 9.4.41.v20210516
[CVE-2021-38296](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/82809?typeId=119493): exclude org.apache.spark: spark-network-common



Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
