### PR TITLE
Upgrade hadoop version from 2.10.1 to 3.2.3

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -253,7 +253,7 @@
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
-                <version>2.10.1</version>
+                <version>3.2.3</version>
                 <exclusions>
                     <exclusion><!--WS-2018-0629-->
                         <groupId>com.fasterxml.woodstox</groupId>

--- a/Utils/spark-tools/pom.xml
+++ b/Utils/spark-tools/pom.xml
@@ -22,7 +22,7 @@
         <scala.version>${scala.version.major}.${scala.version.minor}</scala.version>
         <build.copyDependenciesPhase>none</build.copyDependenciesPhase>
         <CodeCacheSize>512m</CodeCacheSize>
-        <hadoop.version>2.10.1</hadoop.version>
+        <hadoop.version>3.2.3</hadoop.version>
         <test.exclude.tags></test.exclude.tags>
     </properties>
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
[CVE-2022-26612](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/84894?typeId=119493) Upgrade hadoop version from 2.10.1 to 3.2.3 




Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
