### PR TITLE
Fix cve-2012-5783

### DIFF
--- a/Utils/hdinsight-node-common/pom.xml
+++ b/Utils/hdinsight-node-common/pom.xml
@@ -393,6 +393,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-localrun-mock/pom.xml
+++ b/Utils/spark-localrun-mock/pom.xml
@@ -274,6 +274,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix [cve-2012-5783](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/23854?typeId=119493)
exclude  commons-httpclient:commons-httpclient

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
