### PR TITLE
upgrade jetty to `9.4.46.v20220331` to resolve CVE-2021-28169

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -40,7 +40,7 @@
         <azure.toolkit-lib.version>0.20.0-SNAPSHOT</azure.toolkit-lib.version>
         <azure.toolkit-ide-lib.version>0.20.0-SNAPSHOT</azure.toolkit-ide-lib.version>
         <powermock.version>2.0.9</powermock.version>
-        <jetty.version>9.4.40.v20210413</jetty.version>
+        <jetty.version>9.4.46.v20220331</jetty.version>
     </properties>
     <modules>
         <module>azure-toolkit-ide-libs</module>

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -40,7 +40,7 @@
         <azure.toolkit-lib.version>0.20.0-SNAPSHOT</azure.toolkit-lib.version>
         <azure.toolkit-ide-lib.version>0.20.0-SNAPSHOT</azure.toolkit-ide-lib.version>
         <powermock.version>2.0.9</powermock.version>
-        <jetty.version>9.4.46.v20220331</jetty.version>
+        <jetty.version>9.4.41.v20210516</jetty.version>
     </properties>
     <modules>
         <module>azure-toolkit-ide-libs</module>


### PR DESCRIPTION
[AB#1908684](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1908684): CVE-2021-28169 in org.eclipse.jetty:jetty-http 9.4.40.v20210413. Severity: Medium