### PR TITLE
add support for 0.5Gi, 0.5vCPU, Java17 and enterprise tier.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.form
@@ -206,7 +206,7 @@
               </component>
             </children>
           </grid>
-          <component id="c8e4" class="javax.swing.JLabel">
+          <component id="c8e4" class="javax.swing.JLabel" binding="lblRuntime">
             <constraints>
               <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <minimum-size width="100" height="24"/>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.form
@@ -156,7 +156,7 @@
               </component>
             </children>
           </grid>
-          <component id="5faee" class="javax.swing.JLabel">
+          <component id="5faee" class="javax.swing.JLabel" binding="lblDisk">
             <constraints>
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <minimum-size width="100" height="24"/>
@@ -169,7 +169,7 @@
               <text value="Persistent storage:"/>
             </properties>
           </component>
-          <grid id="a28b7" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="a28b7" binding="pnlDisk" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="2" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.form
@@ -88,7 +88,7 @@
             </constraints>
             <properties>
               <horizontalAlignment value="11"/>
-              <text value="Memory/GB:"/>
+              <text value="Memory:"/>
             </properties>
           </component>
           <component id="e47aa" class="com.intellij.openapi.ui.ComboBox" binding="numMemory">

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.form
@@ -99,7 +99,7 @@
           </component>
         </children>
       </grid>
-      <grid id="d4252" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="d4252" layout-manager="GridLayoutManager" row-count="6" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="1" use-parent-layout="false"/>
@@ -122,7 +122,7 @@
           <grid id="da7cf" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>
@@ -172,7 +172,7 @@
           <grid id="a28b7" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>
@@ -233,7 +233,7 @@
           </component>
           <component id="76d4b" class="javax.swing.JTextField" binding="txtJvmOptions">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="4" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -255,7 +255,7 @@
           </component>
           <component id="c58f3" class="com.microsoft.azure.toolkit.intellij.common.EnvironmentVariablesTextFieldWithBrowseButton" binding="envTable">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
@@ -273,7 +273,7 @@
           </component>
           <component id="5aaff" class="com.intellij.ui.HyperlinkLabel" binding="txtTestEndpoint">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <maximum-size width="1000" height="-1"/>
               </grid>
             </constraints>
@@ -298,9 +298,17 @@
           </component>
           <hspacer id="74f59">
             <constraints>
-              <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
+          <component id="aa7f4" class="javax.swing.JRadioButton" binding="useJava17">
+            <constraints>
+              <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Java 17"/>
+            </properties>
+          </component>
         </children>
       </grid>
     </children>
@@ -309,6 +317,7 @@
     <group name="javaVersion">
       <member id="9d535"/>
       <member id="fefff"/>
+      <member id="aa7f4"/>
     </group>
   </buttonGroups>
 </form>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.toolkit.intellij.springcloud.component;
 
+import com.azure.resourcemanager.appplatform.models.RuntimeVersion;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.ui.DocumentAdapter;
 import com.intellij.ui.HyperlinkLabel;
@@ -21,7 +22,6 @@ import com.microsoft.azure.toolkit.lib.common.utils.TailingDebouncer;
 import com.microsoft.azure.toolkit.lib.springcloud.SpringCloudApp;
 import com.microsoft.azure.toolkit.lib.springcloud.config.SpringCloudAppConfig;
 import com.microsoft.azure.toolkit.lib.springcloud.config.SpringCloudDeploymentConfig;
-import com.microsoft.azure.toolkit.lib.springcloud.model.SpringCloudJavaVersion;
 import com.microsoft.azure.toolkit.lib.springcloud.model.SpringCloudPersistentDisk;
 import com.microsoft.azure.toolkit.lib.springcloud.model.SpringCloudSku;
 import lombok.Getter;
@@ -51,6 +51,7 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
     private JButton toggleStorage;
     private JRadioButton useJava8;
     private JRadioButton useJava11;
+    private JRadioButton useJava17;
     private JTextField txtJvmOptions;
     private EnvironmentVariablesTextFieldWithBrowseButton envTable;
     private ComboBox<Double> numCpu;
@@ -83,6 +84,7 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
         this.txtStorage.setBorder(JBUI.Borders.empty(0, 2));
         this.useJava8.addActionListener((e) -> debouncer.debounce());
         this.useJava11.addActionListener((e) -> debouncer.debounce());
+        this.useJava17.addActionListener((e) -> debouncer.debounce());
         this.txtJvmOptions.getDocument().addDocumentListener(new DocumentAdapter() {
             @Override
             protected void textChanged(DocumentEvent documentEvent) {
@@ -183,7 +185,8 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
     public SpringCloudAppConfig getValue(@Nonnull SpringCloudAppConfig appConfig) { // get config from form
         final SpringCloudDeploymentConfig deploymentConfig = Optional.ofNullable(appConfig.getDeployment())
             .orElse(SpringCloudDeploymentConfig.builder().build());
-        final String javaVersion = this.useJava11.isSelected() ? SpringCloudJavaVersion.JAVA_11 : SpringCloudJavaVersion.JAVA_8;
+        final String javaVersion = this.useJava17.isSelected() ? RuntimeVersion.JAVA_17.toString() :
+            this.useJava11.isSelected() ? RuntimeVersion.JAVA_11.toString() : RuntimeVersion.JAVA_8.toString();
         appConfig.setIsPublic("disable".equals(this.toggleEndpoint.getActionCommand()));
         deploymentConfig.setRuntimeVersion(javaVersion);
         deploymentConfig.setEnablePersistentStorage("disable".equals(this.toggleStorage.getActionCommand()));
@@ -202,9 +205,9 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
         final SpringCloudDeploymentConfig deployment = config.getDeployment();
         this.toggleStorage(deployment.getEnablePersistentStorage());
         this.toggleEndpoint(config.getIsPublic());
-        final boolean java11 = StringUtils.equalsIgnoreCase(deployment.getRuntimeVersion(), SpringCloudJavaVersion.JAVA_11);
-        this.useJava11.setSelected(java11);
-        this.useJava8.setSelected(!java11);
+        this.useJava17.setSelected(StringUtils.equalsIgnoreCase(deployment.getRuntimeVersion(), RuntimeVersion.JAVA_17.toString()));
+        this.useJava11.setSelected(StringUtils.equalsIgnoreCase(deployment.getRuntimeVersion(), RuntimeVersion.JAVA_11.toString()));
+        this.useJava8.setSelected(StringUtils.equalsIgnoreCase(deployment.getRuntimeVersion(), RuntimeVersion.JAVA_8.toString()));
 
         this.txtJvmOptions.setText(deployment.getJvmOptions());
         final Map<String, String> env = deployment.getEnvironment();
@@ -228,6 +231,7 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
     public void setEnabled(boolean enable) {
         this.useJava8.setEnabled(enable);
         this.useJava11.setEnabled(enable);
+        this.useJava17.setEnabled(enable);
         this.toggleEndpoint.setEnabled(enable);
         this.toggleStorage.setEnabled(enable);
         numCpu.setEnabled(enable);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.java
@@ -60,6 +60,7 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
     private JBLabel statusEndpoint;
     private JBLabel statusStorage;
     private JLabel lblTestEndpoint;
+    private JLabel lblRuntime;
 
     private Consumer<? super SpringCloudAppConfig> listener = (config) -> {
     };
@@ -163,6 +164,11 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
             }, AzureTask.Modality.ANY);
         });
         final SpringCloudSku sku = app.getParent().getSku();
+        final boolean enterprise = sku.getTier().toLowerCase().startsWith("e");
+        this.useJava8.setVisible(!enterprise);
+        this.useJava11.setVisible(!enterprise);
+        this.useJava17.setVisible(!enterprise);
+        this.lblRuntime.setVisible(!enterprise);
         final boolean basic = sku.getTier().toLowerCase().startsWith("b");
         final Double cpu = this.numCpu.getItem();
         final Double mem = this.numMemory.getItem();
@@ -185,10 +191,14 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
     public SpringCloudAppConfig getValue(@Nonnull SpringCloudAppConfig appConfig) { // get config from form
         final SpringCloudDeploymentConfig deploymentConfig = Optional.ofNullable(appConfig.getDeployment())
             .orElse(SpringCloudDeploymentConfig.builder().build());
-        final String javaVersion = this.useJava17.isSelected() ? RuntimeVersion.JAVA_17.toString() :
-            this.useJava11.isSelected() ? RuntimeVersion.JAVA_11.toString() : RuntimeVersion.JAVA_8.toString();
+        if (this.useJava17.isVisible()) {
+            final String javaVersion = this.useJava17.isSelected() ? RuntimeVersion.JAVA_17.toString() :
+                this.useJava11.isSelected() ? RuntimeVersion.JAVA_11.toString() : RuntimeVersion.JAVA_8.toString();
+            deploymentConfig.setRuntimeVersion(javaVersion);
+        } else {
+            deploymentConfig.setRuntimeVersion(null);
+        }
         appConfig.setIsPublic("disable".equals(this.toggleEndpoint.getActionCommand()));
-        deploymentConfig.setRuntimeVersion(javaVersion);
         deploymentConfig.setEnablePersistentStorage("disable".equals(this.toggleStorage.getActionCommand()));
         deploymentConfig.setCpu(numCpu.getItem());
         deploymentConfig.setMemoryInGB(numMemory.getItem());

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.java
@@ -23,7 +23,6 @@ import com.microsoft.azure.toolkit.lib.springcloud.SpringCloudApp;
 import com.microsoft.azure.toolkit.lib.springcloud.config.SpringCloudAppConfig;
 import com.microsoft.azure.toolkit.lib.springcloud.config.SpringCloudDeploymentConfig;
 import com.microsoft.azure.toolkit.lib.springcloud.model.SpringCloudPersistentDisk;
-import com.microsoft.azure.toolkit.lib.springcloud.model.SpringCloudSku;
 import lombok.Getter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
@@ -163,13 +162,13 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
                 }
             }, AzureTask.Modality.ANY);
         });
-        final SpringCloudSku sku = app.getParent().getSku();
-        final boolean enterprise = sku.getTier().toLowerCase().startsWith("e");
+        final String sku = app.getParent().getSku();
+        final boolean enterprise = sku.toLowerCase().startsWith("e");
         this.useJava8.setVisible(!enterprise);
         this.useJava11.setVisible(!enterprise);
         this.useJava17.setVisible(!enterprise);
         this.lblRuntime.setVisible(!enterprise);
-        final boolean basic = sku.getTier().toLowerCase().startsWith("b");
+        final boolean basic = sku.toLowerCase().startsWith("b");
         final Double cpu = this.numCpu.getItem();
         final Double mem = this.numMemory.getItem();
         final Double[] cpus = basic ? new Double[]{0.5, 1.0} : new Double[]{0.5, 1.0, 2.0, 3.0, 4.0};

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/component/SpringCloudAppConfigPanel.java
@@ -60,6 +60,8 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
     private JBLabel statusStorage;
     private JLabel lblTestEndpoint;
     private JLabel lblRuntime;
+    private JLabel lblDisk;
+    private JPanel pnlDisk;
 
     private Consumer<? super SpringCloudAppConfig> listener = (config) -> {
     };
@@ -168,6 +170,8 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
         this.useJava11.setVisible(!enterprise);
         this.useJava17.setVisible(!enterprise);
         this.lblRuntime.setVisible(!enterprise);
+        this.lblDisk.setVisible(!enterprise);
+        this.pnlDisk.setVisible(!enterprise);
         final boolean basic = sku.toLowerCase().startsWith("b");
         final Double cpu = this.numCpu.getItem();
         final Double mem = this.numMemory.getItem();
@@ -190,15 +194,17 @@ public class SpringCloudAppConfigPanel extends JPanel implements AzureFormPanel<
     public SpringCloudAppConfig getValue(@Nonnull SpringCloudAppConfig appConfig) { // get config from form
         final SpringCloudDeploymentConfig deploymentConfig = Optional.ofNullable(appConfig.getDeployment())
             .orElse(SpringCloudDeploymentConfig.builder().build());
-        if (this.useJava17.isVisible()) {
+        final boolean isEnterpriseTier = this.useJava17.isVisible();
+        if (isEnterpriseTier) {
             final String javaVersion = this.useJava17.isSelected() ? RuntimeVersion.JAVA_17.toString() :
                 this.useJava11.isSelected() ? RuntimeVersion.JAVA_11.toString() : RuntimeVersion.JAVA_8.toString();
             deploymentConfig.setRuntimeVersion(javaVersion);
+            deploymentConfig.setEnablePersistentStorage("disable".equals(this.toggleStorage.getActionCommand()));
         } else {
             deploymentConfig.setRuntimeVersion(null);
+            deploymentConfig.setEnablePersistentStorage(false);
         }
         appConfig.setIsPublic("disable".equals(this.toggleEndpoint.getActionCommand()));
-        deploymentConfig.setEnablePersistentStorage("disable".equals(this.toggleStorage.getActionCommand()));
         deploymentConfig.setCpu(numCpu.getItem());
         deploymentConfig.setMemoryInGB(numMemory.getItem());
         deploymentConfig.setInstanceCount(numInstance.getValue());

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/ide/springcloud/SpringCloudActionsContributor.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/ide/springcloud/SpringCloudActionsContributor.java
@@ -57,7 +57,7 @@ public class SpringCloudActionsContributor implements IActionsContributor {
                 .enabled(s -> s instanceof SpringCloudApp && ((AzResourceBase) s).getFormalStatus().isRunning());
         am.registerAction(STREAM_LOG, new Action<>(STREAM_LOG, streamLogView));
 
-        final ActionView.Builder createClusterView = new ActionView.Builder("Spring Cloud Service")
+        final ActionView.Builder createClusterView = new ActionView.Builder("Spring Apps")
             .title(s -> Optional.ofNullable(s).map(r -> description("springcloud.create_cluster.group", ((ResourceGroup) r).getName())).orElse(null))
             .enabled(s -> s instanceof ResourceGroup);
         am.registerAction(GROUP_CREATE_CLUSTER, new Action<>(GROUP_CREATE_CLUSTER, createClusterView));


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
[AB#1945859](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1945859): support 0.5core and 0.5G memory when configuring spring apps in maven plugin
[AB#1946695](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1946695): add support for Java17
[AB#1942841](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1942841): [Test]When creating the spring app, there should be no output about deploy
[AB#1945868](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1945868): upgrade azure-resourcemanager-appplatform to the latest and fix compatibility issues.


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
