### PR TITLE
Revert "bump version of eclipse plugin to `3.31.0`"

### DIFF
--- a/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml
+++ b/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml
@@ -31,7 +31,7 @@
   </parent>
   <groupId>com.microsoft.azuretools</groupId>
   <artifactId>com.microsoft.azuretools.sdk.lib</artifactId>
-  <version>3.31.0</version>
+  <version>3.31.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>Package for Microsoft Azure Libraries for Java Plugin</name>
   <organization>

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/pom.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tycho-version>2.5.0</tycho-version>
-    <azuretool.eclipse.version>3.31.0</azuretool.eclipse.version>
+    <azuretool.eclipse.version>3.31.0-SNAPSHOT</azuretool.eclipse.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This reverts commit 15b87474e56b9b33c62fb1d35d22e97aaf7f4f8d.

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
