### PR TITLE
#1950086: migrate to use extension point (instead of preloading activity) to register resource/connection definitions for resource connector

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-applicationinsights/src/main/java/com/microsoft/azure/toolkit/intellij/applicationinsights/connection/ApplicationInsightsResourceDefinition.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-applicationinsights/src/main/java/com/microsoft/azure/toolkit/intellij/applicationinsights/connection/ApplicationInsightsResourceDefinition.java
@@ -6,16 +6,13 @@
 package com.microsoft.azure.toolkit.intellij.applicationinsights.connection;
 
 import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.openapi.application.PreloadingActivity;
 import com.intellij.openapi.extensions.PluginId;
-import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.intellij.common.AzureFormJPanel;
 import com.microsoft.azure.toolkit.intellij.connector.AzureServiceResource;
 import com.microsoft.azure.toolkit.intellij.connector.IJavaAgentSupported;
 import com.microsoft.azure.toolkit.intellij.connector.Resource;
-import com.microsoft.azure.toolkit.intellij.connector.ResourceManager;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.applicationinsights.ApplicationInsight;
 import com.microsoft.azure.toolkit.lib.applicationinsights.AzureApplicationInsights;
@@ -23,7 +20,6 @@ import com.microsoft.azure.toolkit.lib.common.cache.Preload;
 import com.microsoft.intellij.CommonConst;
 import lombok.Getter;
 import org.apache.commons.io.FileUtils;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -34,11 +30,10 @@ import java.util.Map;
 
 @Getter
 public class ApplicationInsightsResourceDefinition extends AzureServiceResource.Definition<ApplicationInsight> implements IJavaAgentSupported {
-    public static final ApplicationInsightsResourceDefinition INSTANCE =
-            new ApplicationInsightsResourceDefinition("Azure.Insights", "Azure Application Insights", AzureIcons.ApplicationInsights.MODULE.getIconPath());
+    public static final ApplicationInsightsResourceDefinition INSTANCE = new ApplicationInsightsResourceDefinition();
 
-    private ApplicationInsightsResourceDefinition(String name, String title, String icon) {
-        super(name, title, icon);
+    public ApplicationInsightsResourceDefinition() {
+        super("Azure.Insights", "Azure Application Insights", AzureIcons.ApplicationInsights.MODULE.getIconPath());
     }
 
     @Override
@@ -85,13 +80,6 @@ public class ApplicationInsightsResourceDefinition extends AzureServiceResource.
                 }
             }
             return applicationInsightsLibrary;
-        }
-    }
-
-    public static class RegisterActivity extends PreloadingActivity {
-        @Override
-        public void preload(@NotNull ProgressIndicator progressIndicator) {
-            ResourceManager.registerDefinition(INSTANCE);
         }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-applicationinsights/src/main/resources/META-INF/azure-intellij-plugin-applicationinsights.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-applicationinsights/src/main/resources/META-INF/azure-intellij-plugin-applicationinsights.xml
@@ -1,10 +1,8 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.microsoft.tooling.msservices.intellij.azure">
+        <connectorResourceType implementation="com.microsoft.azure.toolkit.intellij.applicationinsights.connection.ApplicationInsightsResourceDefinition"/>
         <explorerNodeProvider implementation="com.microsoft.azure.toolkit.ide.applicationinsights.ApplicationInsightsNodeProvider"/>
         <actions implementation="com.microsoft.azure.toolkit.ide.applicationinsights.ApplicationInsightsActionsContributor"/>
         <actions implementation="com.microsoft.azure.toolkit.intellij.applicationinsights.IntelliJApplicationInsightsActionsContributor"/>
-    </extensions>
-    <extensions defaultExtensionNs="com.intellij">
-        <preloadingActivity implementation="com.microsoft.azure.toolkit.intellij.applicationinsights.connection.ApplicationInsightsResourceDefinition$RegisterActivity"/>
     </extensions>
 </idea-plugin>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/mysql/connection/MySqlDatabaseResourceDefinition.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/mysql/connection/MySqlDatabaseResourceDefinition.java
@@ -6,22 +6,17 @@
 package com.microsoft.azure.toolkit.intellij.database.mysql.connection;
 
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
-import com.intellij.openapi.application.PreloadingActivity;
-import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.intellij.common.AzureFormJPanel;
 import com.microsoft.azure.toolkit.intellij.connector.Resource;
-import com.microsoft.azure.toolkit.intellij.connector.ResourceManager;
 import com.microsoft.azure.toolkit.intellij.database.connection.SqlDatabaseResourceDefinition;
 import com.microsoft.azure.toolkit.intellij.database.connection.SqlDatabaseResourcePanel;
 import com.microsoft.azure.toolkit.lib.Azure;
-import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import com.microsoft.azure.toolkit.lib.mysql.AzureMySql;
 import com.microsoft.azure.toolkit.lib.mysql.MySqlDatabase;
 import com.microsoft.azure.toolkit.lib.mysql.MySqlServer;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 public class MySqlDatabaseResourceDefinition extends SqlDatabaseResourceDefinition<MySqlDatabase> {
@@ -44,14 +39,6 @@ public class MySqlDatabaseResourceDefinition extends SqlDatabaseResourceDefiniti
     @Override
     public AzureFormJPanel<Resource<MySqlDatabase>> getResourcePanel(Project project) {
         return new SqlDatabaseResourcePanel<>(this, s -> Azure.az(AzureMySql.class).servers(s).list());
-    }
-
-    public static class RegisterActivity extends PreloadingActivity {
-        @Override
-        @ExceptionNotification
-        public void preload(@Nonnull ProgressIndicator progressIndicator) {
-            ResourceManager.registerDefinition(MySqlDatabaseResourceDefinition.INSTANCE);
-        }
     }
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/postgre/connection/PostgreSqlDatabaseResourceDefinition.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/postgre/connection/PostgreSqlDatabaseResourceDefinition.java
@@ -6,22 +6,17 @@
 package com.microsoft.azure.toolkit.intellij.database.postgre.connection;
 
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
-import com.intellij.openapi.application.PreloadingActivity;
-import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.intellij.common.AzureFormJPanel;
 import com.microsoft.azure.toolkit.intellij.connector.Resource;
-import com.microsoft.azure.toolkit.intellij.connector.ResourceManager;
 import com.microsoft.azure.toolkit.intellij.database.connection.SqlDatabaseResourceDefinition;
 import com.microsoft.azure.toolkit.intellij.database.connection.SqlDatabaseResourcePanel;
 import com.microsoft.azure.toolkit.lib.Azure;
-import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import com.microsoft.azure.toolkit.lib.postgre.AzurePostgreSql;
 import com.microsoft.azure.toolkit.lib.postgre.PostgreSqlDatabase;
 import com.microsoft.azure.toolkit.lib.postgre.PostgreSqlServer;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 public class PostgreSqlDatabaseResourceDefinition extends SqlDatabaseResourceDefinition<PostgreSqlDatabase> {
@@ -44,14 +39,6 @@ public class PostgreSqlDatabaseResourceDefinition extends SqlDatabaseResourceDef
     @Override
     public AzureFormJPanel<Resource<PostgreSqlDatabase>> getResourcePanel(Project project) {
         return new SqlDatabaseResourcePanel<>(this, s -> Azure.az(AzurePostgreSql.class).servers(s).list());
-    }
-
-    public static class RegisterActivity extends PreloadingActivity {
-        @Override
-        @ExceptionNotification
-        public void preload(@Nonnull ProgressIndicator progressIndicator) {
-            ResourceManager.registerDefinition(PostgreSqlDatabaseResourceDefinition.INSTANCE);
-        }
     }
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/sqlserver/connection/SqlServerDatabaseResourceDefinition.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/sqlserver/connection/SqlServerDatabaseResourceDefinition.java
@@ -6,22 +6,17 @@
 package com.microsoft.azure.toolkit.intellij.database.sqlserver.connection;
 
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
-import com.intellij.openapi.application.PreloadingActivity;
-import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.intellij.common.AzureFormJPanel;
 import com.microsoft.azure.toolkit.intellij.connector.Resource;
-import com.microsoft.azure.toolkit.intellij.connector.ResourceManager;
 import com.microsoft.azure.toolkit.intellij.database.connection.SqlDatabaseResourceDefinition;
 import com.microsoft.azure.toolkit.intellij.database.connection.SqlDatabaseResourcePanel;
 import com.microsoft.azure.toolkit.lib.Azure;
-import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import com.microsoft.azure.toolkit.lib.sqlserver.AzureSqlServer;
 import com.microsoft.azure.toolkit.lib.sqlserver.MicrosoftSqlDatabase;
 import com.microsoft.azure.toolkit.lib.sqlserver.MicrosoftSqlServer;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 public class SqlServerDatabaseResourceDefinition extends SqlDatabaseResourceDefinition<MicrosoftSqlDatabase> {
@@ -44,14 +39,6 @@ public class SqlServerDatabaseResourceDefinition extends SqlDatabaseResourceDefi
     @Override
     public AzureFormJPanel<Resource<MicrosoftSqlDatabase>> getResourcePanel(Project project) {
         return new SqlDatabaseResourcePanel<>(this, s -> Azure.az(AzureSqlServer.class).servers(s).list());
-    }
-
-    public static class RegisterActivity extends PreloadingActivity {
-        @Override
-        @ExceptionNotification
-        public void preload(@Nonnull ProgressIndicator progressIndicator) {
-            ResourceManager.registerDefinition(SqlServerDatabaseResourceDefinition.INSTANCE);
-        }
     }
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/resources/META-INF/azure-intellij-plugin-database.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/resources/META-INF/azure-intellij-plugin-database.xml
@@ -1,5 +1,8 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.microsoft.tooling.msservices.intellij.azure">
+        <connectorResourceType implementation="com.microsoft.azure.toolkit.intellij.database.mysql.connection.MySqlDatabaseResourceDefinition"/>
+        <connectorResourceType implementation="com.microsoft.azure.toolkit.intellij.database.postgre.connection.PostgreSqlDatabaseResourceDefinition"/>
+        <connectorResourceType implementation="com.microsoft.azure.toolkit.intellij.database.sqlserver.connection.SqlServerDatabaseResourceDefinition"/>
         <explorerNodeProvider implementation="com.microsoft.azure.toolkit.ide.database.postgre.PostgreSqlNodeProvider"/>
         <actions implementation="com.microsoft.azure.toolkit.ide.database.postgre.PostgreSqlActionsContributor"/>
         <actions implementation="com.microsoft.azure.toolkit.intellij.database.postgre.IntellijPostgreSqlActionsContributor"/>
@@ -12,10 +15,7 @@
     </extensions>
     <extensions defaultExtensionNs="com.intellij">
         <fileEditorProvider implementation="com.microsoft.azure.toolkit.intellij.database.postgre.property.PostgreSqlPropertiesEditorProvider"/>
-        <preloadingActivity implementation="com.microsoft.azure.toolkit.intellij.database.postgre.connection.PostgreSqlDatabaseResourceDefinition$RegisterActivity"/>
         <fileEditorProvider implementation="com.microsoft.azure.toolkit.intellij.database.mysql.property.MySqlPropertiesEditorProvider"/>
-        <preloadingActivity implementation="com.microsoft.azure.toolkit.intellij.database.mysql.connection.MySqlDatabaseResourceDefinition$RegisterActivity"/>
         <fileEditorProvider implementation="com.microsoft.azure.toolkit.intellij.database.sqlserver.property.SqlServerPropertiesEditorProvider"/>
-        <preloadingActivity implementation="com.microsoft.azure.toolkit.intellij.database.sqlserver.connection.SqlServerDatabaseResourceDefinition$RegisterActivity"/>
     </extensions>
 </idea-plugin>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/connection/RedisResourceDefinition.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/java/com/microsoft/azure/toolkit/intellij/redis/connection/RedisResourceDefinition.java
@@ -6,24 +6,19 @@
 package com.microsoft.azure.toolkit.intellij.redis.connection;
 
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
-import com.intellij.openapi.application.PreloadingActivity;
-import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.intellij.common.AzureFormJPanel;
 import com.microsoft.azure.toolkit.intellij.connector.AzureServiceResource;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
 import com.microsoft.azure.toolkit.intellij.connector.Resource;
-import com.microsoft.azure.toolkit.intellij.connector.ResourceManager;
 import com.microsoft.azure.toolkit.intellij.connector.spring.SpringSupported;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.auth.AzureCloud;
-import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import com.microsoft.azure.toolkit.redis.AzureRedis;
 import com.microsoft.azure.toolkit.redis.RedisCache;
 import lombok.Getter;
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,7 +30,7 @@ import java.util.Objects;
 public class RedisResourceDefinition extends AzureServiceResource.Definition<RedisCache> implements SpringSupported<RedisCache> {
     public static final RedisResourceDefinition INSTANCE = new RedisResourceDefinition();
 
-    private RedisResourceDefinition() {
+    public RedisResourceDefinition() {
         super("Azure.Redis", "Azure Redis Cache", AzureIcons.RedisCache.MODULE.getIconPath());
     }
 
@@ -71,13 +66,5 @@ public class RedisResourceDefinition extends AzureServiceResource.Definition<Red
     @Override
     public AzureFormJPanel<Resource<RedisCache>> getResourcePanel(Project project) {
         return new RedisResourcePanel();
-    }
-
-    public static class RegisterActivity extends PreloadingActivity {
-        @Override
-        @ExceptionNotification
-        public void preload(@NotNull ProgressIndicator progressIndicator) {
-            ResourceManager.registerDefinition(INSTANCE);
-        }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/resources/META-INF/azure-intellij-plugin-redis.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-redis/src/main/resources/META-INF/azure-intellij-plugin-redis.xml
@@ -1,5 +1,6 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.microsoft.tooling.msservices.intellij.azure">
+        <connectorResourceType implementation="com.microsoft.azure.toolkit.intellij.redis.connection.RedisResourceDefinition"/>
         <explorerNodeProvider implementation="com.microsoft.azure.toolkit.ide.redis.RedisNodeProvider"/>
         <actions implementation="com.microsoft.azure.toolkit.ide.redis.RedisActionsContributor"/>
         <actions implementation="com.microsoft.azure.toolkit.intellij.redis.IntellijRedisActionsContributor"/>
@@ -7,6 +8,5 @@
     <extensions defaultExtensionNs="com.intellij">
         <fileEditorProvider implementation="com.microsoft.azure.toolkit.intellij.redis.property.RedisCachePropertiesEditorProvider"/>
         <fileEditorProvider implementation="com.microsoft.azure.toolkit.intellij.redis.explorer.RedisCacheExplorerProvider"/>
-        <preloadingActivity implementation="com.microsoft.azure.toolkit.intellij.redis.connection.RedisResourceDefinition$RegisterActivity"/>
     </extensions>
 </idea-plugin>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-storage/src/main/java/com/microsoft/azure/toolkit/intellij/storage/connection/StorageAccountResourceDefinition.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-storage/src/main/java/com/microsoft/azure/toolkit/intellij/storage/connection/StorageAccountResourceDefinition.java
@@ -6,24 +6,19 @@
 package com.microsoft.azure.toolkit.intellij.storage.connection;
 
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
-import com.intellij.openapi.application.PreloadingActivity;
-import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.intellij.common.AzureFormJPanel;
 import com.microsoft.azure.toolkit.intellij.connector.AzureServiceResource;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
 import com.microsoft.azure.toolkit.intellij.connector.Resource;
-import com.microsoft.azure.toolkit.intellij.connector.ResourceManager;
 import com.microsoft.azure.toolkit.intellij.connector.spring.SpringSupported;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.auth.AzureCloud;
-import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import com.microsoft.azure.toolkit.lib.storage.AzureStorageAccount;
 import com.microsoft.azure.toolkit.lib.storage.StorageAccount;
 import lombok.Getter;
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,7 +29,7 @@ import java.util.Map;
 public class StorageAccountResourceDefinition extends AzureServiceResource.Definition<StorageAccount> implements SpringSupported<StorageAccount> {
     public static final StorageAccountResourceDefinition INSTANCE = new StorageAccountResourceDefinition();
 
-    private StorageAccountResourceDefinition() {
+    public StorageAccountResourceDefinition() {
         super("Azure.Storage", "Azure Storage Account", AzureIcons.StorageAccount.MODULE.getIconPath());
     }
 
@@ -74,13 +69,5 @@ public class StorageAccountResourceDefinition extends AzureServiceResource.Defin
     @Override
     public AzureFormJPanel<Resource<StorageAccount>> getResourcePanel(Project project) {
         return new StorageAccountResourcePanel();
-    }
-
-    public static class RegisterActivity extends PreloadingActivity {
-        @Override
-        @ExceptionNotification
-        public void preload(@NotNull ProgressIndicator progressIndicator) {
-            ResourceManager.registerDefinition(INSTANCE);
-        }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-storage/src/main/resources/META-INF/azure-intellij-plugin-storage.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-storage/src/main/resources/META-INF/azure-intellij-plugin-storage.xml
@@ -1,10 +1,8 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.microsoft.tooling.msservices.intellij.azure">
+        <connectorResourceType implementation="com.microsoft.azure.toolkit.intellij.storage.connection.StorageAccountResourceDefinition"/>
         <explorerNodeProvider implementation="com.microsoft.azure.toolkit.ide.storage.StorageNodeProvider"/>
         <actions implementation="com.microsoft.azure.toolkit.ide.storage.StorageActionsContributor"/>
         <actions implementation="com.microsoft.azure.toolkit.intellij.storage.IntellijStorageActionsContributor"/>
-    </extensions>
-    <extensions defaultExtensionNs="com.intellij">
-        <preloadingActivity implementation="com.microsoft.azure.toolkit.intellij.storage.connection.StorageAccountResourceDefinition$RegisterActivity"/>
     </extensions>
 </idea-plugin>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectionDefinition.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectionDefinition.java
@@ -36,6 +36,10 @@ public class ConnectionDefinition<R, C> {
         this.consumerDefinition = cd;
     }
 
+    public String getName() {
+        return String.format("%s:%s", resourceDefinition.getName(), consumerDefinition.getName());
+    }
+
     /**
      * create {@link Connection} from given {@code resource} and {@code consumer}
      */

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ModuleResource.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ModuleResource.java
@@ -5,12 +5,9 @@
 
 package com.microsoft.azure.toolkit.intellij.connector;
 
-import com.intellij.openapi.application.PreloadingActivity;
-import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.intellij.common.AzureFormJPanel;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
-import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -49,12 +46,19 @@ public final class ModuleResource implements Resource<String> {
 
     @Getter
     @RequiredArgsConstructor
-    public enum Definition implements ResourceDefinition<String> {
-        IJ_MODULE("Jetbrains.IJModule", "Intellij Module", "/icons/module");
+    @EqualsAndHashCode
+    public static class Definition implements ResourceDefinition<String> {
+        public static final Definition IJ_MODULE = new Definition();
         private final String name;
         private final String title;
         private final String icon;
         private final int role = CONSUMER;
+
+        public Definition() {
+            this.name = "Jetbrains.IJModule";
+            this.title = "Intellij Module";
+            this.icon = "/icons/module";
+        }
 
         @Override
         public Resource<String> define(String resource) {
@@ -80,15 +84,6 @@ public final class ModuleResource implements Resource<String> {
         @Override
         public String toString() {
             return this.getTitle();
-        }
-    }
-
-    public static class RegisterActivity extends PreloadingActivity {
-
-        @Override
-        @ExceptionNotification
-        public void preload(@Nonnull ProgressIndicator progressIndicator) {
-            ResourceManager.registerDefinition(Definition.IJ_MODULE);
         }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/resources/META-INF/azure-intellij-resource-connector-lib.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/resources/META-INF/azure-intellij-resource-connector-lib.xml
@@ -1,11 +1,15 @@
 <idea-plugin>
+    <extensionPoints>
+        <extensionPoint name="connectorResourceType" interface="com.microsoft.azure.toolkit.intellij.connector.ResourceDefinition"/>
+        <extensionPoint name="connectorConnectionType" interface="com.microsoft.azure.toolkit.intellij.connector.ConnectionDefinition"/>
+    </extensionPoints>
     <extensions defaultExtensionNs="com.microsoft.tooling.msservices.intellij.azure">
+        <connectorResourceType implementation="com.microsoft.azure.toolkit.intellij.connector.ModuleResource$Definition"/>
         <actions implementation="com.microsoft.azure.toolkit.intellij.connector.ResourceConnectionActionsContributor"/>
     </extensions>
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="Azure Resource Connector" anchor="right" icon="/icons/Common/AzureResourceConnector.svg"
                     factoryClass="com.microsoft.azure.toolkit.intellij.connector.ResourceConnectionExplorer$ToolWindowFactory"/>
-        <preloadingActivity implementation="com.microsoft.azure.toolkit.intellij.connector.ModuleResource$RegisterActivity"/>
         <projectService
             serviceInterface="com.microsoft.azure.toolkit.intellij.connector.ConnectionManager"
             serviceImplementation="com.microsoft.azure.toolkit.intellij.connector.ConnectionManager$Impl" />


### PR DESCRIPTION


What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
[AB#1950086](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1950086): migrate to use extension point (instead of preloading activity) to register resource/connection definitions for resource connector


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
