### PR TITLE
Fix function local debug port may be same as function host

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/core/FunctionUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/core/FunctionUtils.java
@@ -567,10 +567,10 @@ public class FunctionUtils {
         }
     }
 
-    public static int findFreePort(int startPort) {
+    public static int findFreePort(int startPort, int... skipPorts) {
         ServerSocket socket = null;
         for (int port = startPort; port <= MAX_PORT; port++) {
-            if (isPortFree(port)) {
+            if (!ArrayUtils.contains(skipPorts, port) && isPortFree(port)) {
                 return port;
             }
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunState.java
@@ -207,7 +207,7 @@ public class FunctionRunState extends AzureRunProfileState<Boolean> {
             throws IOException, InterruptedException {
         isDebuggerLaunched = false;
         final int funcPort = functionRunConfiguration.isAutoPort() ? FunctionUtils.findFreePort() : functionRunConfiguration.getFuncPort();
-        final int debugPort = FunctionUtils.findFreePort(Math.max(DEFAULT_DEBUG_PORT, funcPort));
+        final int debugPort = FunctionUtils.findFreePort(DEFAULT_DEBUG_PORT, funcPort);
         processHandler.println(message("function.run.hint.port", funcPort), ProcessOutputTypes.SYSTEM);
         process = getRunFunctionCliProcessBuilder(stagingFolder, funcPort, debugPort).start();
         // Redirect function cli output to console


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Skip function host port when find free port for debug session, fix function local debug port may be same as function host


Does this close any currently open issues?
------------------------------------------
#6696

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
