### PR TITLE
fix bugs found in endgame 202206

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/GuidanceViewManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/GuidanceViewManager.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class GuidanceViewManager {
 
-    public static final String TOOL_WINDOW_ID = "Get Started with Azure";
+    public static final String TOOL_WINDOW_ID = "Getting Started with Azure";
 
     private static final GuidanceViewManager instance = new GuidanceViewManager();
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/GuidanceViewManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/GuidanceViewManager.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
+import javax.swing.*;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -85,7 +86,7 @@ public class GuidanceViewManager {
             final GuidanceView guidanceView = new GuidanceView(project);
             guidanceViewMap.put(project, guidanceView);
             final ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
-            final JBScrollPane view = new JBScrollPane(guidanceView);
+            final JBScrollPane view = new JBScrollPane(guidanceView, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED, ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
             final Content content = contentFactory.createContent(view, "", false);
             toolWindow.getContentManager().addContent(content);
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/component/Tree.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/component/Tree.java
@@ -128,16 +128,20 @@ public class Tree extends SimpleTree implements DataProvider {
 
         @Override
         public void refreshView() {
-            final DefaultTreeModel model = (DefaultTreeModel) this.tree.getModel();
-            if (Objects.nonNull(this.getParent()) && Objects.nonNull(model)) {
-                model.nodeChanged(this);
+            synchronized (this.tree) {
+                final DefaultTreeModel model = (DefaultTreeModel) this.tree.getModel();
+                if (Objects.nonNull(this.getParent()) && Objects.nonNull(model)) {
+                    model.nodeChanged(this);
+                }
             }
         }
 
         private void refreshChildrenView() {
-            final DefaultTreeModel model = (DefaultTreeModel) this.tree.getModel();
-            if (Objects.nonNull(this.getParent()) && Objects.nonNull(model)) {
-                model.nodeStructureChanged(this);
+            synchronized (this.tree) {
+                final DefaultTreeModel model = (DefaultTreeModel) this.tree.getModel();
+                if (Objects.nonNull(this.getParent()) && Objects.nonNull(model)) {
+                    model.nodeStructureChanged(this);
+                }
             }
         }
 
@@ -211,13 +215,15 @@ public class Tree extends SimpleTree implements DataProvider {
         }
 
         public synchronized void clearChildren() {
-            this.removeAllChildren();
-            this.loaded = null;
-            if (this.getAllowsChildren()) {
-                this.add(new LoadingNode());
-                this.tree.collapsePath(new TreePath(this.getPath()));
+            synchronized (this.tree) {
+                this.removeAllChildren();
+                this.loaded = null;
+                if (this.getAllowsChildren()) {
+                    this.add(new LoadingNode());
+                    this.tree.collapsePath(new TreePath(this.getPath()));
+                }
+                this.refreshChildrenView();
             }
-            this.refreshChildrenView();
         }
 
         @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/component/TreeUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/component/TreeUtils.java
@@ -182,21 +182,13 @@ public class TreeUtils {
         final Object highlighted = tree.getClientProperty(HIGHLIGHTED_RESOURCE_KEY);
         final boolean toHighlightThisNode = Optional.ofNullable(highlighted).map(h -> ((Pair<Object, Long>) h))
             .filter(h -> Objects.equals(node.getUserObject(), h.getLeft())).isPresent();
+        SimpleTextAttributes attributes = view.isEnabled() ? SimpleTextAttributes.REGULAR_ATTRIBUTES : SimpleTextAttributes.GRAY_ATTRIBUTES;
         if (selected && toHighlightThisNode) {
-            renderer.setBorder(BorderFactory.createLineBorder(JBColor.RED));
-            renderer.setBackground(JBColor.YELLOW);
-            renderer.setForeground(JBColor.RED);
-            renderer.setOpaque(false);
-        } else {
-            if(selected){
-                tree.putClientProperty(HIGHLIGHTED_RESOURCE_KEY, null);
-            }
-            renderer.setOpaque(true);
-            renderer.setBorder(null);
-            renderer.setBackground(null);
-            renderer.setForeground(null);
+            attributes = attributes.derive(SimpleTextAttributes.STYLE_SEARCH_MATCH, JBColor.RED, JBColor.YELLOW, null);
+        } else if (selected) {
+            tree.putClientProperty(HIGHLIGHTED_RESOURCE_KEY, null);
         }
-        renderer.append(view.getLabel(), view.isEnabled() ? SimpleTextAttributes.REGULAR_ATTRIBUTES : SimpleTextAttributes.GRAY_ATTRIBUTES);
+        renderer.append(view.getLabel(), attributes);
         renderer.append(Optional.ofNullable(view.getDescription()).map(d -> " " + d).orElse(""), SimpleTextAttributes.GRAY_ITALIC_ATTRIBUTES, true);
         renderer.setToolTipText(Optional.ofNullable(view.getTips()).orElse(view.getLabel()));
     }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
[AB#1965071](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1965071): [Test] Better to auto word-wrap when the context is too long in Get Started
[AB#1965079](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1965079): [Test] The red border from Get Started won't disappear when clicking the sub-node

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
![image](https://user-images.githubusercontent.com/69189193/176132455-d73710e5-1e88-4b89-ab31-92daf01dcc1c.png)

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
