### PR TITLE
telemetry volume spikes because some methods are called super frequently by IntelliJ platform

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/FunctionRunConfigurationProducer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/FunctionRunConfigurationProducer.java
@@ -33,7 +33,6 @@ public class FunctionRunConfigurationProducer extends LazyRunConfigurationProduc
     @NotNull
     @Override
     @ExceptionNotification
-    @AzureOperation(name = "function.setup_run_configuration", type = AzureOperation.Type.ACTION)
     public ConfigurationFactory getConfigurationFactory() {
         return Arrays.stream(AzureFunctionSupportConfigurationType.getInstance().getConfigurationFactories())
                     .filter(configurationFactory -> configurationFactory instanceof FunctionRunConfigurationFactory)
@@ -86,7 +85,6 @@ public class FunctionRunConfigurationProducer extends LazyRunConfigurationProduc
 
     @Override
     @ExceptionNotification
-    @AzureOperation(name = "function.setup_run_configuration", type = AzureOperation.Type.ACTION)
     public boolean isConfigurationFromContext(AzureRunConfigurationBase appConfiguration, ConfigurationContext context) {
         if (!(appConfiguration instanceof FunctionRunConfiguration)) {
             return false;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectionManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectionManager.java
@@ -117,7 +117,6 @@ public interface ConnectionManager extends PersistentStateComponent<Element> {
 
         @Override
         @ExceptionNotification
-        @AzureOperation(name = "connector.persist_resource_connections", type = AzureOperation.Type.ACTION)
         public Element getState() {
             final Element connectionsEle = new Element(ELEMENT_NAME_CONNECTIONS);
             for (final Connection<?, ?> connection : this.connections) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/spring/SpringPropertiesLineMarkerProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/spring/SpringPropertiesLineMarkerProvider.java
@@ -39,7 +39,6 @@ public class SpringPropertiesLineMarkerProvider implements LineMarkerProvider {
     @Override
     @Nullable
     @ExceptionNotification
-    @AzureOperation(name = "connector.detect_connections", type = AzureOperation.Type.ACTION)
     public LineMarkerInfo<PsiElement> getLineMarkerInfo(@Nonnull PsiElement element) {
         if (!(element instanceof PropertyImpl)) {
             return null;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=3.66.0
+pluginVersion=3.66.1
 intellijDisplayVersion=2021.3
 needPatchVersion=true
 javaVersion=11

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
              xmlns:xi="http://www.w3.org/2001/XInclude">
   <id>com.microsoft.tooling.msservices.intellij.azure</id>
   <name>Azure Toolkit for IntelliJ</name>
-  <version>3.66.0</version>
+  <version>3.66.1</version>
   <vendor email="java@microsoft.com" url="http://www.microsoft.com">Microsoft</vendor>
 
   <description><![CDATA[


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
disable telemetry on methods called frequently from IntelliJ platform

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
