### PR TITLE
Move azure configurable to tools category

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/common/action/LegacyIntellijAccountActionsContributor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/common/action/LegacyIntellijAccountActionsContributor.java
@@ -67,7 +67,7 @@ public class LegacyIntellijAccountActionsContributor implements IActionsContribu
                 return ArrayUtils.isEmpty(openProjects) ? null : openProjects[0];
             });
             final AzureString title = OperationBundle.description("common.open_azure_settings");
-            AzureTaskManager.getInstance().runAndWait(new AzureTask<>(title, () ->
+            AzureTaskManager.getInstance().runLater(new AzureTask<>(title, () ->
                 ShowSettingsUtil.getInstance().showSettingsDialog(project, AzureConfigurable.class)));
         };
         am.registerHandler(ResourceCommonActionsContributor.OPEN_AZURE_SETTINGS, (i, e) -> true, openSettingsHandler);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/common/action/LegacyIntellijAccountActionsContributor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/azure/toolkit/intellij/common/action/LegacyIntellijAccountActionsContributor.java
@@ -68,7 +68,7 @@ public class LegacyIntellijAccountActionsContributor implements IActionsContribu
             });
             final AzureString title = OperationBundle.description("common.open_azure_settings");
             AzureTaskManager.getInstance().runAndWait(new AzureTask<>(title, () ->
-                ShowSettingsUtil.getInstance().showSettingsDialog(project, AzureConfigurable.AzureAbstractConfigurable.class)));
+                ShowSettingsUtil.getInstance().showSettingsDialog(project, AzureConfigurable.class)));
         };
         am.registerHandler(ResourceCommonActionsContributor.OPEN_AZURE_SETTINGS, (i, e) -> true, openSettingsHandler);
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureConfigurable.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureConfigurable.java
@@ -19,8 +19,7 @@ import javax.swing.*;
 import static com.microsoft.azure.toolkit.intellij.common.AzureBundle.message;
 
 public class AzureConfigurable implements SearchableConfigurable, Configurable.NoScroll, OptionsContainingConfigurable {
-    public static final String AZURE_PLUGIN_NAME = "Microsoft Tools";
-    public static final String AZURE_PLUGIN_ID = "com.microsoft.intellij";
+    public static final String AZURE_CONFIGURABLE_ID = "com.microsoft.intellij.AzureConfigurable";
 
     private java.util.List<Configurable> myPanels;
     private final AzurePanel azurePanel;
@@ -32,7 +31,7 @@ public class AzureConfigurable implements SearchableConfigurable, Configurable.N
     @NotNull
     @Override
     public String getId() {
-        return AZURE_PLUGIN_ID;
+        return AZURE_CONFIGURABLE_ID;
     }
 
     @Nls

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureConfigurable.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureConfigurable.java
@@ -9,37 +9,24 @@ import com.intellij.application.options.OptionsContainingConfigurable;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SearchableConfigurable;
-import com.intellij.openapi.project.Project;
-import com.microsoft.intellij.ui.*;
+import com.microsoft.intellij.ui.AzurePanel;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
 
 import static com.microsoft.azure.toolkit.intellij.common.AzureBundle.message;
 
-public class AzureConfigurable extends SearchableConfigurable.Parent.Abstract implements OptionsContainingConfigurable {
+public class AzureConfigurable implements SearchableConfigurable, Configurable.NoScroll, OptionsContainingConfigurable {
     public static final String AZURE_PLUGIN_NAME = "Microsoft Tools";
     public static final String AZURE_PLUGIN_ID = "com.microsoft.intellij";
 
     private java.util.List<Configurable> myPanels;
-    private final Project myProject;
+    private final AzurePanel azurePanel;
 
-    public AzureConfigurable(Project project) {
-        myProject = project;
-    }
-
-    @Override
-    protected Configurable[] buildConfigurables() {
-        myPanels = new ArrayList<Configurable>();
-        if (!AzurePlugin.IS_ANDROID_STUDIO) {
-            myPanels.add(new AzureAbstractConfigurable(new AzurePanel(myProject)));
-        }
-        return myPanels.toArray(new Configurable[myPanels.size()]);
+    public AzureConfigurable() {
+        this.azurePanel = new AzurePanel();
     }
 
     @NotNull
@@ -51,7 +38,7 @@ public class AzureConfigurable extends SearchableConfigurable.Parent.Abstract im
     @Nls
     @Override
     public String getDisplayName() {
-        return AZURE_PLUGIN_NAME;
+        return azurePanel.getDisplayName();
     }
 
     @Nullable
@@ -62,84 +49,24 @@ public class AzureConfigurable extends SearchableConfigurable.Parent.Abstract im
 
     @Override
     public JComponent createComponent() {
-        JLabel label = new JLabel(message("winAzMsg"), SwingConstants.LEFT);
-        label.setVerticalAlignment(SwingConstants.TOP);
-        return label;
+        azurePanel.init();
+        return azurePanel.getPanel();
     }
 
     @Override
-    public boolean hasOwnContent() {
-        return true;
+    public boolean isModified() {
+        return azurePanel.isModified();
     }
 
     @Override
-    public Set<String> processListOptions() {
-        return new HashSet<String>();
+    public void apply() throws ConfigurationException {
+        if (!azurePanel.doOKAction()) {
+            throw new ConfigurationException(message("setPrefErMsg"), message("errTtl"));
+        }
     }
 
-    public class AzureAbstractConfigurable implements SearchableConfigurable, Configurable.NoScroll, OptionsContainingConfigurable {
-        private AzureAbstractConfigurablePanel myPanel;
-
-        public AzureAbstractConfigurable(AzureAbstractConfigurablePanel myPanel) {
-            this.myPanel = myPanel;
-        }
-
-        @Nls
-        @Override
-        public String getDisplayName() {
-            return myPanel.getDisplayName();
-        }
-
-        @Nullable
-        @Override
-        public String getHelpTopic() {
-            return null;
-        }
-
-        @Override
-        public Set<String> processListOptions() {
-            return null;
-        }
-
-        @Nullable
-        @Override
-        public JComponent createComponent() {
-            myPanel.init();
-            return myPanel.getPanel();
-        }
-
-        @Override
-        public boolean isModified() {
-            return myPanel.isModified();
-        }
-
-        @Override
-        public void apply() throws ConfigurationException {
-            if (!myPanel.doOKAction()) {
-                throw new ConfigurationException(message("setPrefErMsg"), message("errTtl"));
-            }
-        }
-
-        @Override
-        public void reset() {
-            myPanel.reset();
-        }
-
-        @Override
-        public void disposeUIResources() {
-
-        }
-
-        @NotNull
-        @Override
-        public String getId() {
-            return "preferences.sourceCode." + getDisplayName();
-        }
-
-        @Nullable
-        @Override
-        public Runnable enableSearch(String option) {
-            return null;
-        }
+    @Override
+    public void reset() {
+        azurePanel.reset();
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureConfigurableProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/AzureConfigurableProvider.java
@@ -7,15 +7,9 @@ package com.microsoft.intellij;
 
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurableProvider;
-import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.Nullable;
 
 public class AzureConfigurableProvider extends ConfigurableProvider {
-    private final Project myProject;
-
-    public AzureConfigurableProvider(Project project) {
-        myProject = project;
-    }
 
     @Override
     public boolean canCreateConfigurable() {
@@ -25,6 +19,6 @@ public class AzureConfigurableProvider extends ConfigurableProvider {
     @Nullable
     @Override
     public Configurable createConfigurable() {
-        return new AzureConfigurable(myProject);
+        return new AzureConfigurable();
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/DeprecatedAzureConfigurable.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/DeprecatedAzureConfigurable.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.intellij;
+
+import com.intellij.application.options.OptionsContainingConfigurable;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SearchableConfigurable;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.NlsContexts;
+import com.microsoft.intellij.ui.DeprecatedAzurePanel;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class DeprecatedAzureConfigurable implements SearchableConfigurable, Configurable.NoScroll, OptionsContainingConfigurable {
+    private Project project;
+
+    public DeprecatedAzureConfigurable(final Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public @NotNull @NonNls String getId() {
+        return "com.microsoft.intellij.deprecated";
+    }
+
+    @Override
+    public @NlsContexts.ConfigurableName String getDisplayName() {
+        return "Microsoft Tools";
+    }
+
+    @Override
+    public @Nullable JComponent createComponent() {
+        return new DeprecatedAzurePanel(project).getPnlRoot();
+    }
+
+    @Override
+    public boolean isModified() {
+        return false;
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.java
@@ -59,11 +59,6 @@ public class AzurePanel implements AzureAbstractConfigurablePanel {
     private AzureFileInput txtStorageExplorer;
 
     private AzureConfiguration originalConfig;
-    private final Project project;
-
-    public AzurePanel(Project project) {
-        this.project = project;
-    }
 
     @Override
     public void init() {
@@ -261,10 +256,11 @@ public class AzurePanel implements AzureAbstractConfigurablePanel {
     }
 
     private void createUIComponents() {
-        this.funcCoreToolsPath = new FunctionCoreToolsCombobox(project, false);
+        this.funcCoreToolsPath = new FunctionCoreToolsCombobox(null, false);
+        this.funcCoreToolsPath.setPrototypeDisplayValue(StringUtils.EMPTY);
         this.txtStorageExplorer = new AzureFileInput();
         txtStorageExplorer.addActionListener(new ComponentWithBrowseButton.BrowseFolderActionListener("Select path for Azure Storage Explorer", null, txtStorageExplorer,
-                project, FileChooserDescriptorFactory.createSingleLocalFileDescriptor(), TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT));
+                null, FileChooserDescriptorFactory.createSingleLocalFileDescriptor(), TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT));
         txtStorageExplorer.addValidator(this::validateStorageExplorerPath);
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/AzurePanel.java
@@ -8,7 +8,6 @@ package com.microsoft.intellij.ui;
 import com.azure.core.management.AzureEnvironment;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComponentWithBrowseButton;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.ui.TextComponentAccessor;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/DeprecatedAzurePanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/DeprecatedAzurePanel.form
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.microsoft.intellij.ui.DeprecatedAzurePanel">
+  <grid id="27dc6" binding="pnlRoot" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="72b4" class="com.intellij.ui.HyperlinkLabel" binding="lblRedirectLink" custom-create="true">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <vspacer id="5cef1">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+    </children>
+  </grid>
+</form>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/DeprecatedAzurePanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/DeprecatedAzurePanel.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.intellij.ui;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.HyperlinkLabel;
+import com.intellij.ui.navigation.Place;
+import lombok.Getter;
+
+import javax.swing.*;
+import java.awt.*;
+
+import static com.microsoft.intellij.AzureConfigurable.AZURE_CONFIGURABLE_ID;
+
+// todo: deprecate this panel
+public class DeprecatedAzurePanel {
+    public static final String LINK_CONTENT = "<html>Configuration panel here has been deprecated, please switch to <a href=\"\">Tools -> Azure</a> for Azure configuration</html>";
+    private HyperlinkLabel lblRedirectLink;
+    @Getter
+    private JPanel pnlRoot;
+
+    private final Project project;
+
+    public DeprecatedAzurePanel(Project project) {
+        this.project = project;
+    }
+
+    private void createUIComponents() {
+        lblRedirectLink = new HyperlinkLabel();
+        lblRedirectLink.setHtmlText(LINK_CONTENT);
+        lblRedirectLink.addHyperlinkListener(e -> {
+            final Place place = new Place();
+            // refers SettingsEditor.SELECTED_CONFIGURABLE
+            place.putPath("settings.editor.selected.configurable", AZURE_CONFIGURABLE_ID);
+            getSettingsEditor().navigateTo(place, false);
+        });
+    }
+
+    private Place.Navigator getSettingsEditor() {
+        Container container = this.pnlRoot;
+        while (container != null && !(container instanceof Place.Navigator)) {
+            container = container.getParent();
+        }
+        return (Place.Navigator) container;
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/ServerExplorerToolWindowFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/java/com/microsoft/intellij/ui/ServerExplorerToolWindowFactory.java
@@ -15,6 +15,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.actionSystem.Separator;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.options.newEditor.SettingsDialog;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
@@ -90,6 +90,8 @@
     <applicationConfigurable parentId="tools"
                          id="com.microsoft.intellij.AzureConfigurable"
                          provider="com.microsoft.intellij.AzureConfigurableProvider"/>
+    <projectConfigurable parentId="root" instance="com.microsoft.intellij.DeprecatedAzureConfigurable"
+                             id="com.microsoft.intellij.DeprecatedAzureConfigurable"/>
     <projectService serviceImplementation="com.microsoft.intellij.AzureSettings"/>
     <applicationService serviceImplementation="com.microsoft.intellij.ApplicationSettings"/>
     <fileEditorProvider implementation="com.microsoft.azure.hdinsight.jobs.framework.JobViewEditorProvider" />

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
@@ -87,7 +87,7 @@
           id="Azure Activity Log"
           canCloseContents="true"
           icon="/icons/Common/AzureActivityLog.svg"/>
-    <projectConfigurable groupId="root"
+    <applicationConfigurable groupId="tools"
                          id="com.microsoft.intellij.AzureConfigurable"
                          provider="com.microsoft.intellij.AzureConfigurableProvider"
                          dynamic="true"/>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
@@ -87,10 +87,9 @@
           id="Azure Activity Log"
           canCloseContents="true"
           icon="/icons/Common/AzureActivityLog.svg"/>
-    <applicationConfigurable groupId="tools"
+    <applicationConfigurable parentId="tools"
                          id="com.microsoft.intellij.AzureConfigurable"
-                         provider="com.microsoft.intellij.AzureConfigurableProvider"
-                         dynamic="true"/>
+                         provider="com.microsoft.intellij.AzureConfigurableProvider"/>
     <projectService serviceImplementation="com.microsoft.intellij.AzureSettings"/>
     <applicationService serviceImplementation="com.microsoft.intellij.ApplicationSettings"/>
     <fileEditorProvider implementation="com.microsoft.azure.hdinsight.jobs.framework.JobViewEditorProvider" />


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Move azure configurable to tools category
- Add redirect configurable to help user find the new azure configurable panel

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
![image](https://user-images.githubusercontent.com/12445236/178524841-4d023c85-0c61-4149-86ee-1df6aeefe5e5.png)

![image](https://user-images.githubusercontent.com/12445236/178524775-2d0f004d-2042-4587-9876-cc346d3da7e1.png)


Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
