### PR TITLE
Upgrade org.jetbrains.kotlin:kotlin-stdlib from 1.4.20 to 1.6.0 to fix cve-2022-24329

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <azuretool.version>3.67.0-SNAPSHOT</azuretool.version>
         <azure.version>1.41.2</azure.version>
-        <kotlin.version>1.4.20</kotlin.version>
+        <kotlin.version>1.6.0</kotlin.version>
         <kotlin.jvmTargetVersion>1.8</kotlin.jvmTargetVersion>
         <findsecbugs.version>1.11.0</findsecbugs.version>
         <rx.version>1.3.8</rx.version>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Upgrade org.jetbrains.kotlin:kotlin-stdlib from 1.4.20 to 1.6.0 to fix [cve-2022-24329](https://mseng.visualstudio.com/VSJava/_componentGovernance/445/alert/87100?typeId=119493)


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
