### PR TITLE
Upgrade jetty version to resolve CVE-2021-34429

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -40,7 +40,7 @@
         <azure.toolkit-lib.version>0.23.0-SNAPSHOT</azure.toolkit-lib.version>
         <azure.toolkit-ide-lib.version>0.23.0-SNAPSHOT</azure.toolkit-ide-lib.version>
         <powermock.version>2.0.9</powermock.version>
-        <jetty.version>9.4.41.v20210516</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
     </properties>
     <modules>
         <module>azure-toolkit-ide-libs</module>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Upgrade jetty version to resolve [CVE-2021-34429](https://mseng.visualstudio.com/VSJava/_componentGovernance/445/alert/85704?typeId=119493)


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
