### PR TITLE
exclude xalan dependency to fix CVE-2022-34169

### DIFF
--- a/Utils/hdinsight-node-common/pom.xml
+++ b/Utils/hdinsight-node-common/pom.xml
@@ -337,6 +337,12 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>xalan</groupId>
+                    <artifactId>xalan</artifactId>
+                </exclusion>
+            </exclusions>
          </dependency>
         <dependency>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
exclude xalan dependency to fix[ CVE-2022-34169](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/91213?typeId=161945)


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
