### PR TITLE
Fix open live metrics did not shown in guidance summary panel

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/Phase.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/Phase.java
@@ -103,8 +103,10 @@ public class Phase implements Disposable {
     }
 
     public void setStatus(final Status status) {
-        this.status = status;
-        this.listenerList.forEach(listener -> AzureTaskManager.getInstance().runOnPooledThread(() -> listener.accept(status)));
+        if (this.status != status) {
+            this.status = status;
+            this.listenerList.forEach(listener -> AzureTaskManager.getInstance().runOnPooledThread(() -> listener.accept(status)));
+        }
     }
 
     public boolean validateInputs() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/view/components/SummaryPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/view/components/SummaryPanel.java
@@ -68,14 +68,15 @@ public class SummaryPanel extends JPanel {
         this.descPanel.setBorder(null);
         this.descPanel.setText(this.phase.getDescription());
         this.descPanel.setVisible(StringUtils.isNotBlank(this.phase.getDescription()));
-        this.initDetailsPanel();
-        this.updateStatus(this.phase.getStatus());
         this.phase.addStatusListener(this::updateStatus);
     }
 
     private void updateStatus(Status status) {
         this.statusIcon.setIcon(AllIcons.General.BalloonInformation);
         this.focused = status == Status.READY || status == Status.RUNNING || status == Status.FAILED || status == Status.SUCCEED || status == Status.PARTIAL_SUCCEED;
+        if (status == Status.SUCCEED) {
+            initDetailsPanel();
+        }
         this.setVisible(this.focused);
         final Color bgColor = this.focused ? BACKGROUND_COLOR : JBUI.CurrentTheme.ToolWindow.background();
         PhasePanel.doForOffsprings(this.contentPanel, c -> c.setBackground(bgColor));


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix open live metrics did not shown in guidance summary panel, [AB#1973893](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1973893)


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
