### PR TITLE
Resolve issues in august endgame test

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/appservice/task/TriggerFunctionTask.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/appservice/task/TriggerFunctionTask.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.Objects;
 
 public class TriggerFunctionTask implements Task {
     public static final String FUNCTION_ID = "functionId";
@@ -41,7 +42,8 @@ public class TriggerFunctionTask implements Task {
         final String functionId = (String) context.getParameter(FUNCTION_ID);
         final String trigger = (String) context.getParameter(TRIGGER);
         final FunctionApp functionApp = Azure.az(AzureFunctions.class).functionApp(functionId);
-        final List<FunctionEntity> functionEntities = functionApp.listFunctions(true);
+        final List<FunctionEntity> functionEntities = Objects.requireNonNull(functionApp, String.format("failed to find function with id (%s) in Azure",
+                functionId)).listFunctions(true);
         final FunctionEntity target = functionEntities.stream().filter(entity -> StringUtils.equals(entity.getName(), trigger))
                 .findFirst().orElse(functionEntities.get(0));
         final Action.Id<FunctionEntity> action = PlatformUtils.isIdeaUltimate() ?

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/AppServiceInfoAdvancedPanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/AppServiceInfoAdvancedPanel.java
@@ -175,6 +175,7 @@ public class AppServiceInfoAdvancedPanel<T extends AppServiceConfig> extends JPa
         this.selectorSubscription.addItemListener(this::onSubscriptionChanged);
         this.selectorRuntime.addItemListener(this::onRuntimeChanged);
         this.selectorRegion.addItemListener(this::onRegionChanged);
+        this.selectorGroup.addItemListener(this::onGroupChanged);
         this.textName.setRequired(true);
         this.selectorServicePlan.setRequired(true);
         this.selectorSubscription.setRequired(true);
@@ -194,6 +195,12 @@ public class AppServiceInfoAdvancedPanel<T extends AppServiceConfig> extends JPa
             final Runtime runtime = this.selectorRuntime.getValue();
             return StringUtils.isNotBlank(ext) && WebAppUtils.isSupportedArtifactType(runtime, ext);
         });
+    }
+
+    private void onGroupChanged(ItemEvent e) {
+        if (e.getStateChange() == ItemEvent.SELECTED || e.getStateChange() == ItemEvent.DESELECTED) {
+            this.selectorServicePlan.setResourceGroup((ResourceGroup) e.getItem());
+        }
     }
 
     private void onRegionChanged(final ItemEvent e) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/serviceplan/ServicePlanComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/serviceplan/ServicePlanComboBox.java
@@ -19,6 +19,8 @@ import com.microsoft.azure.toolkit.lib.common.cache.CacheManager;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
+import com.microsoft.azure.toolkit.lib.resource.ResourceGroup;
+import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -44,6 +46,8 @@ public class ServicePlanComboBox extends AzureComboBox<AppServicePlan> {
     private final List<AppServicePlanDraft> localItems = new ArrayList<>();
     private OperatingSystem os;
     private Region region;
+    @Setter
+    private ResourceGroup resourceGroup;
 
     private List<PricingTier> pricingTierList = new ArrayList<>(PricingTier.WEB_APP_PRICING);
     private PricingTier defaultPricingTier = PricingTier.BASIC_B2;
@@ -169,8 +173,10 @@ public class ServicePlanComboBox extends AzureComboBox<AppServicePlan> {
     }
 
     private void showServicePlanCreationPopup() {
-        final ServicePlanCreationDialog dialog = new ServicePlanCreationDialog(this.subscription, this.os, this.region, pricingTierList, defaultPricingTier);
+        final ServicePlanCreationDialog dialog = new ServicePlanCreationDialog(this.subscription, this.resourceGroup, pricingTierList, defaultPricingTier);
         dialog.setOkActionListener((plan) -> {
+            plan.setRegion(region);
+            plan.setOperatingSystem(os);
             this.localItems.add(0, plan);
             dialog.close();
             final List<AppServicePlan> items = this.getItems();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/action/CreateFunctionAppAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/action/CreateFunctionAppAction.java
@@ -86,7 +86,7 @@ public class CreateFunctionAppAction {
             }
         });
         CacheManager.getUsageHistory(FunctionAppConfig.class).push(config);
-        return AzureTaskManager.getInstance().runInModalAsObservable(task).toSingle().doOnSuccess(app -> {
+        return AzureTaskManager.getInstance().runInBackgroundAsObservable(task).toSingle().doOnSuccess(app -> {
             AzureMessager.getMessager().success(message("function.create.success.message", app.name()), message("function.create.success.title"));
         });
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/action/DeployFunctionAppAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/action/DeployFunctionAppAction.java
@@ -59,7 +59,7 @@ public class DeployFunctionAppAction {
             settings = manager.createConfiguration(runConfigurationName, factory);
         }
         final RunConfiguration runConfiguration = settings.getConfiguration();
-        if (runConfiguration instanceof FunctionDeployConfiguration && functionApp.getFormalStatus().isRunning()) {
+        if (runConfiguration instanceof FunctionDeployConfiguration && functionApp.getFormalStatus().isConnected()) {
             final FunctionAppConfig config = FunctionAppService.getInstance().getFunctionAppConfigFromExistingFunction(functionApp);
             ((FunctionDeployConfiguration) runConfiguration).saveConfig(config);
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/action/CreateWebAppAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/action/CreateWebAppAction.java
@@ -77,7 +77,7 @@ public class CreateWebAppAction {
             return WebAppService.getInstance().createWebApp(config);
         });
         CacheManager.getUsageHistory(WebAppConfig.class).push(config);
-        return AzureTaskManager.getInstance().runInModalAsObservable(task).toSingle().doOnSuccess(CreateWebAppAction::notifyCreationSuccess);
+        return AzureTaskManager.getInstance().runInBackgroundAsObservable(task).toSingle().doOnSuccess(CreateWebAppAction::notifyCreationSuccess);
     }
 
     @AzureOperation(name = "webapp.deploy_artifact.app", params = {"webapp.name()"}, type = AzureOperation.Type.ACTION)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/runner/webappconfig/WebAppRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/runner/webappconfig/WebAppRunState.java
@@ -154,7 +154,7 @@ public class WebAppRunState extends AzureRunProfileState<AppServiceAppBase<?, ?,
         if (deployTarget instanceof WebApp) {
             processHandler.setText("Updating application settings...");
             final WebAppDraft draft = (WebAppDraft) deployTarget.update();
-            webAppConfiguration.getAppSettingsToRemove().forEach(draft::removeAppSetting);
+            Optional.ofNullable(webAppConfiguration.getAppSettingsToRemove()).ifPresent(keys -> keys.forEach(draft::removeAppSetting));
             draft.setAppSettings(applicationSettings);
             draft.updateIfExist();
             processHandler.setText("Update application settings successfully.");
@@ -162,7 +162,7 @@ public class WebAppRunState extends AzureRunProfileState<AppServiceAppBase<?, ?,
             processHandler.setText("Updating deployment slot application settings...");
             final WebAppDeploymentSlotDraft update = (WebAppDeploymentSlotDraft) deployTarget.update();
             update.setAppSettings(applicationSettings);
-            webAppConfiguration.getAppSettingsToRemove().forEach(update::removeAppSetting);
+            Optional.ofNullable(webAppConfiguration.getAppSettingsToRemove()).ifPresent(keys -> keys.forEach(update::removeAppSetting));
             update.updateIfExist();
             processHandler.setText("Update deployment slot application settings successfully.");
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/FunctionAppService.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/FunctionAppService.java
@@ -101,7 +101,7 @@ public class FunctionAppService {
         draft.setRuntime(config.getRuntime());
         draft.setAppSettings(appSettings);
         draft.setDiagnosticConfig(config.getMonitorConfig().getDiagnosticConfig());
-        return draft.createIfNotExist();
+        return draft.commit();
     }
 
     private Map<String, String> getAppSettings(final FunctionAppConfig config) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-containerservice/src/main/java/com/microsoft/azure/toolkit/intellij/containerservice/property/KubernetesServicePropertiesEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-containerservice/src/main/java/com/microsoft/azure/toolkit/intellij/containerservice/property/KubernetesServicePropertiesEditor.java
@@ -146,16 +146,16 @@ public class KubernetesServicePropertiesEditor extends AzResourcePropertiesEdito
         subscriptionTextField.setText(subscription.getName());
         subscriptionIDTextField.setText(subscription.getId());
         txtKubernetesVersion.setText(server.getKubernetesVersion());
-        txtApiServerAddress.setText(server.getApiServerAddress());
-//
+        txtApiServerAddress.setText(Optional.ofNullable(server.getApiServerAddress()).orElse("N/A"));
+
         final ContainerServiceNetworkProfile profile = server.getContainerServiceNetworkProfile();
-        txtNetworkType.setText(Optional.ofNullable(profile.getNetworkPlugin()).map(NetworkPlugin::getValue).orElse("None"));
-        txtNetworkPolicy.setText(Optional.ofNullable(profile.getNetworkPolicy()).map(NetworkPolicy::getValue).orElse("None"));
-        txtLoadBalancer.setText(Optional.ofNullable(profile.getLoadBalancerSku()).map(LoadBalancerSku::getValue).orElse("None"));
-        txtPodCidr.setText(profile.getPodCidr());
-        txtServiceCidr.setText(profile.getServiceCidr());
-        txtDndServiceIp.setText(profile.getDnsServiceIp());
-        txtDockerBridgeCidr.setText(profile.getDockerBridgeCidr());
+        txtNetworkType.setText(Optional.ofNullable(profile).map(p -> p.getNetworkPlugin()).map(NetworkPlugin::getValue).orElse("None"));
+        txtNetworkPolicy.setText(Optional.ofNullable(profile).map(p -> p.getNetworkPolicy()).map(NetworkPolicy::getValue).orElse("None"));
+        txtLoadBalancer.setText(Optional.ofNullable(profile).map(p -> p.getLoadBalancerSku()).map(LoadBalancerSku::getValue).orElse("None"));
+        txtPodCidr.setText(Optional.ofNullable(profile).map(p -> p.getPodCidr()).orElse("N/A"));
+        txtServiceCidr.setText(Optional.ofNullable(profile).map(p -> p.getServiceCidr()).orElse("N/A"));
+        txtDndServiceIp.setText(Optional.ofNullable(profile).map(p -> p.getDnsServiceIp()).orElse("N/A"));
+        txtDockerBridgeCidr.setText(Optional.ofNullable(profile).map(p -> p.getDockerBridgeCidr()).orElse("N/A"));
         AzureTaskManager.getInstance().runInBackgroundAsObservable(new AzureTask<>("Loading node pools", () -> cluster.agentPools().list()))
                 .subscribeOn(Schedulers.io())
                 .subscribe(pools -> AzureTaskManager.getInstance().runLater(() -> fillNodePools(pools)));

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-cosmos/src/main/java/com/microsoft/azure/toolkit/intellij/cosmos/creation/CosmosDatabaseCreationDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-cosmos/src/main/java/com/microsoft/azure/toolkit/intellij/cosmos/creation/CosmosDatabaseCreationDialog.java
@@ -65,7 +65,7 @@ public class CosmosDatabaseCreationDialog extends AzureDialog<DatabaseConfig> im
     private AzureValidationInfo validateDatabaseName() {
             final String value = txtName.getValue();
             return StringUtils.endsWith(value, StringUtils.SPACE) || StringUtils.containsAny(value, "\\", "/","#", "?", "%") ?
-                    AzureValidationInfo.error("Database name not end with space nor contains characters '\\', '/', '#', '?', '%'", txtName) : AzureValidationInfo.success(txtName);
+                    AzureValidationInfo.error("Database name should not end with space nor contains characters '\\', '/', '#', '?', '%'", txtName) : AzureValidationInfo.success(txtName);
     }
 
     private AzureValidationInfo validateThroughputIncrements(@Nonnull AzureIntegerInput input) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/GuidanceViewManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/GuidanceViewManager.java
@@ -34,8 +34,9 @@ public class GuidanceViewManager {
         final ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(GuidanceViewManager.TOOL_WINDOW_ID);
         AzureTaskManager.getInstance().runLater(() -> {
             assert toolWindow != null;
-            toolWindow.setAvailable(true);
             toolWindow.activate(() -> {
+                toolWindow.setAvailable(true);
+                toolWindow.show();
                 final GuidanceView guidanceView = GuidanceViewFactory.getGuidanceView(project);
                 if (Objects.nonNull(guidanceView)) {
                     final Course course = new Course(courseConfig, project);
@@ -52,6 +53,7 @@ public class GuidanceViewManager {
             assert toolWindow != null;
             toolWindow.activate(() -> {
                 toolWindow.setAvailable(true);
+                toolWindow.show();
                 final GuidanceView guidanceView = GuidanceViewFactory.getGuidanceView(project);
                 if (Objects.nonNull(guidanceView)) {
                     guidanceView.showCoursesView();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/Step.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/Step.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -96,7 +97,10 @@ public class Step implements Disposable {
             } catch (final Exception e) {
                 setStatus(continueOnError ? Status.PARTIAL_SUCCEED : Status.FAILED);
                 AzureMessager.getMessager().error(e);
-                AzureMessager.getDefaultMessager().error(e);
+                // Also show error notification
+                if (!Objects.equals(AzureMessager.getMessager(), AzureMessager.getDefaultMessager())) {
+                    AzureMessager.getDefaultMessager().error(e);
+                }
             }
         }));
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/task/FocusResourceInAzureExplorerTask.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/task/FocusResourceInAzureExplorerTask.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import lombok.RequiredArgsConstructor;
 
 import javax.annotation.Nonnull;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 public class FocusResourceInAzureExplorerTask implements Task {
@@ -27,7 +28,7 @@ public class FocusResourceInAzureExplorerTask implements Task {
     @AzureOperation(name = "guidance.focus_resource", type = AzureOperation.Type.SERVICE)
     public void execute() {
         final String resourceId = (String) context.getParameter(RESOURCE_ID);
-        final AbstractAzResource<?, ?, ?> resource = Azure.az().getById(resourceId);
+        final AbstractAzResource<?, ?, ?> resource = Objects.requireNonNull(Azure.az().getById(resourceId), String.format("failed to get resource with id (%s) in Azure", resourceId));
         final DataContext context = dataId -> CommonDataKeys.PROJECT.getName().equals(dataId) ? this.context.getProject() : null;
         final AnActionEvent event = AnActionEvent.createFromAnAction(new EmptyAction(), null, "azure.guidance.summary", context);
         AzureActionManager.getInstance().getAction(ResourceCommonActionsContributor.HIGHLIGHT_RESOURCE_IN_EXPLORER).handle(resource, event);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/azuresdk/model/module/MavenProjectModule.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/azuresdk/model/module/MavenProjectModule.java
@@ -16,11 +16,13 @@ import org.jetbrains.idea.maven.utils.MavenArtifactUtilKt;
 import javax.annotation.Nonnull;
 import javax.swing.*;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Getter
 public class MavenProjectModule implements ProjectModule {
     private final Project project;
+    @Nonnull
     private final MavenProject mavenProject;
 
     public MavenProjectModule(@Nonnull final Project project, @Nonnull final MavenProject mavenProject) {
@@ -34,14 +36,14 @@ public class MavenProjectModule implements ProjectModule {
 
     public MavenArtifact getMavenDependency(final String groupId, final String artifactId) {
         return mavenProject.getDependencies().stream()
-                .filter(dependency -> MavenArtifactUtilKt.resolved(dependency))
+                .filter(MavenArtifactUtilKt::resolved)
                 .filter(dependency -> StringUtils.equalsIgnoreCase(groupId, dependency.getGroupId()) &&
                         StringUtils.equalsIgnoreCase(artifactId, dependency.getArtifactId())).findFirst().orElse(null);
     }
 
     @Override
     public String getName() {
-        return mavenProject.getDisplayName();
+        return Optional.ofNullable(mavenProject.getMavenId().getArtifactId()).orElseGet(mavenProject::getName);
     }
 
     @Override

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/function/FunctionAppConfig.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/function/FunctionAppConfig.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.toolkit.ide.appservice.function;
 import com.microsoft.azure.toolkit.ide.appservice.model.AppServiceConfig;
 import com.microsoft.azure.toolkit.ide.appservice.model.ApplicationInsightsConfig;
 import com.microsoft.azure.toolkit.ide.appservice.model.MonitorConfig;
+import com.microsoft.azure.toolkit.ide.appservice.webapp.model.WebAppConfig;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.account.IAzureAccount;
 import com.microsoft.azure.toolkit.lib.appservice.config.AppServicePlanConfig;
@@ -21,6 +22,7 @@ import com.microsoft.azure.toolkit.lib.common.cache.CacheManager;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
+import com.microsoft.azure.toolkit.lib.common.utils.Utils;
 import com.microsoft.azure.toolkit.lib.resource.ResourceGroup;
 import com.microsoft.azure.toolkit.lib.resource.ResourceGroupConfig;
 import lombok.AllArgsConstructor;
@@ -54,21 +56,20 @@ public class FunctionAppConfig extends AppServiceConfig {
     }
 
     public static FunctionAppConfig getFunctionAppDefaultConfig(final String name) {
-        final String appName = StringUtils.isEmpty(name) ? String.format("app-%s", DATE_FORMAT.format(new Date())) :
-            String.format("app-%s-%s", name, DATE_FORMAT.format(new Date()));
-        final List<Subscription> subs = Azure.az(IAzureAccount.class).account().getSelectedSubscriptions();
+        final String namePrefix = StringUtils.isEmpty(name) ? "app" : String.format("app-%s", name);
+        final String appName = Utils.generateRandomResourceName(namePrefix, APP_SERVICE_NAME_MAX_LENGTH);        final List<Subscription> subs = Azure.az(IAzureAccount.class).account().getSelectedSubscriptions();
         final Subscription historySub = CacheManager.getUsageHistory(Subscription.class).peek(subs::contains);
         final Subscription sub = Optional.ofNullable(historySub).orElseGet(() -> subs.stream().findFirst().orElse(null));
 
         final Region historyRegion = CacheManager.getUsageHistory(Region.class).peek();
         final Region region = Optional.ofNullable(historyRegion).orElseGet(AppServiceConfig::getDefaultRegion);
 
-        final String rgName = StringUtils.substring(String.format("rg-%s", appName), 0, RG_NAME_MAX_LENGTH);
+        final String rgName = Utils.generateRandomResourceName(String.format("rg-%s", namePrefix), RG_NAME_MAX_LENGTH);
         final ResourceGroup historyRg = CacheManager.getUsageHistory(ResourceGroup.class).peek(r -> Objects.isNull(sub) || r.getSubscriptionId().equals(sub.getId()));
         final Subscription subscription = Optional.ofNullable(sub).orElseGet(() -> Optional.ofNullable(historyRg).map(AzResource::getSubscription).orElse(null));
         final ResourceGroupConfig group = Optional.ofNullable(historyRg).map(ResourceGroupConfig::fromResource).orElseGet(() -> ResourceGroupConfig.builder().subscriptionId(sub.getId()).name(rgName).region(region).build());
 
-        final String planName = StringUtils.substring(String.format("sp-%s", appName), 0, SP_NAME_MAX_LENGTH);
+        final String planName = Utils.generateRandomResourceName(String.format("sp-%s", namePrefix), SP_NAME_MAX_LENGTH);
         final AppServicePlan historyPlan = CacheManager.getUsageHistory(AppServicePlan.class).peek();
         final AppServicePlanConfig plan = Optional.ofNullable(historyPlan)
             .filter(p -> p.getSubscriptionId().equals(subscription.getId()))
@@ -81,16 +82,20 @@ public class FunctionAppConfig extends AppServiceConfig {
                 .region(region)
                 .os(FunctionAppConfig.DEFAULT_RUNTIME.getOperatingSystem())
                 .pricingTier(PricingTier.CONSUMPTION).build());
+
+        final Runtime historyRuntime = CacheManager.getUsageHistory(Runtime.class).peek(runtime -> Runtime.FUNCTION_APP_RUNTIME.contains(runtime));
+        final Runtime runtime = Optional.ofNullable(historyRuntime).orElse(FunctionAppConfig.DEFAULT_RUNTIME);
+
         final ApplicationInsightsConfig insightsConfig = ApplicationInsightsConfig.builder().name(appName).newCreate(true).build();
         final MonitorConfig monitorConfig = MonitorConfig.builder().applicationInsightsConfig(insightsConfig).build();
         return FunctionAppConfig.builder()
-            .subscription(subscription)
-            .resourceGroup(group)
-            .name(appName)
-            .servicePlan(plan)
-            .runtime(FunctionAppConfig.DEFAULT_RUNTIME)
-            .pricingTier(PricingTier.CONSUMPTION)
-            .monitorConfig(monitorConfig)
+                .subscription(subscription)
+                .resourceGroup(group)
+                .name(appName)
+                .servicePlan(plan)
+                .runtime(runtime)
+                .pricingTier(PricingTier.CONSUMPTION)
+                .monitorConfig(monitorConfig)
                 .region(region).build();
     }
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/model/AppServiceConfig.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/model/AppServiceConfig.java
@@ -41,6 +41,7 @@ import java.util.Set;
 @SuperBuilder(toBuilder = true)
 public abstract class AppServiceConfig {
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyMMddHHmmss");
+    protected static final int APP_SERVICE_NAME_MAX_LENGTH = 60;
     protected static final int RG_NAME_MAX_LENGTH = 90;
     protected static final int SP_NAME_MAX_LENGTH = 40;
     @Builder.Default

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/webapp/model/WebAppConfig.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/webapp/model/WebAppConfig.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.toolkit.ide.appservice.webapp.model;
 
+import com.azure.resourcemanager.resources.fluentcore.utils.ResourceManagerUtils;
 import com.microsoft.azure.toolkit.ide.appservice.model.AppServiceConfig;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.account.IAzureAccount;
@@ -18,6 +19,7 @@ import com.microsoft.azure.toolkit.lib.common.cache.CacheManager;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
+import com.microsoft.azure.toolkit.lib.common.utils.Utils;
 import com.microsoft.azure.toolkit.lib.resource.ResourceGroup;
 import com.microsoft.azure.toolkit.lib.resource.ResourceGroupConfig;
 import lombok.AllArgsConstructor;
@@ -49,8 +51,8 @@ public class WebAppConfig extends AppServiceConfig {
     }
 
     public static WebAppConfig getWebAppDefaultConfig(final String name) {
-        final String appName = StringUtils.isEmpty(name) ? String.format("app-%s", DATE_FORMAT.format(new Date())) :
-            String.format("app-%s-%s", name, DATE_FORMAT.format(new Date()));
+        final String namePrefix = StringUtils.isEmpty(name) ? "app" : String.format("app-%s", name);
+        final String appName = Utils.generateRandomResourceName(namePrefix, APP_SERVICE_NAME_MAX_LENGTH);
         final List<Subscription> subs = Azure.az(IAzureAccount.class).account().getSelectedSubscriptions();
 
         final Subscription historySub = CacheManager.getUsageHistory(Subscription.class).peek(subs::contains);
@@ -59,18 +61,18 @@ public class WebAppConfig extends AppServiceConfig {
         final Region historyRegion = CacheManager.getUsageHistory(Region.class).peek();
         final Region region = Optional.ofNullable(historyRegion).orElseGet(AppServiceConfig::getDefaultRegion);
 
-        final String rgName = StringUtils.substring(String.format("rg-%s", appName), 0, RG_NAME_MAX_LENGTH);
+        final String rgName = Utils.generateRandomResourceName(String.format("rg-%s", namePrefix), RG_NAME_MAX_LENGTH);
         final ResourceGroup historyRg = CacheManager.getUsageHistory(ResourceGroup.class).peek(r -> Objects.isNull(sub) || r.getSubscriptionId().equals(sub.getId()));
         final Subscription subscription = Optional.ofNullable(sub).orElseGet(() -> Optional.ofNullable(historyRg).map(AzResource::getSubscription).orElse(null));
         final ResourceGroupConfig group = Optional.ofNullable(historyRg).map(ResourceGroupConfig::fromResource).orElseGet(() -> ResourceGroupConfig.builder().subscriptionId(sub.getId()).name(rgName).region(region).build());
 
-        final Runtime historyRuntime = CacheManager.getUsageHistory(Runtime.class).peek();
+        final Runtime historyRuntime = CacheManager.getUsageHistory(Runtime.class).peek(runtime -> Runtime.WEBAPP_RUNTIME.contains(runtime));
         final Runtime runtime = Optional.ofNullable(historyRuntime).orElse(WebAppConfig.DEFAULT_RUNTIME);
 
         final PricingTier historyPricingTier = CacheManager.getUsageHistory(PricingTier.class).peek();
         final PricingTier pricingTier = Optional.ofNullable(historyPricingTier).orElse(WebAppConfig.DEFAULT_PRICING_TIER);
 
-        final String planName = StringUtils.substring(String.format("sp-%s", appName), 0, SP_NAME_MAX_LENGTH);
+        final String planName = Utils.generateRandomResourceName(String.format("sp-%s", namePrefix), SP_NAME_MAX_LENGTH);
         final AppServicePlan historyPlan = CacheManager.getUsageHistory(AppServicePlan.class).peek();
         final AppServicePlanConfig plan = Optional.ofNullable(historyPlan)
             .filter(p -> p.getSubscriptionId().equals(subscription.getId()))
@@ -84,13 +86,13 @@ public class WebAppConfig extends AppServiceConfig {
                 .os(runtime.getOperatingSystem())
                 .pricingTier(pricingTier).build());
         return WebAppConfig.builder()
-            .subscription(sub)
-            .resourceGroup(group)
-            .name(appName)
-            .servicePlan(plan)
-            .runtime(runtime)
-            .pricingTier(pricingTier)
-            .region(region).build();
+                .subscription(sub)
+                .resourceGroup(group)
+                .name(appName)
+                .servicePlan(plan)
+                .runtime(runtime)
+                .pricingTier(pricingTier)
+                .region(region).build();
     }
 
     public static com.microsoft.azure.toolkit.lib.appservice.config.AppServiceConfig convertToTaskConfig(WebAppConfig config) {

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azuretools/core/mvp/model/webapp/AzureWebAppMvpModel.java
@@ -163,7 +163,7 @@ public class AzureWebAppMvpModel {
         draft.setAppServicePlan(appServicePlan);
         draft.setRuntime(model.getRuntime());
         draft.setDiagnosticConfig(diagnosticConfig);
-        return draft.createIfNotExist();
+        return draft.commit();
     }
 
     // todo: Move duplicated codes to azure common library

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureResourceIconProvider.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/component/AzureResourceIconProvider.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.toolkit.lib.common.model.AzResourceBase;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -38,7 +39,10 @@ public class AzureResourceIconProvider<T extends AzResource<?, ?, ?>> implements
             return AzureIcons.Common.REFRESH_ICON;
         }
         final String iconPath = getAzureBaseResourceIconPath(resource);
-        final List<AzureIcon.Modifier> modifiers = modifierFunctionList.stream().map(function -> function.apply(resource)).collect(Collectors.toList());
+        final List<AzureIcon.Modifier> modifiers = modifierFunctionList.stream()
+                .map(function -> function.apply(resource))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
         return AzureIcon.builder().iconPath(iconPath).modifierList(modifiers).build();
     }
 

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/resources/bundles/com/microsoft/azure/toolkit/operation.properties
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/resources/bundles/com/microsoft/azure/toolkit/operation.properties
@@ -497,6 +497,7 @@ guidance.clone=clone project to local
 guidance.open_resource_in_azure=open resource in Azure
 guidance.select_subscription=select subscription
 guidance.sign_in=sign in
+guidance.show_courses_view=open getting start courses
 guidance.open_course.course=open course ({0})
 guidance.execute_phase.phase=execute phase ({0})
 guidance.execute_step.step=execute step ({0})

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-containerregistry-lib/src/main/java/com/microsoft/tooling/msservices/serviceexplorer/azure/container/ContainerRegistryPropertyViewPresenter.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-containerregistry-lib/src/main/java/com/microsoft/tooling/msservices/serviceexplorer/azure/container/ContainerRegistryPropertyViewPresenter.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.container;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import com.microsoft.azure.toolkit.lib.common.utils.JsonUtils;
@@ -153,7 +155,7 @@ public class ContainerRegistryPropertyViewPresenter<V extends ContainerRegistryP
             Map<String, String> responseMap = ContainerExplorerMvpModel.getInstance().listTags(registry
                     .getLoginServerUrl(), setting.getUsername(), setting.getPassword(), repo, query);
             updatePaginationInfo(isNextPage, Type.TAG, responseMap.get(HEADER_LINK));
-            Tag tag = JsonUtils.fromJson(responseMap.get(BODY), Tag.class);
+            Tag tag = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).readValue(responseMap.get(BODY), Tag.class);
             return tag.getTags();
         })
                 .subscribeOn(getSchedulerProvider().io())

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/ide/cosmos/CosmosNodeProvider.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/ide/cosmos/CosmosNodeProvider.java
@@ -173,9 +173,10 @@ public class CosmosNodeProvider implements IExplorerNodeProvider {
                     Optional.ofNullable(account.getKind()).map(DatabaseAccountKind::getValue).orElse("Unknown") : account.getStatus(), COSMOS_ICON_PROVIDER);
         }
 
-        @Nonnull
+        @Nullable
         private static AzureIcon.Modifier getAPIModifier(@Nonnull CosmosDBAccount resource) {
-            return new AzureIcon.Modifier(StringUtils.lowerCase(Objects.requireNonNull(resource.getKind()).getValue()), AzureIcon.ModifierLocation.BOTTOM_LEFT);
+            final DatabaseAccountKind kind = resource.getKind();
+            return Objects.isNull(kind) ? null : new AzureIcon.Modifier(StringUtils.lowerCase(kind.getValue()), AzureIcon.ModifierLocation.BOTTOM_LEFT);
         }
     }
 }

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/ide/cosmos/CosmosNodeProvider.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/ide/cosmos/CosmosNodeProvider.java
@@ -72,6 +72,7 @@ public class CosmosNodeProvider implements IExplorerNodeProvider {
                     .view(new CosmosDBAccountLabelView<>(sqlCosmosDBAccount))
                     .inlineAction(ResourceCommonActionsContributor.PIN)
                     .actions(CosmosActionsContributor.SQL_ACCOUNT_ACTIONS)
+                    .doubleClickAction(ResourceCommonActionsContributor.OPEN_PORTAL_URL)
                     .addChildren(account -> account.sqlDatabases().list(), (database, accountNode) -> this.createNode(database, accountNode, manager));
         } else if (data instanceof MongoCosmosDBAccount) {
             final MongoCosmosDBAccount mongoCosmosDBAccount = (MongoCosmosDBAccount) data;
@@ -79,6 +80,7 @@ public class CosmosNodeProvider implements IExplorerNodeProvider {
                     .view(new CosmosDBAccountLabelView<>(mongoCosmosDBAccount))
                     .inlineAction(ResourceCommonActionsContributor.PIN)
                     .actions(CosmosActionsContributor.MONGO_ACCOUNT_ACTIONS)
+                    .doubleClickAction(ResourceCommonActionsContributor.OPEN_PORTAL_URL)
                     .addChildren(account -> account.mongoDatabases().list(), (database, accountNode) -> this.createNode(database, accountNode, manager));
         } else if (data instanceof CassandraCosmosDBAccount) {
             final CassandraCosmosDBAccount cassandraCosmosDBAccount = (CassandraCosmosDBAccount) data;
@@ -86,6 +88,7 @@ public class CosmosNodeProvider implements IExplorerNodeProvider {
                     .view(new CosmosDBAccountLabelView<>(cassandraCosmosDBAccount))
                     .inlineAction(ResourceCommonActionsContributor.PIN)
                     .actions(CosmosActionsContributor.CASSANDRA_ACCOUNT_ACTIONS)
+                    .doubleClickAction(ResourceCommonActionsContributor.OPEN_PORTAL_URL)
                     .addChildren(account -> account.keySpaces().list(), (keyspace, accountNode) -> this.createNode(keyspace, accountNode, manager));
         } else if (data instanceof CosmosDBAccount) {
             // for other cosmos db account (table/graph...)
@@ -93,46 +96,53 @@ public class CosmosNodeProvider implements IExplorerNodeProvider {
             return new Node<>(account)
                     .view(new CosmosDBAccountLabelView<>(account))
                     .inlineAction(ResourceCommonActionsContributor.PIN)
-                    .actions(CosmosActionsContributor.ACCOUNT_ACTIONS);
+                    .actions(CosmosActionsContributor.ACCOUNT_ACTIONS)
+                    .doubleClickAction(ResourceCommonActionsContributor.OPEN_PORTAL_URL);
         } else if (data instanceof MongoDatabase) {
             final MongoDatabase mongoDatabase = (MongoDatabase) data;
             return new Node<>(mongoDatabase)
                     .view(new AzureResourceLabelView<>(mongoDatabase))
                     .inlineAction(ResourceCommonActionsContributor.PIN)
                     .actions(CosmosActionsContributor.MONGO_DATABASE_ACTIONS)
+                    .doubleClickAction(ResourceCommonActionsContributor.OPEN_PORTAL_URL)
                     .addChildren(database -> database.collections().list(), (collection, databaseNode) -> this.createNode(collection, databaseNode, manager));
         } else if (data instanceof MongoCollection) {
             final MongoCollection table = (MongoCollection) data;
             return new Node<>(table)
                     .view(new AzureResourceLabelView<>(table))
                     .inlineAction(ResourceCommonActionsContributor.PIN)
-                    .actions(CosmosActionsContributor.MONGO_COLLECTION_ACTIONS);
+                    .actions(CosmosActionsContributor.MONGO_COLLECTION_ACTIONS)
+                    .doubleClickAction(ResourceCommonActionsContributor.OPEN_PORTAL_URL);
         } else if (data instanceof SqlDatabase) {
             final SqlDatabase sqlDatabase = (SqlDatabase) data;
             return new Node<>(sqlDatabase)
                     .view(new AzureResourceLabelView<>(sqlDatabase))
                     .inlineAction(ResourceCommonActionsContributor.PIN)
                     .actions(CosmosActionsContributor.SQL_DATABASE_ACTIONS)
+                    .doubleClickAction(ResourceCommonActionsContributor.OPEN_PORTAL_URL)
                     .addChildren(database -> database.containers().list(), (container, databaseNode) -> this.createNode(container, databaseNode, manager));
         } else if (data instanceof SqlContainer) {
             final SqlContainer table = (SqlContainer) data;
             return new Node<>(table)
                     .view(new AzureResourceLabelView<>(table))
                     .inlineAction(ResourceCommonActionsContributor.PIN)
-                    .actions(CosmosActionsContributor.SQL_CONTAINER_ACTIONS);
+                    .actions(CosmosActionsContributor.SQL_CONTAINER_ACTIONS)
+                    .doubleClickAction(ResourceCommonActionsContributor.OPEN_PORTAL_URL);
         } else if (data instanceof CassandraKeyspace) {
             final CassandraKeyspace cassandraKeyspace = (CassandraKeyspace) data;
             return new Node<>(cassandraKeyspace)
                     .view(new AzureResourceLabelView<>(cassandraKeyspace))
                     .inlineAction(ResourceCommonActionsContributor.PIN)
                     .actions(CosmosActionsContributor.CASSANDRA_KEYSPACE_ACTIONS)
+                    .doubleClickAction(ResourceCommonActionsContributor.OPEN_PORTAL_URL)
                     .addChildren(keyspace -> keyspace.tables().list(), (table, keyspaceNode) -> this.createNode(table, keyspaceNode, manager));
         } else if (data instanceof CassandraTable) {
             final CassandraTable table = (CassandraTable) data;
             return new Node<>(table)
                     .view(new AzureResourceLabelView<>(table))
                     .inlineAction(ResourceCommonActionsContributor.PIN)
-                    .actions(CosmosActionsContributor.CASSANDRA_TABLE_ACTIONS);
+                    .actions(CosmosActionsContributor.CASSANDRA_TABLE_ACTIONS)
+                    .doubleClickAction(ResourceCommonActionsContributor.OPEN_PORTAL_URL);
         }
         return null;
     }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix NPE when open properties view for a creating kubernetes instance, [AB#1974431](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1974431)
Fix stopped function could not be selected by default in deploy action, [AB#1974850](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1974850)
Fix display name for maven module, [AB#1974850](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1974850)
Fix getting start toolwindow may not show up, [AB#1974479](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1974479)
Fix typo in cosmos db database validation, [AB#1980704](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1980704)
Fix error message will shown twice in summary steps, [AB#1980707](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1980707)
Fix possible NPE in guidance summary tasks
Migrate to run in background for resource creation, [AB#1980710](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1980710)
Add double click actions for cosmos db account nodes in azure explorer, [AB#1981854](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1981854)


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
