### PR TITLE
Update hadoop package version to 3.2.4 to fix cve issue

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -284,7 +284,7 @@
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
-                <version>3.2.3</version>
+                <version>3.2.4</version>
                 <exclusions>
                     <exclusion><!--WS-2018-0629-->
                         <groupId>com.fasterxml.woodstox</groupId>

--- a/Utils/spark-tools/pom.xml
+++ b/Utils/spark-tools/pom.xml
@@ -22,7 +22,7 @@
         <scala.version>${scala.version.major}.${scala.version.minor}</scala.version>
         <build.copyDependenciesPhase>none</build.copyDependenciesPhase>
         <CodeCacheSize>512m</CodeCacheSize>
-        <hadoop.version>3.2.3</hadoop.version>
+        <hadoop.version>3.2.4</hadoop.version>
         <test.exclude.tags></test.exclude.tags>
     </properties>
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix workitem [bug1976182
](https://dev.azure.com/mseng/VSJava/_workitems/edit/1976182) [Component Governance Alert] - CVE-2022-25168 in org.apache.hadoop:hadoop-common 3.2.3. Severity: Medium

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [x] Tested
