### PR TITLE
Users/jiezhang3/#1983777 get cluster configration request from new api

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/HDInsightNewAPI/ClusterOperationNewAPIImpl.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/HDInsightNewAPI/ClusterOperationNewAPIImpl.java
@@ -58,9 +58,8 @@ public class ClusterOperationNewAPIImpl extends ClusterOperationImpl implements 
                 .get(url, null, null, Map.class);
     }
 
-    private Observable<ClusterConfiguration> getClusterConfigurationFromManagementEndpoint(
-            @NotNull final String clusterId) {
-        String managementURI = Azure.az(AzureCloud.class).getOrDefault().getManagementEndpoint();
+    private Observable<ClusterConfiguration> getClusterConfigurationRequest(
+            @NotNull final String clusterId, String managementURI) {
         String url = URI.create(managementURI)
                 .resolve(clusterId.replaceAll("/+$", "") + "/configurations").toString();
         StringEntity entity = new StringEntity("", StandardCharsets.UTF_8);
@@ -70,22 +69,11 @@ public class ClusterOperationNewAPIImpl extends ClusterOperationImpl implements 
                 .post(url, entity, null, null, ClusterConfiguration.class);
     }
 
-    private Observable<ClusterConfiguration> getClusterConfigurationFromResourceManagerEndpoint(
-            @NotNull final String clusterId) {
-        String managementURI = Azure.az(AzureCloud.class).getOrDefault().getResourceManagerEndpoint();
-        String url = URI.create(managementURI)
-                .resolve(clusterId.replaceAll("/+$", "") + "/configurations").toString();
-        StringEntity entity = new StringEntity("", StandardCharsets.UTF_8);
-        entity.setContentType("application/json");
-        return getHttp()
-                .withUuidUserAgent()
-                .post(url, entity, null, null, ClusterConfiguration.class);
-    }
 
     public Observable<Boolean> isProbeGetConfigurationSucceed(final ClusterRawInfo clusterRawInfo) {
         String clusterId = clusterRawInfo.getId();
-
-        return getClusterConfigurationFromResourceManagerEndpoint(clusterId)
+        String managementURI = Azure.az(AzureCloud.class).getOrDefault().getResourceManagerEndpoint();
+        return getClusterConfigurationRequest(clusterId,managementURI)
                 .map(clusterConfiguration -> {
                     if (isClusterConfigurationValid(clusterRawInfo, clusterConfiguration)) {
                         setRoleType(HDInsightUserRoleType.OWNER);
@@ -176,7 +164,8 @@ public class ClusterOperationNewAPIImpl extends ClusterOperationImpl implements 
         try {
             switch (roleType) {
                 case OWNER:
-                    return getClusterConfigurationFromManagementEndpoint(clusterId)
+                    String managementURI = Azure.az(AzureCloud.class).getOrDefault().getManagementEndpoint();
+                    return getClusterConfigurationRequest(clusterId,managementURI)
                             // As you can see, the response class is
                             // com.microsoft.azure.hdinsight.sdk.cluster.HDInsightNewAPI.ClusterConfiguration.
                             // However, if we want to override method getClusterConfiguration, the method return type should be

--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/HDInsightNewAPI/ClusterOperationNewAPIImpl.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/sdk/cluster/HDInsightNewAPI/ClusterOperationNewAPIImpl.java
@@ -171,7 +171,7 @@ public class ClusterOperationNewAPIImpl extends ClusterOperationImpl implements 
                             // However, if we want to override method getClusterConfiguration, the method return type should be
                             // com.microsoft.azure.hdinsight.sdk.cluster.ClusterConfiguration.
                             // Therefore, we need to convert the new API response to old API.
-                            .map(ClusterOperationNewAPIImpl::convertConfigurationToOldAPI)
+                                  .map(ClusterOperationNewAPIImpl::convertConfigurationToOldAPI)
                             .toBlocking()
                             .singleOrDefault(null);
                 case READER:


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add a new parameter to getClusterConfigurationRequest method to make getClusterConfigurationFromManagementEndpoint method and getClusterConfigurationFromResourceManagerEndpoint method into one method
Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
