### PR TITLE
Properly end the thread that opened yarnUI

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/jobs/ActionHttpHandler.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/spark/jobs/ActionHttpHandler.java
@@ -24,17 +24,17 @@ public class ActionHttpHandler implements HttpHandler {
 
         final String path = requestDetail.getRequestPath();
         final String clusterConnectString = requestDetail.getCluster().getConnectionUrl();
-        if (path.contains("yarnui")) {
-            JobUtils.openYarnUIHistory(clusterConnectString, requestDetail.getAppId());
-        } else if (path.contains("sparkui")) {
-            try {
+        try {
+            if (path.contains("yarnui")) {
+                JobUtils.openYarnUIHistory(clusterConnectString, requestDetail.getAppId());
+            } else if (path.contains("sparkui")) {
                 Application application = JobViewCacheManager.getSingleSparkApplication(new ApplicationKey(requestDetail.getCluster(), requestDetail.getAppId()));
                 JobUtils.openSparkUIHistory(clusterConnectString, requestDetail.getAppId(), application.getLastAttemptId());
-                JobUtils.setResponse(httpExchange, "open browser successfully");
-            } catch (ExecutionException e) {
-                JobUtils.setResponse(httpExchange, "open browser error", 500);
-                DefaultLoader.getUIHelper().showError(e.getMessage(), "open browser error");
             }
+            JobUtils.setResponse(httpExchange, "open browser successfully");
+        } catch (ExecutionException e) {
+            JobUtils.setResponse(httpExchange, "open browser error", 500);
+            DefaultLoader.getUIHelper().showError(e.getMessage(), "open browser error");
         }
     }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
…
The thread that opened the `yarnUI` link was not properly ended in the previous code, the new code gave the front page a correct Response

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
