### PR TITLE
fix CVE-2022-40150 exclude jettison

### DIFF
--- a/Utils/hdinsight-node-common/pom.xml
+++ b/Utils/hdinsight-node-common/pom.xml
@@ -215,6 +215,10 @@
                     <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-server</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2022-40150-->
+                    <groupId>org.codehaus.jettison</groupId>
+                    <artifactId>jettison</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-localrun-mock/pom.xml
+++ b/Utils/spark-localrun-mock/pom.xml
@@ -185,6 +185,10 @@
                     <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-server</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2022-40150-->
+                    <groupId>org.codehaus.jettison</groupId>
+                    <artifactId>jettison</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.1/pom.xml
+++ b/Utils/spark-tools/spark-v2.1/pom.xml
@@ -168,6 +168,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2022-40150-->
+                    <groupId>org.codehaus.jettison</groupId>
+                    <artifactId>jettison</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.3/spark-v2.3.0/pom.xml
+++ b/Utils/spark-tools/spark-v2.3/spark-v2.3.0/pom.xml
@@ -148,6 +148,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2022-40150-->
+                    <groupId>org.codehaus.jettison</groupId>
+                    <artifactId>jettison</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.3/spark-v2.3.2/pom.xml
+++ b/Utils/spark-tools/spark-v2.3/spark-v2.3.2/pom.xml
@@ -148,6 +148,10 @@
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2022-40150-->
+                    <groupId>org.codehaus.jettison</groupId>
+                    <artifactId>jettison</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix [CVE-2022-40150](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/93769?typeId=99957)
Exclude org.codehaus.jettison:jettison 1.1 related dependency

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
