### PR TITLE
Fix id 1997076 bug

### DIFF
--- a/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/ClusterNode.java
+++ b/Utils/hdinsight-node-common/src/com/microsoft/azure/hdinsight/serverexplore/hdinsightnode/ClusterNode.java
@@ -147,6 +147,13 @@ public class ClusterNode extends RefreshableNode implements TelemetryProperties,
     }
 
     @Override
+    protected boolean refreshEnabledWhenNotSignIn() {
+        // HDInsight cluster users should be accessible to their linked clusters
+        // when not sign in their Azure accounts
+        return true;
+    }
+
+    @Override
     protected void refreshItems() {
         if(!clusterDetail.isEmulator()) {
             JobViewManager.registerJovViewNode(clusterDetail.getName(), clusterDetail);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Should Jobs and storage account nodes under the linked cluster 
[1997076](https://dev.azure.com/mseng/VSJava/_workitems/edit/1997076)


Does this close any currently open issues?
------------------------------------------
YES


Any relevant logs, screenshots, error output, etc.?
-------------------------------------

<img width="478" alt="MicrosoftTeams-image" src="https://user-images.githubusercontent.com/58549494/195258727-e0f9676a-a772-4e56-9d3c-59c5d5e0e7c8.png">

Any other comments?
-------------------
without

Has this been tested?
---------------------------
* [x] Tested