### PR TITLE
fix configurations/telemetry of rating popup.

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/feedback/MonkeySurvey.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/feedback/MonkeySurvey.java
@@ -14,14 +14,8 @@ import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.intellij.common.AzureFileType;
 import com.microsoft.azure.toolkit.intellij.common.IntelliJAzureIcons;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
-import com.microsoft.azure.toolkit.lib.common.utils.InstallationIdUtils;
 
 import javax.annotation.Nonnull;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.concurrent.CompletableFuture;
 
 public class MonkeySurvey {
     public static final Key<String> SURVEY_URL = Key.create("survey_url");
@@ -60,58 +54,5 @@ public class MonkeySurvey {
             }
         }
         return virtualFile;
-    }
-
-    /**
-     * @param score 1, 2, 3, 4, 5
-     */
-    public static CompletableFuture<HttpResponse<String>> send(int score) {
-        final String json = buildRequestBody(score);
-        final HttpClient client = HttpClient.newHttpClient();
-        final HttpRequest request = HttpRequest.newBuilder()
-            .uri(URI.create("https://api.surveymonkey.com/v3/collectors/445843454/responses"))
-            .header("Content-Type", "application/json")
-            .header("Accept", "application/json")
-            .POST(HttpRequest.BodyPublishers.ofString(json))
-            .build();
-        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString());
-    }
-
-    @Nonnull
-    private static String buildRequestBody(int score) {
-        return "{" +
-            "  \"pages\": [" +
-            "    {" +
-            "      \"id\": \"27440878\"," +
-            "      \"questions\": [" +
-            "        {" +
-            "          \"id\": \"72189355\"," +
-            "          \"answers\": [" +
-            "            {" +
-            "              \"choice_id\": \"58129617" + score + "\"," +
-            "              \"row_id\": \"581296170\"" +
-            "            }" +
-            "          ]" +
-            "        }," +
-            "        {" +
-            "          \"id\": \"70321780\"," +
-            "          \"answers\": [" +
-            "            {" +
-            "              \"text\": \"" + score + "\"" +
-            "            }" +
-            "          ]" +
-            "        }," +
-            "        {" +
-            "          \"id\": \"70321940\"," +
-            "          \"answers\": [" +
-            "            {" +
-            "              \"text\": \"" + InstallationIdUtils.getHashMac() + "@AzureToolkitForIntelliJ\"" +
-            "            }" +
-            "          ]" +
-            "        }" +
-            "      ]" +
-            "    }" +
-            "  ]" +
-            "}";
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/feedback/RatePopup.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/feedback/RatePopup.java
@@ -184,7 +184,6 @@ public class RatePopup {
             final String strNextPopAfter = store.getProperty(RateManager.SERVICE, RateManager.NEXT_POP_AFTER, "0");
             final long nextPopAfter = Long.parseLong(Objects.requireNonNull(strNextPopAfter));
             if (nextPopAfter >= 0 && System.currentTimeMillis() > nextPopAfter) {
-                store.setProperty(RateManager.SERVICE, RateManager.NEXT_POP_AFTER, String.valueOf(System.currentTimeMillis() + 15 * DateUtils.MILLIS_PER_DAY));
                 popup.debounce();
                 return true;
             }
@@ -218,7 +217,9 @@ public class RatePopup {
         final int times = Integer.parseInt(Objects.requireNonNull(strTimes)) + 1;
         store.setProperty(RateManager.SERVICE, RateManager.POPPED_AT, String.valueOf(System.currentTimeMillis()));
         store.setProperty(RateManager.SERVICE, RateManager.POPPED_TIMES, String.valueOf(times));
-        store.setProperty(RateManager.SERVICE, RateManager.NEXT_POP_AFTER, String.valueOf(System.currentTimeMillis() + 15 * DateUtils.MILLIS_PER_DAY));
+        OperationContext.current().setTelemetryProperty(RateManager.POPPED_TIMES, String.valueOf(times));
+        // popup 3 days later if the popup is faded out automatically
+        popDaysLater(3);
 
         final JFrame frame = ((JFrame) IdeUtils.getWindow(project));
         RatePopup.balloon.show(new PositionTracker<>(frame.getRootPane()) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/feedback/RatePopup.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/feedback/RatePopup.java
@@ -25,7 +25,6 @@ import com.microsoft.azure.toolkit.ide.common.store.AzureStoreManager;
 import com.microsoft.azure.toolkit.ide.common.store.IIdeStore;
 import com.microsoft.azure.toolkit.intellij.common.IdeUtils;
 import com.microsoft.azure.toolkit.lib.common.action.AzureActionManager;
-import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.common.operation.OperationContext;
@@ -42,11 +41,8 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.net.http.HttpResponse;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 public class RatePopup {
     public static final JBColor BACKGROUND_COLOR =
@@ -138,14 +134,6 @@ public class RatePopup {
                 store.setProperty(RateManager.SERVICE, RateManager.RATED_AT, String.valueOf(System.currentTimeMillis()));
                 store.setProperty(RateManager.SERVICE, RateManager.RATED_SCORE, String.valueOf(index + 1));
                 if (index >= 3) {
-                    AzureTaskManager.getInstance().runOnPooledThread(() -> {
-                        final CompletableFuture<HttpResponse<String>> response = MonkeySurvey.send(index + 1);
-                        try {
-                            System.out.println(response.get());
-                        } catch (final InterruptedException | ExecutionException ex) {
-                            throw new AzureToolkitRuntimeException(ex);
-                        }
-                    });
                     AzureMessager.getMessager().success("Thank you for the feedback!");
                     popDaysLater(-1);
                 } else {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* change to popup 3 (instead of 15) days later if the popup is faded out automatically
* add `causeOperation` in telemetry body of score operations
* don't rewind score for InterruptedException


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
