### PR TITLE
workaround methods doesn't work in 2022.3 because deprecated `preload` method doesn't execute by platform

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-cosmos/src/main/java/com/microsoft/azure/toolkit/intellij/cosmos/dbtools/DbToolsWorkaround.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-cosmos/src/main/java/com/microsoft/azure/toolkit/intellij/cosmos/dbtools/DbToolsWorkaround.java
@@ -11,7 +11,6 @@ import com.intellij.database.dataSource.DatabaseDriverManagerImpl;
 import com.intellij.database.dataSource.url.ui.UrlPropertiesPanel;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.PreloadingActivity;
-import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.util.JDOMUtil;
 import com.intellij.openapi.util.registry.Registry;
 import com.microsoft.azure.toolkit.intellij.common.IntelliJAzureIcons;
@@ -37,7 +36,7 @@ public class DbToolsWorkaround extends PreloadingActivity {
     public static final String COSMOS_CASSANDRA_DRIVER_CONFIG = "databaseDrivers/azure-cosmos-cassandra-drivers.xml";
 
     @Override
-    public void preload(@Nonnull ProgressIndicator indicator) {
+    public void preload() {
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
             DbToolsWorkaround.makeAccountShowAtTop();
             loadMongoDriver();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/dbtools/DatabaseDbToolsWorkaround.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-database/src/main/java/com/microsoft/azure/toolkit/intellij/database/dbtools/DatabaseDbToolsWorkaround.java
@@ -10,16 +10,14 @@ import com.intellij.database.dataSource.DatabaseDriverManager;
 import com.intellij.database.dataSource.url.template.UrlTemplate;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.PreloadingActivity;
-import com.intellij.openapi.progress.ProgressIndicator;
 
-import javax.annotation.Nonnull;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
 public class DatabaseDbToolsWorkaround extends PreloadingActivity {
     @Override
-    public void preload(@Nonnull ProgressIndicator indicator) {
+    public void preload() {
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
             loadMySqlAzureTemplates();
             loadPostgreSqlAzureTemplates();


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
`preload(@Suppress("unused") indicator: ProgressIndicator?)` is not called by platform.
switch to use `preload()` instead.


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
