### PR TITLE
Tiny fixes for issues founded in endgame for eap toolkit

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/component/Tree.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/component/Tree.java
@@ -154,13 +154,11 @@ public class Tree extends SimpleTree implements DataProvider {
                 final DefaultTreeModel model = (DefaultTreeModel) this.tree.getModel();
                 if (incremental.length > 0 && incremental[0] && Objects.nonNull(model)) {
                     this.removeLoadMoreNode();
-                    this.refreshChildrenView();
-                    model.insertNodeInto(new LoadingNode(), this, this.getChildCount());
                 } else {
                     this.removeAllChildren();
-                    this.add(new LoadingNode());
-                    this.refreshChildrenView();
                 }
+                this.add(new LoadingNode());
+                this.refreshChildrenView();
                 this.loaded = null;
                 this.loadChildren(incremental);
             }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Modify tree model with runLater in SDK reference book
- Fix index out of bound exception when refresh cosmos document tree nodes, [AB#2012029](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/2012029)

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
