### PR TITLE
Fix open reference book in explorer still open default library in reference book

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/azuresdk/referencebook/AzureSdkTreePanel.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/azuresdk/referencebook/AzureSdkTreePanel.java
@@ -146,7 +146,7 @@ public class AzureSdkTreePanel implements TextDocumentListenerAdapter {
             this.services = AzureSdkLibraryService.loadAzureSdkServices();
             this.categories = AzureSdkCategoryService.loadAzureSDKCategories();
             this.fillDescriptionFromCategoryIfMissing(this.categories, this.services);
-            AzureTaskManager.getInstance().runLater(() -> this.loadData(this.categories, this.services, this.searchBox.getText()), AzureTask.Modality.ANY);
+            AzureTaskManager.getInstance().runAndWait(() -> this.loadData(this.categories, this.services, this.searchBox.getText()), AzureTask.Modality.ANY);
             Optional.ofNullable(this.lastNodePath).ifPresent(p -> AzureTaskManager.getInstance().runAndWait(() -> TreeUtil.selectPath(this.tree, p)));
             AzureEventBus.emit("reference.refresh");
         } catch (final IOException e) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix open reference book in explorer still open default library in reference book


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
