### PR TITLE
send assignment unit id by telemetry properties

### DIFF
--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/experiment/ExperimentationClient.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/java/com/microsoft/azure/toolkit/ide/common/experiment/ExperimentationClient.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.toolkit.ide.common.experiment;
 
+import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
+import com.microsoft.azure.toolkit.lib.common.operation.OperationContext;
 import com.microsoft.azure.toolkit.lib.common.utils.InstallationIdUtils;
 import lombok.Getter;
 
@@ -28,11 +30,14 @@ public class ExperimentationClient {
         return experimentationService;
     }
 
+    @AzureOperation(name = "internal/exp.assignment")
     private static void init() {
         try {
             final Map<String, String> audienceFilters = new HashMap<>();
             final Map<String, String> assignmentIds = new HashMap<>();
-            assignmentIds.put(ASSIGNMENT_UNIT_ID, InstallationIdUtils.getHashMac());
+            final String assignmentUnitId = InstallationIdUtils.getHashMac();
+            assignmentIds.put(ASSIGNMENT_UNIT_ID, assignmentUnitId);
+            OperationContext.action().setTelemetryProperty("ExpAssignmentUnit", assignmentUnitId);
             experimentationService = new ExperimentationService()
                     .withEndPoint(END_POINT)
                     .withAudienceFilters(audienceFilters)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add installation id as ExpAssignmentUnit param in action properties. So that we can trace installation id in exp server.


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
