### PR TITLE
fix CVE 2014 125087

### DIFF
--- a/Utils/spark-tools/spark-v2.3/spark-v2.3.0/pom.xml
+++ b/Utils/spark-tools/spark-v2.3/spark-v2.3.0/pom.xml
@@ -190,6 +190,10 @@
                     <groupId>org.apache.ivy</groupId>
                     <artifactId>ivy</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2014-125087-->
+                    <groupId>com.jamesmurty.utils</groupId>
+                    <artifactId>java-xmlbuilder</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Utils/spark-tools/spark-v2.3/spark-v2.3.2/pom.xml
+++ b/Utils/spark-tools/spark-v2.3/spark-v2.3.2/pom.xml
@@ -190,6 +190,10 @@
                     <groupId>org.apache.ivy</groupId>
                     <artifactId>ivy</artifactId>
                 </exclusion>
+                <exclusion><!--CVE-2014-125087-->
+                    <groupId>com.jamesmurty.utils</groupId>
+                    <artifactId>java-xmlbuilder</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- exclude Java-XMLbuilder fix [CVE-2014-125087](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/102867?typeId=161945)

Does this close any currently open issues?
------------------------------------------
[AB#2033072](https://dev.azure.com/mseng/VSJava/_workitems/edit/2033072)


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
