### PR TITLE
additional fix CVE 2022 2047

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -41,7 +41,7 @@
         <azure.toolkit-lib.version>0.30.0</azure.toolkit-lib.version>
         <azure.toolkit-ide-lib.version>0.30.0</azure.toolkit-ide-lib.version>
         <hdinsight.toolkit-ide-lib.version>0.1.0</hdinsight.toolkit-ide-lib.version>
-        <jetty.version>9.4.47.v20220610</jetty.version>
+        <jetty.version>9.4.50.v20221201</jetty.version>
         <woodstox.version>6.4.0</woodstox.version>
     </properties>
     <modules>
@@ -330,7 +330,7 @@
             <dependency>
                 <groupId>net.sourceforge.htmlunit</groupId>
                 <artifactId>htmlunit</artifactId>
-                <version>2.61.0</version>
+                <version>2.68.0</version>
                 <exclusions>
                     <!--xml-apis has conflict with azure-storage,-->
                     <exclusion>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Fix [CVE-2022-2047](https://dev.azure.com/mseng/VSJava/_componentGovernance/445/alert/101902?typeId=119493&pipelinesTrackingFilter=1)
The old version of jetty is used in the htmlunit package, so upgrade it

Does this close any currently open issues?
------------------------------------------

- AB#[2024695](https://dev.azure.com/mseng/VSJava/_workitems/edit/2024695)
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
