### PR TITLE
[Task #2040703] Add new get start course for azure spring app

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/GuidanceViewManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/GuidanceViewManager.java
@@ -1,5 +1,6 @@
 package com.microsoft.azure.toolkit.ide.guidance;
 
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -74,7 +75,7 @@ public class GuidanceViewManager {
         });
     }
 
-    public static class GuidanceViewFactory implements ToolWindowFactory {
+    public static class GuidanceViewFactory implements ToolWindowFactory, DumbAware {
         private static final Map<Project, GuidanceView> guidanceViewMap = new ConcurrentHashMap<>();
 
         @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/action/ShowGettingStartAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/java/com/microsoft/azure/toolkit/ide/guidance/action/ShowGettingStartAction.java
@@ -1,6 +1,7 @@
 package com.microsoft.azure.toolkit.ide.guidance.action;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
 import com.microsoft.azure.toolkit.ide.common.store.AzureStoreManager;
 import com.microsoft.azure.toolkit.ide.guidance.GuidanceViewManager;
 import com.microsoft.azure.toolkit.intellij.common.IntelliJAzureIcons;
@@ -15,7 +16,7 @@ import java.util.Optional;
 
 import static com.microsoft.azure.toolkit.ide.common.icon.AzureIcons.Common.*;
 
-public class ShowGettingStartAction extends AzureAnAction {
+public class ShowGettingStartAction extends AzureAnAction implements DumbAware {
     public static final String GUIDANCE = "guidance";
     public static final String IS_ACTION_TRIGGERED = "is_action_triggered";
     private static boolean isActionTriggered = false;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/resources/guidance/helloworld-spring-apps.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/resources/guidance/helloworld-spring-apps.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "../flow-schema/Course.json",
+  "name": "hello-spring-apps",
+  "title": "Deploy Your First Spring App to Azure",
+  "description": "This tutorial shows how to use the IntelliJ toolkit to deploy a simple todo-app project to Azure Spring Apps.",
+  "repository": "https://github.com/Azure-Samples/ASA-Samples-Web-Application.git",
+  "tags": [
+    "Spring Apps",
+    "For beginners",
+    "Quickstart"
+  ],
+  "context": {
+    "repository": "https://github.com/Azure-Samples/ASA-Samples-Web-Application.git",
+    "branch": "quickstart",
+    "deployModule": "simple-todo-web",
+    "packageModule": "simple-todo-parent"
+  },
+  "phases": [
+    {
+      "title": "Clone",
+      "description": "Clone demo project to your local machine",
+      "steps": [
+        {
+          "title": "Clone",
+          "description": null,
+          "inputs": [
+            {
+              "name": "input.common.file-chooser",
+              "paramMapping": {
+                "value": "defaultLocation"
+              }
+            }
+          ],
+          "task": {
+            "name": "task.clone",
+            "resultMapping": {
+              "defaultGitDirectory": "defaultLocation"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "title": "Sign-in",
+      "description": "Sign in with your Azure account",
+      "steps": [
+        {
+          "title": "Sign-in",
+          "description": null,
+          "task": {
+            "name": "task.signin"
+          }
+        },
+        {
+          "title": "Select Subscription",
+          "description": null,
+          "task": {
+            "name": "task.select_subscription"
+          }
+        }
+      ]
+    },
+    {
+      "title": "Prepare",
+      "description": "Create resources and related resource connection for deployment",
+      "steps": [
+        {
+          "title": "Create Spring App",
+          "description": null,
+          "inputs": [
+            {
+              "name": "input.springcloud.cluster"
+            },
+            {
+              "name": "input.springcloud.name",
+              "paramMapping": {
+                "springAppName": "defaultSpringAppName"
+              },
+              "resultMapping": {
+                "springAppName": "newSpringAppName"
+              }
+            }
+          ],
+          "task": {
+            "name": "task.springcloud.create",
+            "description": "Create Azure Spring App ${context.newSpringAppName}",
+            "paramMapping": {
+              "springAppName": "newSpringAppName"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "title": "Build & Deploy",
+      "description": "Build artifacts, prepare dependent resources and deploy your project to Azure Spring App ${context.springApp.name}",
+      "steps": [
+        {
+          "title": "Deploy",
+          "description": "Deploy to Azure Spring App ${context.springApp.name}",
+          "task": {
+            "name": "task.springcloud.deploy"
+          }
+        }
+      ]
+    },
+    {
+      "title": "Congratulations!",
+      "type": "summary",
+      "description": "Your project has been deployed to Azure Spring Apps, enjoy your Azure experience!",
+      "steps": [
+        {
+          "title": "View in Azure Explorer",
+          "description": null,
+          "task": {
+            "name": "task.common.focus_resource_in_explorer",
+            "paramMapping": {
+              "resource": "springApp"
+            }
+          }
+        },
+        {
+          "title": "Open in Browser",
+          "description": null,
+          "task": {
+            "name": "task.springcloud.open_in_browser",
+            "paramMapping": {
+              "resource": "springApp"
+            }
+          }
+        },
+        {
+          "title": "Open Log Streaming",
+          "description": null,
+          "task": {
+            "name": "task.springcloud.log_streaming",
+            "paramMapping": {
+              "resource": "springApp"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/resources/guidance/helloworld-spring-apps.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-guidance/src/main/resources/guidance/helloworld-spring-apps.json
@@ -93,11 +93,11 @@
     },
     {
       "title": "Build & Deploy",
-      "description": "Build artifacts, prepare dependent resources and deploy your project to Azure Spring App ${context.springApp.name}",
+      "description": "Build artifacts, prepare dependent resources and deploy your project to Azure Spring App ${context.springApp?.name}",
       "steps": [
         {
           "title": "Deploy",
-          "description": "Deploy to Azure Spring App ${context.springApp.name}",
+          "description": "Deploy to Azure Spring App ${context.springApp?.name}",
           "task": {
             "name": "task.springcloud.deploy"
           }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/IntelliJSpringCloudTaskProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/java/com/microsoft/azure/toolkit/intellij/springcloud/IntelliJSpringCloudTaskProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.intellij.springcloud;
+
+import com.microsoft.azure.toolkit.ide.guidance.ComponentContext;
+import com.microsoft.azure.toolkit.ide.guidance.Context;
+import com.microsoft.azure.toolkit.ide.guidance.Task;
+import com.microsoft.azure.toolkit.ide.guidance.config.TaskConfig;
+import com.microsoft.azure.toolkit.ide.guidance.task.GuidanceTaskProvider;
+import com.microsoft.azure.toolkit.intellij.springcloud.task.CreateSpringAppTask;
+import com.microsoft.azure.toolkit.intellij.springcloud.task.DeploySpringAppTask;
+import com.microsoft.azure.toolkit.intellij.springcloud.task.OpenInBrowserTask;
+import com.microsoft.azure.toolkit.intellij.springcloud.task.OpenLogStreamingTask;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class IntelliJSpringCloudTaskProvider implements GuidanceTaskProvider {
+    @Nullable
+    @Override
+    public Task createTask(@Nonnull TaskConfig config, @Nonnull Context context) {
+        final ComponentContext taskContext = new ComponentContext(config, context);
+        return switch (config.getName()) {
+            case "task.springcloud.create" -> new CreateSpringAppTask(taskContext);
+            case "task.springcloud.deploy" -> new DeploySpringAppTask(taskContext);
+            case "task.springcloud.open_in_browser" -> new OpenInBrowserTask(taskContext);
+            case "task.springcloud.log_streaming" -> new OpenLogStreamingTask(taskContext);
+            default -> null;
+        };
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/resources/META-INF/azure-intellij-plugin-springcloud.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-springcloud/src/main/resources/META-INF/azure-intellij-plugin-springcloud.xml
@@ -3,6 +3,8 @@
         <explorerNodeProvider implementation="com.microsoft.azure.toolkit.ide.springcloud.SpringCloudNodeProvider"/>
         <actions implementation="com.microsoft.azure.toolkit.ide.springcloud.SpringCloudActionsContributor"/>
         <actions implementation="com.microsoft.azure.toolkit.intellij.springcloud.IntellijSpringCloudActionsContributor"/>
+        <guidanceTaskProvider implementation="com.microsoft.azure.toolkit.intellij.springcloud.IntelliJSpringCloudTaskProvider"/>
+        <guidanceInputProvider implementation="com.microsoft.azure.toolkit.intellij.springcloud.IntelliJSpringCloudInputProvider"/>
     </extensions>
     <extensions defaultExtensionNs="com.intellij">
         <fileEditorProvider implementation="com.microsoft.azure.toolkit.intellij.springcloud.properties.SpringCloudAppPropertiesEditorProvider"/>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Add new get start course for azure spring app
- Register task/input provider for spring app get start
- Make getting start tool window/action `DumbAware`


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
