### PR TITLE
Azure Monitor: Extend date range filter with time units

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-monitor/src/main/java/com/microsoft/azure/toolkit/intellij/monitor/view/right/filter/CustomTimeRangeDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-monitor/src/main/java/com/microsoft/azure/toolkit/intellij/monitor/view/right/filter/CustomTimeRangeDialog.java
@@ -31,7 +31,7 @@ public class CustomTimeRangeDialog extends AzureDialog<String> implements AzureF
 
     public CustomTimeRangeDialog() {
         super();
-        this.dateFilterComponent = new DateFilterComponent(false, DateFormatUtil.getDateFormat().getDelegate());
+        this.dateFilterComponent = new DateFilterComponent(false, DateFormatUtil.getDateTimeFormat().getDelegate());
         restoreDate();
         init();
     }
@@ -100,7 +100,7 @@ public class CustomTimeRangeDialog extends AzureDialog<String> implements AzureF
 
     private void setCustomKustoString() {
         final VcsLogDateFilter filter = VcsLogFilterObject.fromDates(dateFilterComponent.getAfter(), dateFilterComponent.getBefore());
-        final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         final String kustoAfter = Optional.ofNullable(filter.getAfter())
                 .map(d -> String.format("where TimeGenerated >= datetime(%s)", formatter.format(d))).orElse(StringUtils.EMPTY);
         final String kustoBefore = Optional.ofNullable(filter.getBefore())

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-monitor/src/main/java/com/microsoft/azure/toolkit/intellij/monitor/view/right/filter/TimeRangeComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-monitor/src/main/java/com/microsoft/azure/toolkit/intellij/monitor/view/right/filter/TimeRangeComboBox.java
@@ -99,7 +99,7 @@ public class TimeRangeComboBox extends AzureComboBox<TimeRangeComboBox.TimeRange
         try {
             final Date afterDate = new Date(after);
             final Date beforeDate = new Date(before);
-            final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+            final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
             final String kustoAfter = String.format("where TimeGenerated >= datetime(%s)", formatter.format(afterDate));
             final String kustoBefore = String.format("where TimeGenerated <= datetime(%s)", formatter.format(beforeDate));
             customKustoString = StringUtils.join(new String[] {kustoBefore, kustoAfter}, " | ");


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adding time units (e.g. hours/minutes/seconds) to a time range component of Azure Monitor will allow to fetch log entries (especially historical ones) more precisely when there is only 5000 of maximal records we can fetch according to settings. 


Does this close any currently open issues?
------------------------------------------
Seems no
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [x] Tested
