### PR TITLE
fix CVE 2023 26049

### DIFF
--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -41,8 +41,9 @@
         <azure.toolkit-lib.version>0.33.0-SNAPSHOT</azure.toolkit-lib.version>
         <azure.toolkit-ide-lib.version>0.33.0-SNAPSHOT</azure.toolkit-ide-lib.version>
         <hdinsight.toolkit-ide-lib.version>0.1.0</hdinsight.toolkit-ide-lib.version>
-        <jetty.version>9.4.50.v20221201</jetty.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
         <woodstox.version>6.4.0</woodstox.version>
+        <hadoop.version>3.3.0</hadoop.version>
     </properties>
     <modules>
         <module>azure-toolkit-ide-libs</module>
@@ -288,7 +289,7 @@
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
-                <version>3.2.4</version>
+                <version>${hadoop.version}</version>
                 <exclusions>
                     <exclusion><!--WS-2018-0629-->
                         <groupId>com.fasterxml.woodstox</groupId>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
bump hadoop version 3.2.4 to 3.3.0,jetty version 9.4.50.v20221201 to 9.4.51.v20230217


Does this close any currently open issues?
------------------------------------------
- fix CVE-2023-26049
- AB[#2061567](https://dev.azure.com/mseng/VSJava/_workitems/edit/2061567)
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
