### PR TITLE
Migrate resource connection features to new connection/resource manager

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice-java/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/deploy/FunctionDeploymentState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice-java/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/deploy/FunctionDeploymentState.java
@@ -12,7 +12,7 @@ import com.intellij.psi.PsiMethod;
 import com.microsoft.azure.toolkit.ide.appservice.AppServiceActionsContributor;
 import com.microsoft.azure.toolkit.intellij.common.RunProcessHandler;
 import com.microsoft.azure.toolkit.intellij.common.RunProcessHandlerMessenger;
-import com.microsoft.azure.toolkit.intellij.connector.function.FunctionSupported;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.DotEnvBeforeRunTaskProvider;
 import com.microsoft.azure.toolkit.intellij.legacy.common.AzureRunProfileState;
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.core.FunctionUtils;
 import com.microsoft.azure.toolkit.lib.appservice.function.FunctionApp;
@@ -97,11 +97,9 @@ public class FunctionDeploymentState extends AzureRunProfileState<FunctionAppBas
 
     private void applyResourceConnection() {
         if (functionDeployConfiguration.isConnectionEnabled()) {
-            functionDeployConfiguration.getConnections().stream()
-                    .filter(connection -> connection.getResource().getDefinition() instanceof FunctionSupported)
-                    .forEach(connection -> ((FunctionSupported) connection.getResource().getDefinition())
-                            .getPropertiesForFunction(connection.getResource().getData(), connection)
-                            .forEach((key, value) -> functionDeployConfiguration.getConfig().getAppSettings().put(key.toString(), value.toString())));
+            final DotEnvBeforeRunTaskProvider.LoadDotEnvBeforeRunTask loadDotEnvBeforeRunTask = functionDeployConfiguration.getLoadDotEnvBeforeRunTask();
+            final Map<String, String> appSettings = functionDeployConfiguration.getConfig().getAppSettings();
+            loadDotEnvBeforeRunTask.loadEnv().forEach(env -> appSettings.put(env.getKey(), env.getValue()));
         }
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice-java/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice-java/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localrun/FunctionRunState.java
@@ -29,7 +29,7 @@ import com.microsoft.azure.toolkit.intellij.common.ReadStreamLineThread;
 import com.microsoft.azure.toolkit.intellij.common.RunProcessHandler;
 import com.microsoft.azure.toolkit.intellij.common.RunProcessHandlerMessenger;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
-import com.microsoft.azure.toolkit.intellij.connector.function.FunctionSupported;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.DotEnvBeforeRunTaskProvider;
 import com.microsoft.azure.toolkit.intellij.function.components.connection.FunctionConnectionCreationDialog;
 import com.microsoft.azure.toolkit.intellij.legacy.common.AzureRunProfileState;
 import com.microsoft.azure.toolkit.intellij.legacy.function.runner.core.FunctionUtils;
@@ -144,11 +144,8 @@ public class FunctionRunState extends AzureRunProfileState<Boolean> {
 
     private void applyResourceConnection(Map<String, String> appSettings) {
         if (functionRunConfiguration.isConnectionEnabled()) {
-            functionRunConfiguration.getConnections().stream()
-                    .filter(connection -> connection.getResource().getDefinition() instanceof FunctionSupported)
-                    .forEach(connection -> ((FunctionSupported) connection.getResource().getDefinition())
-                            .getPropertiesForFunction(connection.getResource().getData(), connection)
-                            .forEach((key, value) -> appSettings.put(key.toString(), value.toString())));
+            final DotEnvBeforeRunTaskProvider.LoadDotEnvBeforeRunTask loadDotEnvBeforeRunTask = functionRunConfiguration.getLoadDotEnvBeforeRunTask();
+            loadDotEnvBeforeRunTask.loadEnv().forEach(env -> appSettings.put(env.getKey(), env.getValue()));
         }
     }
 
@@ -242,7 +239,7 @@ public class FunctionRunState extends AzureRunProfileState<Boolean> {
             }
         });
         // Pending for function cli
-        int result = process.waitFor();
+        final int result = process.waitFor();
         if (result != 0) {
             throw new AzureToolkitRuntimeException(error[0]);
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/function/components/connection/FunctionConnectionComboBox.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/function/components/connection/FunctionConnectionComboBox.java
@@ -20,7 +20,8 @@ import com.microsoft.azure.toolkit.intellij.common.AzureComboBox;
 import com.microsoft.azure.toolkit.intellij.common.ProjectUtils;
 import com.microsoft.azure.toolkit.intellij.common.IntelliJAzureIcons;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
-import com.microsoft.azure.toolkit.intellij.connector.ConnectionManager;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.AzureModule;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.Environment;
 import com.microsoft.azure.toolkit.intellij.function.connection.CommonConnectionResource;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
@@ -41,12 +42,7 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class FunctionConnectionComboBox extends AzureComboBox<FunctionConnectionComboBox.ConnectionConfiguration> {
@@ -101,8 +97,11 @@ public class FunctionConnectionComboBox extends AzureComboBox<FunctionConnection
         if (Objects.isNull(module)) {
             return Collections.emptyList();
         }
-        return project.getService(ConnectionManager.class).getConnectionsByConsumerId(module.getName()).stream()
-                .map(ConnectionConfiguration::new).collect(Collectors.toList());
+        final List<Connection<?, ?>> connections = Optional.ofNullable(AzureModule.from(module))
+                .map(AzureModule::getEnvironment)
+                .map(Environment::getConnections)
+                .orElse(Collections.emptyList());
+        return connections.stream().map(ConnectionConfiguration::new).collect(Collectors.toList());
     }
 
     private List<ConnectionConfiguration> getConfigurationFromLocalSettings() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/function/components/connection/FunctionDefinitionManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/function/components/connection/FunctionDefinitionManager.java
@@ -5,7 +5,7 @@
 package com.microsoft.azure.toolkit.intellij.function.components.connection;
 
 import com.microsoft.azure.toolkit.intellij.connector.ResourceDefinition;
-import com.microsoft.azure.toolkit.intellij.connector.ResourceManager;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.ResourceManager;
 import com.microsoft.azure.toolkit.intellij.connector.function.FunctionSupported;
 import org.apache.commons.lang3.StringUtils;
 
@@ -23,7 +23,7 @@ public class FunctionDefinitionManager {
                     .map(d -> (FunctionSupported) d)
                     .filter(d -> StringUtils.equals(d.getResourceType(), resourceType))
                     .findFirst().orElse(null);
-        } catch (Throwable t) {
+        } catch (final Throwable t) {
             // swallow exception when get connection definition
             return null;
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/spring/SpringPropertiesCompletionContributor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/spring/SpringPropertiesCompletionContributor.java
@@ -5,13 +5,7 @@
 
 package com.microsoft.azure.toolkit.intellij.connector.spring;
 
-import com.intellij.codeInsight.completion.CompletionContributor;
-import com.intellij.codeInsight.completion.CompletionParameters;
-import com.intellij.codeInsight.completion.CompletionProvider;
-import com.intellij.codeInsight.completion.CompletionResultSet;
-import com.intellij.codeInsight.completion.CompletionType;
-import com.intellij.codeInsight.completion.InsertHandler;
-import com.intellij.codeInsight.completion.InsertionContext;
+import com.intellij.codeInsight.completion.*;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.command.WriteCommandAction;
@@ -24,11 +18,12 @@ import com.intellij.util.ProcessingContext;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.intellij.common.IntelliJAzureIcons;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
-import com.microsoft.azure.toolkit.intellij.connector.ConnectionManager;
 import com.microsoft.azure.toolkit.intellij.connector.ConnectorDialog;
 import com.microsoft.azure.toolkit.intellij.connector.ModuleResource;
 import com.microsoft.azure.toolkit.intellij.connector.ResourceDefinition;
-import com.microsoft.azure.toolkit.intellij.connector.ResourceManager;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.AzureModule;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.ConnectionManager;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.ResourceManager;
 import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
@@ -40,6 +35,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class SpringPropertiesCompletionContributor extends CompletionContributor {
     public SpringPropertiesCompletionContributor() {
@@ -48,7 +44,7 @@ public class SpringPropertiesCompletionContributor extends CompletionContributor
             @Override
             public void addCompletions(@Nonnull CompletionParameters parameters, @Nonnull ProcessingContext context, @Nonnull CompletionResultSet resultSet) {
                 final Module module = ModuleUtil.findModuleForFile(parameters.getOriginalFile());
-                if (module == null) {
+                if (Objects.isNull(module)) {
                     return;
                 }
                 ResourceManager.getDefinitions(ResourceDefinition.RESOURCE).stream()
@@ -78,12 +74,12 @@ public class SpringPropertiesCompletionContributor extends CompletionContributor
         public void handleInsert(@Nonnull InsertionContext context, @Nonnull LookupElement lookupElement) {
             final Project project = context.getProject();
             final Module module = ModuleUtil.findModuleForFile(context.getFile().getVirtualFile(), project);
-            if (module != null) {
-                project.getService(ConnectionManager.class)
-                        .getConnectionsByConsumerId(module.getName()).stream()
-                        .filter(c -> Objects.equals(definition, c.getResource().getDefinition())).findAny()
-                        .ifPresentOrElse(c -> this.insert(c, context), () -> this.createAndInsert(module, context));
-            }
+            Optional.ofNullable(module).map(AzureModule::from)
+                    .map(AzureModule::getEnvironment).map(e -> e.getConnectionManager(true))
+                    .ifPresent(connectionManager -> connectionManager
+                            .getConnectionsByConsumerId(module.getName()).stream()
+                            .filter(c -> Objects.equals(definition, c.getResource().getDefinition())).findAny()
+                            .ifPresentOrElse(c -> this.insert(c, context), () -> this.createAndInsert(module, context)));
         }
 
         private void createAndInsert(Module module, @Nonnull InsertionContext context) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/spring/SpringPropertiesLineMarkerProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/spring/SpringPropertiesLineMarkerProvider.java
@@ -20,8 +20,8 @@ import com.intellij.psi.PsiElement;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.intellij.common.IntelliJAzureIcons;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
-import com.microsoft.azure.toolkit.intellij.connector.ConnectionManager;
 import com.microsoft.azure.toolkit.intellij.connector.Resource;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.AzureModule;
 import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import lombok.RequiredArgsConstructor;
@@ -31,8 +31,10 @@ import org.apache.commons.lang3.tuple.Pair;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.awt.event.MouseEvent;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class SpringPropertiesLineMarkerProvider implements LineMarkerProvider {
 
@@ -50,8 +52,10 @@ public class SpringPropertiesLineMarkerProvider implements LineMarkerProvider {
             return null;
         }
         final ImmutablePair<String, String> keyProp = new ImmutablePair<>(propKey, propVal);
-        final List<Connection<?, ?>> connections = element.getProject().getService(ConnectionManager.class)
-                .getConnectionsByConsumerId(module.getName());
+        final List<Connection<?, ?>> connections = Optional.ofNullable(AzureModule.from(module)).map(AzureModule::getEnvironment)
+                .map(env -> env.getConnectionManager(true))
+                .map(cm -> cm.getConnectionsByConsumerId(module.getName()))
+                .orElse(Collections.emptyList());
         for (final Connection<?, ?> connection : connections) {
             final List<Pair<String, String>> properties = SpringSupported.getProperties(connection);
             if (!properties.isEmpty() && properties.get(0).equals(keyProp)) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/Connection.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/Connection.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.toolkit.intellij.connector;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.project.Project;
+import com.microsoft.azure.toolkit.intellij.connector.function.FunctionSupported;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import lombok.AccessLevel;
@@ -78,8 +79,12 @@ public class Connection<R, C> {
     }
 
     public Map<String, String> getEnvironmentVariables(final Project project) {
-        return this.resource.initEnv(project).entrySet().stream()
+        final Map<String, String> result = this.resource.initEnv(project).entrySet().stream()
                 .collect(Collectors.toMap(e -> e.getKey().replaceAll(Connection.ENV_PREFIX, this.getEnvPrefix()), Map.Entry::getValue));
+        if (this.getResource().getDefinition() instanceof FunctionSupported<R>) {
+            result.putAll(((FunctionSupported<R>) this.getResource().getDefinition()).getPropertiesForFunction(this.getResource().getData(), this));
+        }
+        return result;
     }
 
     /**

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectionManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectionManager.java
@@ -143,7 +143,7 @@ public interface ConnectionManager extends PersistentStateComponent<Element> {
                 final String name = connectionEle.getAttributeValue(FIELD_TYPE);
                 final ConnectionDefinition<?, ?> definition = ConnectionManager.getDefinitionOrDefault(name);
                 try {
-                    Optional.ofNullable(definition).map(d -> d.read(connectionEle)).ifPresent(this::addConnection);
+                    Optional.ofNullable(definition).map(d -> d.readDeprecatedConnection(connectionEle)).ifPresent(this::addConnection);
                 } catch (final Exception e) {
                     log.warn(String.format("error occurs when load a resource connection of type '%s'", name), e);
                 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.java
@@ -63,6 +63,7 @@ public class ConnectorDialog extends AzureDialog<Connection<?, ?>> implements Az
     public ConnectorDialog(Project project) {
         super(project);
         this.project = project;
+        $$$setupUI$$$();
         this.init();
     }
 
@@ -260,5 +261,9 @@ public class ConnectorDialog extends AzureDialog<Connection<?, ?>> implements Az
                 return Collections.emptyList();
             }
         };
+    }
+
+    // CHECKSTYLE IGNORE check FOR NEXT 1 LINES
+    void $$$setupUI$$$() {
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/IConnectionAware.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/IConnectionAware.java
@@ -2,9 +2,12 @@ package com.microsoft.azure.toolkit.intellij.connector;
 
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.openapi.module.Module;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.AzureModule;
 import com.microsoft.azure.toolkit.intellij.connector.dotazure.DotEnvBeforeRunTaskProvider;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.Environment;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
 import java.util.List;
 
 public interface IConnectionAware extends RunConfiguration {
@@ -17,7 +20,10 @@ public interface IConnectionAware extends RunConfiguration {
 
     @Nonnull
     default List<Connection<?, ?>> getConnections() {
-        return ConnectionManager.getConnectionForRunConfiguration(this);
+        return AzureModule.createIfSupport(this)
+                .map(AzureModule::getEnvironment)
+                .map(Environment::getConnections)
+                .orElse(Collections.emptyList());
     }
 
     default boolean isConnectionEnabled() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/IConnectionAware.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/IConnectionAware.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.toolkit.intellij.connector.dotazure.Environment;
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public interface IConnectionAware extends RunConfiguration {
     @Deprecated
@@ -26,7 +27,12 @@ public interface IConnectionAware extends RunConfiguration {
                 .orElse(Collections.emptyList());
     }
 
+    default DotEnvBeforeRunTaskProvider.LoadDotEnvBeforeRunTask getLoadDotEnvBeforeRunTask() {
+        return (DotEnvBeforeRunTaskProvider.LoadDotEnvBeforeRunTask) this.getBeforeRunTasks().stream()
+                .filter(task -> task instanceof DotEnvBeforeRunTaskProvider.LoadDotEnvBeforeRunTask).findAny().orElse(null);
+    }
+
     default boolean isConnectionEnabled() {
-        return this.getBeforeRunTasks().stream().anyMatch(task -> task instanceof DotEnvBeforeRunTaskProvider.LoadDotEnvBeforeRunTask);
+        return Objects.nonNull(getLoadDotEnvBeforeRunTask());
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ResourceConnectionExplorer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ResourceConnectionExplorer.java
@@ -26,10 +26,14 @@ import com.microsoft.azure.toolkit.intellij.connector.dotazure.Environment;
 import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
+import org.apache.commons.collections4.CollectionUtils;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.microsoft.azure.toolkit.intellij.connector.ConnectionTopics.CONNECTIONS_REFRESHED;
 import static com.microsoft.azure.toolkit.intellij.connector.ConnectionTopics.CONNECTION_CHANGED;
@@ -127,8 +131,13 @@ public class ResourceConnectionExplorer extends Tree {
 
         @Override
         public boolean shouldBeAvailable(@Nonnull Project project) {
-            final ConnectionManager cm = project.getService(ConnectionManager.class);
-            return cm.getConnections().size() > 0;
+            final List<Connection<?, ?>> connections = AzureModule.list(project).stream()
+                    .map(AzureModule::getEnvironment)
+                    .filter(Objects::nonNull)
+                    .map(Environment::getConnections)
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+            return CollectionUtils.isNotEmpty(connections);
         }
 
         @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/Environment.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/Environment.java
@@ -49,11 +49,11 @@ public class Environment {
         final VirtualFile dotAzureDir = this.dotEnvFile.getParent();
         final VirtualFile connectionsFile = dotAzureDir.findChild("connections.xml");
         final VirtualFile resourcesFile = dotAzureDir.findChild("resources.xml");
-        if (Objects.nonNull(connectionsFile)) {
-            this.connectionManager = new ConnectionManager(connectionsFile);
-        }
         if (Objects.nonNull(resourcesFile)) {
-            this.resourceManager = new ResourceManager(resourcesFile);
+            this.resourceManager = new ResourceManager(resourcesFile, this);
+        }
+        if (Objects.nonNull(connectionsFile)) {
+            this.connectionManager = new ConnectionManager(connectionsFile, this);
         }
     }
 
@@ -157,7 +157,7 @@ public class Environment {
     }
 
     public List<Connection<?, ?>> getConnections() {
-        return Optional.ofNullable(this.getConnectionManager(false)).map(ConnectionManager::getConnections)
+        return Optional.ofNullable(this.getConnectionManager(true)).map(ConnectionManager::getConnections)
             .orElse(Collections.emptyList());
     }
 
@@ -169,13 +169,13 @@ public class Environment {
             if (createIfNotExist) {
                 try {
                     final VirtualFile connectionsFile = dotAzureDir.findOrCreateChildData(this, "connections.xml");
-                    this.connectionManager = new ConnectionManager(connectionsFile);
+                    this.connectionManager = new ConnectionManager(connectionsFile, this);
                 } catch (final IOException e) {
                     throw new AzureToolkitRuntimeException(e);
                 }
             } else {
                 this.connectionManager = Optional.ofNullable(dotAzureDir.findChild("connections.xml"))
-                    .map(ConnectionManager::new)
+                    .map(file -> new ConnectionManager(file, this))
                     .orElse(null);
             }
         }
@@ -190,13 +190,13 @@ public class Environment {
             if (createIfNotExist) {
                 try {
                     final VirtualFile resourcesFile = dotAzureDir.findOrCreateChildData(this, "resources.xml");
-                    this.resourceManager = new ResourceManager(resourcesFile);
+                    this.resourceManager = new ResourceManager(resourcesFile, this);
                 } catch (final IOException e) {
                     throw new AzureToolkitRuntimeException(e);
                 }
             } else {
                 this.resourceManager = Optional.ofNullable(dotAzureDir.findChild("resources.xml"))
-                    .map(ResourceManager::new)
+                    .map(file -> new ResourceManager(file, this))
                     .orElse(null);
             }
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/ResourceManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/ResourceManager.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.toolkit.intellij.connector.ResourceDefinition;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -40,8 +41,11 @@ public class ResourceManager {
     private static final String ELEMENT_NAME_RESOURCE = "resource";
     private final Set<Resource<?>> resources = new LinkedHashSet<>();
     private final VirtualFile resourcesFile;
+    @Getter
+    private final Environment environment;
 
-    public ResourceManager(@Nonnull VirtualFile resourcesFile) {
+    public ResourceManager(@Nonnull VirtualFile resourcesFile, @Nonnull final Environment environment) {
+        this.environment = environment;
         this.resourcesFile = resourcesFile;
         try {
             this.load();
@@ -115,7 +119,7 @@ public class ResourceManager {
         final Element resourcesEle = JDOMUtil.load(this.resourcesFile.toNioPath());
         for (final Element resourceEle : resourcesEle.getChildren()) {
             final String resDef = resourceEle.getAttributeValue(ATTR_DEFINITION);
-            final ResourceDefinition<?> definition = com.microsoft.azure.toolkit.intellij.connector.ResourceManager.getDefinition(resDef);
+            final ResourceDefinition<?> definition = ResourceManager.getDefinition(resDef);
             try {
                 Optional.ofNullable(definition).map(d -> definition.read(resourceEle)).ifPresent(this::addResource);
             } catch (final Exception e) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Migrate resource connection features to new connection/resource manager
- Migrate to LoadDotEnvBeforeRunTask to get env in azure related run configuration

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
