### PR TITLE
[AB#2074011] Support restore resource connections in Azure Toolkit

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-facet/src/main/java/com/microsoft/azure/toolkit/intellij/facet/projectexplorer/ActionNode.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-facet/src/main/java/com/microsoft/azure/toolkit/intellij/facet/projectexplorer/ActionNode.java
@@ -11,13 +11,16 @@ import com.intellij.openapi.project.Project;
 import com.intellij.ui.SimpleTextAttributes;
 import com.microsoft.azure.toolkit.intellij.common.action.IntellijAzureActionManager;
 import com.microsoft.azure.toolkit.lib.common.action.Action;
+import com.microsoft.azure.toolkit.lib.common.action.IActionGroup;
 import com.microsoft.azure.toolkit.lib.common.view.IView;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 public class ActionNode<T> extends AbstractTreeNode<Action<T>> implements IAzureFacetNode {
     @Nullable
@@ -58,6 +61,27 @@ public class ActionNode<T> extends AbstractTreeNode<Action<T>> implements IAzure
     @Override
     public void onClicked(Object event) {
         this.getValue().handle(this.source, event);
+    }
+
+    @Nullable
+    @Override
+    public IActionGroup getActionGroup() {
+        return new IActionGroup() {
+            @Override
+            public IView.Label getView() {
+                return null;
+            }
+
+            @Override
+            public List<Object> getActions() {
+                return Arrays.asList(ActionNode.this.getValue());
+            }
+
+            @Override
+            public void addAction(Object action) {
+                // do nothing here
+            }
+        };
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-facet/src/main/java/com/microsoft/azure/toolkit/intellij/facet/projectexplorer/ConnectionNode.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-facet/src/main/java/com/microsoft/azure/toolkit/intellij/facet/projectexplorer/ConnectionNode.java
@@ -81,10 +81,10 @@ public class ConnectionNode extends AbstractTreeNode<Connection<?, ?>> implement
         final Connection<?, ?> connection = this.getValue();
         final Resource<?> resource = connection.getResource();
         final ResourceId resourceId = ResourceId.fromString(resource.getDataId());
-        final boolean isValidate = connection.validate(getProject());
-        presentation.setIcon(isValidate ? IntelliJAzureIcons.getIcon(AzureResourceIconProvider.getResourceIconPath(resourceId)) : AllIcons.General.Warning);
+        final boolean isValid = connection.validate(getProject());
+        presentation.setIcon(isValid ? IntelliJAzureIcons.getIcon(AzureResourceIconProvider.getResourceIconPath(resourceId)) : AllIcons.General.Warning);
         presentation.addText(connection.getEnvPrefix() + "_*", SimpleTextAttributes.REGULAR_ATTRIBUTES);
-        if (isValidate) {
+        if (isValid) {
             presentation.addText(" " + resource.getName(), SimpleTextAttributes.GRAYED_ATTRIBUTES);
         } else {
             final String message = connection.getResource().isValidResource() ? "Invalid Consumer" : "Invalid Resource";

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/AzureServiceResource.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/AzureServiceResource.java
@@ -103,6 +103,11 @@ public class AzureServiceResource<T extends AzResource> implements Resource<T> {
         return String.format("%s[%s]", this.getDefinition().title, this.getName());
     }
 
+    @Override
+    public boolean isValidResource() {
+        return Optional.ofNullable(getData()).map(AzResource::exists).orElse(false);
+    }
+
     @Getter
     @RequiredArgsConstructor
     @EqualsAndHashCode(onlyExplicitlyIncluded = true)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/AzureServiceResource.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/AzureServiceResource.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.ide.common.action.ResourceCommonActionsContributor;
 import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
 import com.microsoft.azure.toolkit.lib.common.action.AzureActionManager;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
@@ -105,6 +106,9 @@ public class AzureServiceResource<T extends AzResource> implements Resource<T> {
 
     @Override
     public boolean isValidResource() {
+        if (!Azure.az(AzureAccount.class).isLoggedIn()) {
+            return true;
+        }
         return Optional.ofNullable(getData()).map(AzResource::exists).orElse(false);
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/Connection.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/Connection.java
@@ -135,7 +135,10 @@ public class Connection<R, C> {
     }
 
     public boolean validate(Project project) {
-        return this.getDefinition().validate(this, project);
+        final boolean isResourceValid = this.getResource().isValidResource();
+        final boolean isConsumerValid = this.getConsumer().isValidResource();
+        final boolean isConnectionValid = this.getDefinition().validate(this, project);
+        return isResourceValid && isConsumerValid && isConnectionValid;
     }
 
     public void setProfile(Profile profile) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectionDefinition.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectionDefinition.java
@@ -155,8 +155,8 @@ public class ConnectionDefinition<R, C> {
         }
         final Resource<R> existedResource = (Resource<R>) profile.getResourceManager().getResourceById(resource.getId());
         if (Objects.nonNull(existedResource)) { // not new
-            final R current = resource.getData();
-            final R origin = existedResource.getData();
+            final String current = resource.getDataId();
+            final String origin = existedResource.getDataId();
             if (Objects.equals(origin, current) && existedResource.isModified(resource)) { // modified
                 final String template = "%s \"%s\" with different configuration is found on your PC. \nDo you want to override it?";
                 final String msg = String.format(template, resource.getDefinition().getTitle(), resource.getName());

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectionDefinition.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectionDefinition.java
@@ -33,6 +33,7 @@ import static com.microsoft.azure.toolkit.intellij.connector.dotazure.Connection
 public class ConnectionDefinition<R, C> {
     private static final ExtensionPointName<ConnectionProvider> exPoints =
             ExtensionPointName.create("com.microsoft.tooling.msservices.intellij.azure.connectionProvider");
+    public static final String ENV_PREFIX = "envPrefix";
     @Nonnull
     @EqualsAndHashCode.Include
     private final ResourceDefinition<R> resourceDefinition;
@@ -70,23 +71,31 @@ public class ConnectionDefinition<R, C> {
     /**
      * read/deserialize a instance of {@link Connection} from {@code element}
      */
-    @Nullable
+    @Nonnull
     @SuppressWarnings("unchecked")
     public Connection<R, C> read(@Nonnull final com.microsoft.azure.toolkit.intellij.connector.dotazure.ResourceManager manager, Element connectionEle) {
         final String id = connectionEle.getAttributeValue(FIELD_ID);
-        final Element consumerEle = connectionEle.getChild("consumer");
+        final String envPrefix = connectionEle.getAttributeValue(ENV_PREFIX);
+        final Resource<R> resource = Optional.ofNullable(readResourceFromElement(connectionEle, manager))
+                .orElseGet(() -> new InvalidResource<>(this.getResourceDefinition()));
+        final Resource<C> consumer = Optional.ofNullable(readConsumerFromElement(connectionEle, manager))
+                .orElseGet(() -> new InvalidResource<>(this.getConsumerDefinition()));
+        final Connection<R, C> connection = this.define(id, resource, consumer);
+        connection.setEnvPrefix(envPrefix);
+        return connection;
+    }
+
+    private Resource<R> readResourceFromElement(Element connectionEle, @Nonnull final com.microsoft.azure.toolkit.intellij.connector.dotazure.ResourceManager manager) {
         final Element resourceEle = connectionEle.getChild("resource");
+        return (Resource<R>) manager.getResourceById(resourceEle.getTextTrim());
+    }
+
+    private Resource<C> readConsumerFromElement(Element connectionEle, @Nonnull final com.microsoft.azure.toolkit.intellij.connector.dotazure.ResourceManager manager) {
+        final Element consumerEle = connectionEle.getChild("consumer");
         final String consumerDefName = consumerEle.getAttributeValue("type");
-        final Resource<R> resource = (Resource<R>) manager.getResourceById(resourceEle.getTextTrim());
-        final Resource<C> consumer = ModuleResource.Definition.IJ_MODULE.getName().equals(consumerDefName) ?
+        return ModuleResource.Definition.IJ_MODULE.getName().equals(consumerDefName) ?
                 (Resource<C>) new ModuleResource(consumerEle.getTextTrim()) :
                 (Resource<C>) manager.getResourceById(consumerEle.getTextTrim());
-        if (Objects.nonNull(resource) && Objects.nonNull(consumer)) {
-            final Connection<R, C> connection = this.define(id, resource, consumer);
-            connection.setEnvPrefix(connectionEle.getAttributeValue("envPrefix"));
-            return connection;
-        }
-        return null;
     }
 
     public Connection<R, C> readDeprecatedConnection(Element connectionEle) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.form
@@ -10,7 +10,7 @@
     <children>
       <component id="1fd3" class="com.intellij.ui.TitledSeparator" binding="consumerTitle">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Consumer"/>
@@ -19,7 +19,7 @@
       </component>
       <component id="28181" class="com.intellij.ui.components.JBLabel" binding="consumerTypeLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <minimum-size width="100" height="24"/>
             <preferred-size width="100" height="24"/>
             <maximum-size width="100" height="24"/>
@@ -31,19 +31,19 @@
       </component>
       <component id="a2af1" class="com.microsoft.azure.toolkit.intellij.common.AzureComboBox" binding="consumerTypeSelector" custom-create="true" default-binding="true">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <component id="655b" class="com.microsoft.azure.toolkit.intellij.common.AzureComboBox" binding="resourceTypeSelector" custom-create="true" default-binding="true">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <component id="80d53" class="com.intellij.ui.components.JBLabel" binding="resourceTypeLabel">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <minimum-size width="100" height="24"/>
             <preferred-size width="100" height="24"/>
             <maximum-size width="100" height="24"/>
@@ -55,7 +55,7 @@
       </component>
       <component id="c34b7" class="com.intellij.ui.TitledSeparator" binding="resourceTitle">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Resource"/>
@@ -70,7 +70,7 @@
       <grid id="2a3e3" binding="consumerPanelContainer" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -79,7 +79,7 @@
       <grid id="fe6b6" binding="resourcePanelContainer" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="4" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="4" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -87,7 +87,7 @@
       </grid>
       <component id="d02fb" class="javax.swing.JTextField" binding="envPrefixTextField">
         <constraints>
-          <grid row="4" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="5" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <minimum-size width="110" height="30"/>
             <preferred-size width="110" height="30"/>
           </grid>
@@ -98,7 +98,7 @@
       </component>
       <component id="4c846" class="javax.swing.JLabel">
         <constraints>
-          <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="56" height="16"/>
           </grid>
         </constraints>
@@ -108,10 +108,33 @@
       </component>
       <component id="e074f" class="com.intellij.ui.HyperlinkLabel" binding="lblSignIn" custom-create="true">
         <constraints>
-          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
-        <properties/>
       </component>
+      <grid id="be772" binding="descriptionContainer" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="5" left="0" bottom="5" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <visible value="false"/>
+        </properties>
+        <border type="none"/>
+        <children>
+          <component id="ecea9" class="javax.swing.JTextPane" binding="descriptionPane">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                <minimum-size width="420" height="-1"/>
+                <preferred-size width="420" height="-1"/>
+              </grid>
+            </constraints>
+            <properties>
+              <contentType value="text/html"/>
+              <editable value="false"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
     </children>
   </grid>
 </form>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/InvalidResource.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/InvalidResource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+package com.microsoft.azure.toolkit.intellij.connector;
+
+import lombok.RequiredArgsConstructor;
+
+import javax.annotation.Nonnull;
+
+@RequiredArgsConstructor
+public class InvalidResource<T> implements Resource<T> {
+
+    private final ResourceDefinition<T> definition;
+
+    @Nonnull
+    @Override
+    public ResourceDefinition<T> getDefinition() {
+        return this.definition;
+    }
+
+    @Override
+    public String getId() {
+        return null;
+    }
+
+    @Override
+    public T getData() {
+        return null;
+    }
+
+    @Override
+    public String getDataId() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return "Invalid Resource";
+    }
+
+    @Override
+    public boolean isValidResource() {
+        return false;
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/Resource.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/Resource.java
@@ -52,4 +52,8 @@ public interface Resource<T> {
     default boolean isModified(Resource<T> resource) {
         return !this.equals(resource);
     }
+
+    default boolean isValidResource() {
+        return true;
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ResourceConnectionActionsContributor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ResourceConnectionActionsContributor.java
@@ -6,7 +6,6 @@
 package com.microsoft.azure.toolkit.intellij.connector;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
@@ -26,7 +25,6 @@ import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -157,17 +155,6 @@ public class ResourceConnectionActionsContributor implements IActionsContributor
 
     public static void fixResourceConnection(Connection<?, ?> c, Project project) {
         AzureTaskManager.getInstance().runAndWait(() -> {
-            if (c.getConsumer() instanceof ModuleResource) {
-                final String moduleName = ((ModuleResource) c.getConsumer()).getModuleName();
-                final Module module = ModuleManager.getInstance(project).findModuleByName(moduleName);
-                try {
-                    // must init dotenv file first or there will be exception during update connection
-                    // todo: discuss whether we need to update the resource connection update/delete logic
-                    WriteAction.compute(() -> AzureModule.from(module).initializeWithDefaultProfileIfNot().getOrInitDotAzureFile());
-                } catch (IOException e) {
-                    AzureMessager.getMessager().error("Failed to initialize Azure Toolkit configuration file.", e);
-                }
-            }
             final String invalidResourceName = c.getResource().isValidResource() ? null : c.getResource().getDefinition().getTitle();
             final String invalidConsumerName = c.getConsumer().isValidResource() ? null : c.getConsumer().getDefinition().getTitle();
             final String invalidProperties = Stream.of(invalidResourceName, invalidConsumerName)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ResourceConnectionActionsContributor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ResourceConnectionActionsContributor.java
@@ -29,12 +29,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ResourceConnectionActionsContributor implements IActionsContributor {
     public static final Action.Id<Object> REFRESH_CONNECTIONS = Action.Id.of("user/connector.refresh_connections");
     public static final Action.Id<AzureModule> ADD_CONNECTION = Action.Id.of("user/connector.add_connection");
     public static final Action.Id<Connection<?, ?>> EDIT_CONNECTION = Action.Id.of("user/connector.edit_connection");
     public static final Action.Id<Connection<?, ?>> REMOVE_CONNECTION = Action.Id.of("user/connector.remove_connection");
+    public static final Action.Id<Connection<?, ?>> FIX_CONNECTION = Action.Id.of("user/connector.fix_connection");
 
     public static final Action.Id<AzureModule> CONNECT_TO_MODULE = Action.Id.of("user/connector.connect_to_module");
     public static final Action.Id<AzureModule> REFRESH_MODULE = Action.Id.of("user/connector.refresh_module");
@@ -101,6 +103,14 @@ public class ResourceConnectionActionsContributor implements IActionsContributor
             .withAuthRequired(false)
             .register(am);
 
+        new Action<>(FIX_CONNECTION)
+                .withLabel("Fix Connection")
+                .withIcon(AzureIcons.Action.EDIT.getIconPath())
+                .visibleWhen(m -> m instanceof Connection<?, ?>)
+                .withHandler((c, e) -> fixResourceConnection(c, ((AnActionEvent) e).getProject()))
+                .withAuthRequired(false)
+                .register(am);
+
         new Action<>(REMOVE_CONNECTION)
             .withLabel("Remove")
             .withIcon(AzureIcons.Action.REMOVE.getIconPath())
@@ -143,14 +153,30 @@ public class ResourceConnectionActionsContributor implements IActionsContributor
             .register(am);
     }
 
-    private void refreshModuleConnections(AzureModule module) {
-//        AzureEventBus.emit("");
-        AzureEventBus.emit("connector.refreshed.module_connections", module);
+    public static void fixResourceConnection(Connection<?, ?> c, Project project) {
+        AzureTaskManager.getInstance().runAndWait(() -> {
+            final String title = String.format("Fix resource connection %s", c.getEnvPrefix());
+            final String invalidResourceName = c.getResource().isValidResource() ? null : c.getResource().getDefinition().getTitle();
+            final String invalidConsumerName = c.getConsumer().isValidResource() ? null : c.getConsumer().getDefinition().getTitle();
+            final String invalidProperties = Stream.of(invalidResourceName, invalidConsumerName)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.joining(", "));
+            final String promptMessage = String.format("Please set correct %s for connection %s", invalidProperties, c.getEnvPrefix());
+            final ConnectorDialog dialog = new ConnectorDialog(project);
+            dialog.setTitle(title);
+            dialog.setDescription(promptMessage);
+            dialog.setFixedEnvPrefix(c.getEnvPrefix());
+            dialog.setFixedConnectionDefinition(c.getDefinition());
+            dialog.setValue(c);
+            dialog.show();
+        });
+    }
 
+    private void refreshModuleConnections(AzureModule module) {
+        AzureEventBus.emit("connector.refreshed.module_connections", module);
     }
 
     private void refreshModule(AzureModule module) {
-//        AzureEventBus.emit("");
         AzureEventBus.emit("connector.refreshed.module_root", module);
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/DotEnvBeforeRunTaskProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/DotEnvBeforeRunTaskProvider.java
@@ -15,11 +15,13 @@ import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.fileChooser.FileChooser;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
+import com.microsoft.azure.toolkit.intellij.connector.ResourceConnectionActionsContributor;
 import com.microsoft.azure.toolkit.lib.common.messager.ExceptionNotification;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
@@ -28,7 +30,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.concurrency.AsyncPromise;
@@ -130,10 +131,16 @@ public class DotEnvBeforeRunTaskProvider extends BeforeRunTaskProvider<DotEnvBef
 
         @AzureOperation("platform/connector.load_env_beforeruntask")
         public List<Pair<String, String>> loadEnv() {
-            final Profile profile = AzureModule.createIfSupport(this.config).map(AzureModule::getDefaultProfile).orElse(null);
-            if (CollectionUtils.isNotEmpty(profile.getInvalidConnections())) {
-                AzureTaskManager.getInstance().runAndWait(profile::fixInvalidResourceConnection);
+            final AzureModule azureModule = AzureModule.createIfSupport(this.config).orElse(null);
+            final Project project = Optional.ofNullable(azureModule).map(AzureModule::getProject).orElse(null);
+            final List<Connection<?, ?>> invalidConnections = Optional.ofNullable(azureModule).map(AzureModule::getDefaultProfile)
+                    .map(Profile::getConnections)
+                    .stream().flatMap(List::stream)
+                    .filter(c -> !c.validate(project)).toList();
+            for (final Connection<?, ?> connection : invalidConnections) {
+                ResourceConnectionActionsContributor.fixResourceConnection(connection, project);
             }
+            // todo: wait for all connection has been saved to .env
             return Optional.ofNullable(this.file)
                 .or(() -> AzureModule.createIfSupport(this.config).map(AzureModule::getDefaultProfile).map(Profile::getDotEnvFile))
                 .map(Profile::load)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/Profile.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/Profile.java
@@ -123,6 +123,10 @@ public class Profile {
         return this;
     }
 
+    public VirtualFile getOrInitDotAzureFile() throws IOException {
+        return WriteAction.compute(() -> this.profileDir.findOrCreateChildData(this, DOT_ENV));
+    }
+
     public void save() {
         try {
             this.connectionManager.save();
@@ -174,7 +178,7 @@ public class Profile {
         if (!this.profileDir.isValid()) {
             throw new AzureToolkitRuntimeException(String.format("'.azure/%s' doesn't exist.", this.name));
         }
-        WriteAction.run(() -> this.dotEnvFile = this.profileDir.findOrCreateChildData(this, DOT_ENV));
+        this.dotEnvFile = getOrInitDotAzureFile();
         Objects.requireNonNull(this.dotEnvFile, String.format("'.azure/%s/.env' can not be created.", this.name));
         final AzureString description = OperationBundle.description("boundary/connector.load_env.resource", connection.getResource().getDataId());
         return AzureTaskManager.getInstance().runInBackgroundAsObservable(description, () -> {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/Profile.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/Profile.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
 import com.microsoft.azure.toolkit.intellij.connector.ConnectionTopics;
 import com.microsoft.azure.toolkit.intellij.connector.DeploymentTargetTopics;
+import com.microsoft.azure.toolkit.intellij.connector.ResourceConnectionActionsContributor;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
@@ -217,5 +218,19 @@ public class Profile {
 
     public List<String> getTargetAppIds() {
         return this.deploymentTargetManager.getTargets();
+    }
+
+    public List<Connection<?, ?>> getInvalidConnections() {
+        final Project project = this.module.getProject();
+        return this.getConnections().stream().filter(c -> !c.validate(project)).collect(Collectors.toList());
+    }
+
+    public void fixInvalidResourceConnection() {
+        final Project project = this.module.getProject();
+        final List<Connection<?, ?>> invalidConnections = getInvalidConnections();
+        for (Connection<?, ?> connection : invalidConnections) {
+            ResourceConnectionActionsContributor.fixResourceConnection(connection, project);
+        }
+        WriteAction.run(() -> this.save());
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/Profile.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/Profile.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
 import com.microsoft.azure.toolkit.intellij.connector.ConnectionTopics;
 import com.microsoft.azure.toolkit.intellij.connector.DeploymentTargetTopics;
-import com.microsoft.azure.toolkit.intellij.connector.ResourceConnectionActionsContributor;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
@@ -214,19 +213,5 @@ public class Profile {
 
     public List<String> getTargetAppIds() {
         return this.deploymentTargetManager.getTargets();
-    }
-
-    public List<Connection<?, ?>> getInvalidConnections() {
-        final Project project = this.module.getProject();
-        return this.getConnections().stream().filter(c -> !c.validate(project)).collect(Collectors.toList());
-    }
-
-    public void fixInvalidResourceConnection() {
-        final Project project = this.module.getProject();
-        final List<Connection<?, ?>> invalidConnections = getInvalidConnections();
-        for (Connection<?, ?> connection : invalidConnections) {
-            ResourceConnectionActionsContributor.fixResourceConnection(connection, project);
-        }
-        WriteAction.run(() -> this.save());
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/ResourceManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/ResourceManager.java
@@ -96,7 +96,8 @@ public class ResourceManager {
     @AzureOperation("boundary/connector.save_resources")
     void save() throws IOException {
         final Element resourcesEle = new Element(ELEMENT_NAME_RESOURCES);
-        this.resources.forEach(resource -> {
+        // todo: whether to save invalid resources?
+        this.resources.stream().filter(Resource::isValidResource).forEach(resource -> {
             final Element resourceEle = new Element(ELEMENT_NAME_RESOURCE);
             try {
                 if (resource.writeTo(resourceEle)) {

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/resources/bundles/com/microsoft/azure/toolkit/operation.properties
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-common-lib/src/main/resources/bundles/com/microsoft/azure/toolkit/operation.properties
@@ -492,6 +492,7 @@ user/connector.add_connection=add new resource connection
 user/connector.edit_connection=edit selected resource connection
 user/connector.refresh_connections=refresh all resource connections
 user/connector.remove_connection=remove selected resource connection
+user/connector.fix_connection=fix resource connection with invalid configuration
 user/cosmos.copy_connection_string.account=copy connection string of Azure Cosmos DB Account ({0})
 user/cosmos.create_cosmos_db_account.group=create Azure Cosmos DB account in resource group ({0})
 user/cosmos.import_document.container=import document into container ({0})


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Support load connections without resource definition
- Prompt users to fix resource connection when invoke connection task with invalid connections
- Render invalid resource connection in project explorer and show edit … 



Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
