### PR TITLE
Show common resource connections in azure explorer

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/function/connection/CommonConnectionCreationPanel.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/function/connection/CommonConnectionCreationPanel.form
@@ -11,9 +11,9 @@
       <component id="ad076" class="javax.swing.JLabel" binding="lblConnectionName">
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <minimum-size width="80" height="-1"/>
-            <preferred-size width="80" height="-1"/>
-            <maximum-size width="80" height="-1"/>
+            <minimum-size width="100" height="-1"/>
+            <preferred-size width="100" height="-1"/>
+            <maximum-size width="100" height="-1"/>
           </grid>
         </constraints>
         <properties>
@@ -34,9 +34,9 @@
       <component id="9819c" class="javax.swing.JLabel" binding="lblConnectionString">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <minimum-size width="80" height="-1"/>
-            <preferred-size width="80" height="-1"/>
-            <maximum-size width="80" height="-1"/>
+            <minimum-size width="100" height="-1"/>
+            <preferred-size width="100" height="-1"/>
+            <maximum-size width="100" height="-1"/>
           </grid>
         </constraints>
         <properties>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/function/connection/CommonConnectionResource.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/function/connection/CommonConnectionResource.java
@@ -73,6 +73,10 @@ public class CommonConnectionResource implements Resource<ConnectionTarget> {
         return this.data.getName();
     }
 
+    public String getEnvPrefix() {
+        return this.data.getName();
+    }
+
     @Getter
     @EqualsAndHashCode(onlyExplicitlyIncluded = true)
     @RequiredArgsConstructor
@@ -142,6 +146,11 @@ public class CommonConnectionResource implements Resource<ConnectionTarget> {
         @Override
         public String getResourceConnectionString(@Nonnull ConnectionTarget resource) {
             return resource.getConnectionString();
+        }
+
+        @Override
+        public boolean isCustomizedEnvPrefixSupported() {
+            return false;
         }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/Connection.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/Connection.java
@@ -124,10 +124,8 @@ public class Connection<R, C> {
     }
 
     public String getEnvPrefix() {
-        if (StringUtils.isBlank(this.envPrefix)) {
-            return this.definition.getResourceDefinition().getDefaultEnvPrefix();
-        }
-        return this.envPrefix;
+        return resource.getDefinition().isCustomizedEnvPrefixSupported() ?
+                StringUtils.firstNonBlank(this.envPrefix, this.resource.getEnvPrefix()) : this.resource.getEnvPrefix();
     }
 
     public void write(Element connectionEle) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.form
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.form
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.microsoft.azure.toolkit.intellij.connector.ConnectorDialog">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="8" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="8" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="48" y="54" width="564" height="243"/>
+      <xy x="48" y="54" width="580" height="263"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <component id="1fd3" class="com.intellij.ui.TitledSeparator" binding="consumerTitle">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Consumer"/>
@@ -31,7 +31,7 @@
       </component>
       <component id="a2af1" class="com.microsoft.azure.toolkit.intellij.common.AzureComboBox" binding="consumerTypeSelector" custom-create="true" default-binding="true">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -55,7 +55,7 @@
       </component>
       <component id="c34b7" class="com.intellij.ui.TitledSeparator" binding="resourceTitle">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Resource"/>
@@ -70,7 +70,7 @@
       <grid id="2a3e3" binding="consumerPanelContainer" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -79,42 +79,22 @@
       <grid id="fe6b6" binding="resourcePanelContainer" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="4" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children/>
       </grid>
-      <component id="d02fb" class="javax.swing.JTextField" binding="envPrefixTextField">
-        <constraints>
-          <grid row="5" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="110" height="30"/>
-            <preferred-size width="110" height="30"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value="AZURE_MYSQL_"/>
-        </properties>
-      </component>
-      <component id="4c846" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="56" height="16"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value="Env prefix:"/>
-        </properties>
-      </component>
       <component id="e074f" class="com.intellij.ui.HyperlinkLabel" binding="lblSignIn" custom-create="true">
         <constraints>
           <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
+        <properties/>
       </component>
       <grid id="be772" binding="descriptionContainer" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="5" left="0" bottom="5" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <visible value="false"/>
@@ -131,6 +111,39 @@
             <properties>
               <contentType value="text/html"/>
               <editable value="false"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="ceac0" binding="pnlEnvPrefix" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <minimum-size width="160" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="d02fb" class="javax.swing.JTextField" binding="envPrefixTextField">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                <minimum-size width="110" height="30"/>
+                <preferred-size width="110" height="30"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="AZURE_MYSQL_"/>
+            </properties>
+          </component>
+          <component id="4c846" class="javax.swing.JLabel" binding="lblEnvPrefix">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="56" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="Env prefix:"/>
             </properties>
           </component>
         </children>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.java
@@ -64,6 +64,8 @@ public class ConnectorDialog extends AzureDialog<Connection<?, ?>> implements Az
     private HyperlinkLabel lblSignIn;
     private JPanel descriptionContainer;
     private JTextPane descriptionPane;
+    private JPanel pnlEnvPrefix;
+    private JLabel lblEnvPrefix;
     private ResourceDefinition<?> resourceDefinition;
     private ResourceDefinition<?> consumerDefinition;
 
@@ -193,7 +195,9 @@ public class ConnectorDialog extends AzureDialog<Connection<?, ?>> implements Az
             connection.setConsumer(consumer);
             connection.setDefinition(connectionDefinition);
         }
-        connection.setEnvPrefix(this.envPrefixTextField.getText().trim());
+        if (resourceDef.isCustomizedEnvPrefixSupported()) {
+            connection.setEnvPrefix(this.envPrefixTextField.getText().trim());
+        }
         return connection;
     }
 
@@ -241,6 +245,8 @@ public class ConnectorDialog extends AzureDialog<Connection<?, ?>> implements Az
             this.envPrefixTextField.setText(definition.getDefaultEnvPrefix());
             this.resourceTypeSelector.setValue(new ItemReference<>(definition.getName(), ResourceDefinition::getName));
             this.resourcePanel = this.updatePanel(definition, this.resourcePanelContainer);
+            this.lblEnvPrefix.setVisible(resourceDefinition.isCustomizedEnvPrefixSupported());
+            this.envPrefixTextField.setVisible(resourceDefinition.isCustomizedEnvPrefixSupported());
         }
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/Resource.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/Resource.java
@@ -56,4 +56,8 @@ public interface Resource<T> {
     default boolean isValidResource() {
         return true;
     }
+
+    default String getEnvPrefix() {
+        return this.getDefinition().getDefaultEnvPrefix();
+    }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ResourceDefinition.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ResourceDefinition.java
@@ -59,6 +59,10 @@ public interface ResourceDefinition<T> {
      */
     Resource<T> read(@Nonnull final Element element);
 
+    default boolean isCustomizedEnvPrefixSupported() {
+        return true;
+    }
+
     default String getDefaultEnvPrefix() {
         return this.getName().toUpperCase().replaceAll("[^a-zA-Z0-9]", "_");
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/ResourceManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/ResourceManager.java
@@ -74,6 +74,7 @@ public class ResourceManager {
     public static List<ResourceDefinition<?>> getDefinitions() {
         return getDefinitionsMap().values().stream()
             .sorted(Comparator.comparing(ResourceDefinition::getTitle))
+            .sorted(Comparator.comparing((ResourceDefinition<?> d) -> !d.isCustomizedEnvPrefixSupported()))
             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Fix render logic in `ConnectionNode` so that common resource connection could also be rendered in project explorer
- Hide env prefix components for common resource connection in connector dialog, which will not affact
- Move common resource connection to the bottom of resource type combo in connector dialog

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
