### PR TITLE
Add no response GitHub actions

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,23 @@
+name: No Response
+
+# **What it does**: Closes issues where the original author doesn't respond to a request for information.
+# **Why we have it**: To remove the need for maintainers to remember to check back on issues periodically to see if contributors have responded.
+# **Who does it impact**: Everyone that works on docs or docs-internal.
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          daysUntilClose: 14 # Number of days of inactivity before an Issue is closed for lack of response
+          responseRequiredLabel: "need more info" # Label indicating that a response from the original author is required
+          closeComment: >
+            This issue has been closed automatically because it needs more information and has not had recent activity. Please reach out if you have or find the answers we need so that we can investigate further.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add no response GitHub actions, refers https://github.com/microsoft/vscode-maven/blob/main/.github/workflows/no-response.yml


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
