### PR TITLE
Change the order of workspace tagging

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/azuresdk/service/WorkspaceTaggingService.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-sdk-reference-book/src/main/java/com/microsoft/azure/toolkit/intellij/azuresdk/service/WorkspaceTaggingService.java
@@ -33,7 +33,7 @@ public class WorkspaceTaggingService {
         if (StringUtils.isAnyEmpty(groupId, artifactId)) {
             return null;
         }
-        return ObjectUtils.firstNonNull(getAzureDependencyTag(groupId, artifactId), getExternalDependencyTag(groupId, artifactId));
+        return ObjectUtils.firstNonNull(getExternalDependencyTag(groupId, artifactId), getAzureDependencyTag(groupId, artifactId));
     }
 
     private static String getAzureDependencyTag(final String groupId, final String artifactId) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Change the order of workspace tagging, so that we could get detail resource tag (openai/eventhubs) instead of simple client sdk


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
