### PR TITLE
Fix issues in endgame 202310

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-storage/src/main/java/com/microsoft/azure/toolkit/intellij/storage/code/Utils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-storage/src/main/java/com/microsoft/azure/toolkit/intellij/storage/code/Utils.java
@@ -37,8 +37,8 @@ public class Utils {
     }
 
     public static StorageAccount getBindingStorageAccount(@Nonnull final PsiAnnotation annotation) {
-        final PsiMethod method = Objects.requireNonNull(PsiTreeUtil.getParentOfType(annotation, PsiMethod.class));
-        final PsiAnnotation accountAnnotation = Arrays.stream(method.getAnnotations())
+        final PsiMethod method = PsiTreeUtil.getParentOfType(annotation, PsiMethod.class);
+        final PsiAnnotation accountAnnotation = Objects.isNull(method) ? null : Arrays.stream(method.getAnnotations())
                 .filter(ann -> StringUtils.equalsIgnoreCase(ann.getQualifiedName(), "com.microsoft.azure.functions.annotation.StorageAccount"))
                 .findFirst().orElse(null);
         return Stream.of(accountAnnotation, annotation).filter(Objects::nonNull)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/AbstractResourceConnectionAnnotator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/AbstractResourceConnectionAnnotator.java
@@ -110,13 +110,8 @@ public abstract class AbstractResourceConnectionAnnotator implements Annotator {
             AnnotationFixes.createSignInAnnotation(element, holder);
             return;
         }
-        final Object data = connection.getResource().getData();
-        if (!(data instanceof AzResource)) {
-            return;
-        }
-        final AzResource resource = (AzResource) data;
-        if (!resource.getFormalStatus().isConnected()) {
-            holder.newAnnotation(HighlightSeverity.WARNING, "Connected resource is not available")
+        if (!connection.isValidConnection()) {
+            holder.newAnnotation(HighlightSeverity.WARNING, String.format("Connection '%s' is not valid", connection.getEnvPrefix()))
                     .range(element.getTextRange())
                     .highlightType(ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
                     .withFix(new EditConnectionFix(connection))

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/AbstractResourceConnectionAnnotator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/AbstractResourceConnectionAnnotator.java
@@ -44,7 +44,7 @@ public abstract class AbstractResourceConnectionAnnotator implements Annotator {
         if (!(isAzureFacetEnabled(element) && shouldAccept(element))) {
             return;
         }
-        final Connection<? extends AzResource, ?> connection = getConnectionForPsiElement(element);
+        final Connection<?, ?> connection = getConnectionForPsiElement(element);
         if (Objects.isNull(connection)) {
             validateNamePattern(element, holder);
         } else {
@@ -62,7 +62,7 @@ public abstract class AbstractResourceConnectionAnnotator implements Annotator {
     protected abstract String extractVariableValue(@Nonnull final PsiElement element);
 
     @Nullable
-    protected Connection<? extends AzResource, ?> getConnectionForPsiElement(@Nonnull final PsiElement element) {
+    protected Connection<?, ?> getConnectionForPsiElement(@Nonnull final PsiElement element) {
         final Module module = ModuleUtil.findModuleForPsiElement(element);
         return Utils.getConnectionWithEnvironmentVariable(module, extractVariableValue(element));
     }
@@ -75,6 +75,7 @@ public abstract class AbstractResourceConnectionAnnotator implements Annotator {
             return;
         }
         final String text = extractVariableValue(element);
+        //noinspection ReturnOfNull
         final AzureServiceResource.Definition<?> definition = ConnectionManager.getDefinitions().stream()
                 .map(d -> d.getResourceDefinition() instanceof AzureServiceResource.Definition ?
                         (AzureServiceResource.Definition<?>) d.getResourceDefinition() : null)
@@ -95,6 +96,7 @@ public abstract class AbstractResourceConnectionAnnotator implements Annotator {
                     .map(Pair::getKey)
                     .filter(key -> StringUtils.isNotBlank(suffix) && StringUtils.endsWith(key, suffix))
                     .toList();
+            //noinspection ResultOfMethodCallIgnored
             values.stream()
                     .map(property -> new ChangeEnvironmentVariableFix(text, property, SmartPointerManager.createPointer(element)))
                     .forEach(builder::withFix);
@@ -103,13 +105,17 @@ public abstract class AbstractResourceConnectionAnnotator implements Annotator {
     }
 
     private void validateConnectionResource(@Nonnull final PsiElement element, @Nonnull final AnnotationHolder holder,
-                                            @Nonnull final Connection<? extends AzResource, ?> connection) {
+                                            @Nonnull final Connection<?, ?> connection) {
         if (!Azure.az(AzureAccount.class).isLoggedIn()) {
             AnnotationFixes.createSignInAnnotation(element, holder);
             return;
         }
-        final AzResource data = connection.getResource().getData();
-        if (Objects.isNull(data) || !data.getFormalStatus().isConnected()) {
+        final Object data = connection.getResource().getData();
+        if (!(data instanceof AzResource)) {
+            return;
+        }
+        final AzResource resource = (AzResource) data;
+        if (!resource.getFormalStatus().isConnected()) {
             holder.newAnnotation(HighlightSeverity.WARNING, "Connected resource is not available")
                     .range(element.getTextRange())
                     .highlightType(ProblemHighlightType.GENERIC_ERROR_OR_WARNING)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/AbstractResourceConnectionLineMarkerProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/AbstractResourceConnectionLineMarkerProvider.java
@@ -13,7 +13,6 @@ import com.intellij.psi.PsiElement;
 import com.microsoft.azure.toolkit.intellij.connector.AzureServiceResource;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
 import com.microsoft.azure.toolkit.intellij.connector.dotazure.AzureModule;
-import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -26,7 +25,7 @@ public abstract class AbstractResourceConnectionLineMarkerProvider implements Li
     @Nullable
     public LineMarkerInfo<?> getLineMarkerInfo(@Nonnull PsiElement element) {
         if (isAzureFacetEnabled(element) && shouldAccept(element)) {
-            final Connection<? extends AzResource, ?> connection = getConnectionForPsiElement(element);
+            final Connection<?, ?> connection = getConnectionForPsiElement(element);
             final AzureServiceResource<?> resource = Optional.ofNullable(connection)
                     .filter(c -> c.getResource() instanceof AzureServiceResource)
                     .map(c -> ((AzureServiceResource<?>) c.getResource())).orElse(null);
@@ -45,5 +44,5 @@ public abstract class AbstractResourceConnectionLineMarkerProvider implements Li
     protected abstract boolean shouldAccept(@Nonnull final PsiElement element);
 
     @Nullable
-    protected abstract Connection<? extends AzResource, ?> getConnectionForPsiElement(@Nonnull final PsiElement element);
+    protected abstract Connection<?, ?> getConnectionForPsiElement(@Nonnull final PsiElement element);
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/AnnotationFixes.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/AnnotationFixes.java
@@ -22,6 +22,7 @@ import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
 import com.microsoft.azure.toolkit.lib.common.action.Action;
 import com.microsoft.azure.toolkit.lib.common.action.AzureActionManager;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
@@ -66,7 +67,7 @@ public class AnnotationFixes {
                     final var dialog = new ConnectorDialog(project);
                     dialog.setConsumer(new ModuleResource(module.getName()));
                     dialog.setResourceDefinition(definition);
-                    Optional.ofNullable(defaultEnvPrefix).ifPresent(dialog::setFixedEnvPrefix);
+                    Optional.ofNullable(defaultEnvPrefix).filter(StringUtils::isNoneBlank).ifPresent(dialog::setEnvPrefix);
                     if (dialog.showAndGet()) {
                         callback.accept(dialog.getValue());
                     } else {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/AnnotationFixes.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/AnnotationFixes.java
@@ -25,6 +25,7 @@ import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 public class AnnotationFixes {
@@ -34,6 +35,10 @@ public class AnnotationFixes {
     };
 
     public static IntentionAction createNewConnection(ResourceDefinition<?> definition, Consumer<Connection<?, ?>> callback) {
+        return createNewConnection(definition, callback, null);
+    }
+
+    public static IntentionAction createNewConnection(ResourceDefinition<?> definition, Consumer<Connection<?, ?>> callback, String defaultEnvPrefix) {
         return new IntentionAction() {
 
             @Override
@@ -61,6 +66,7 @@ public class AnnotationFixes {
                     final var dialog = new ConnectorDialog(project);
                     dialog.setConsumer(new ModuleResource(module.getName()));
                     dialog.setResourceDefinition(definition);
+                    Optional.ofNullable(defaultEnvPrefix).ifPresent(dialog::setFixedEnvPrefix);
                     if (dialog.showAndGet()) {
                         callback.accept(dialog.getValue());
                     } else {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/ChangeEnvironmentVariableFix.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/ChangeEnvironmentVariableFix.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.toolkit.intellij.connector.code;
 import com.intellij.codeInsight.intention.choice.ChoiceVariantIntentionAction;
 import com.intellij.codeInspection.util.IntentionFamilyName;
 import com.intellij.codeInspection.util.IntentionName;
+import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
@@ -57,7 +58,9 @@ public class ChangeEnvironmentVariableFix extends ChoiceVariantIntentionAction {
         final PsiElement element = pointer.getElement();
         final TextRange textRange = element.getTextRange();
         final String newValue = StringUtils.isEmpty(origin) ? String.format("\"%s\"", value) : StringUtils.replace(element.getText(), origin, value);
-        document.replaceString(textRange.getStartOffset(), textRange.getEndOffset(), newValue);
-        PsiDocumentManager.getInstance(project).commitDocument(document);
+        WriteAction.run(() -> {
+            document.replaceString(textRange.getStartOffset(), textRange.getEndOffset(), newValue);
+            PsiDocumentManager.getInstance(project).commitDocument(document);
+        });
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/ChangeEnvironmentVariableFix.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/ChangeEnvironmentVariableFix.java
@@ -9,6 +9,7 @@ import com.intellij.codeInsight.intention.choice.ChoiceVariantIntentionAction;
 import com.intellij.codeInspection.util.IntentionFamilyName;
 import com.intellij.codeInspection.util.IntentionName;
 import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
@@ -58,7 +59,7 @@ public class ChangeEnvironmentVariableFix extends ChoiceVariantIntentionAction {
         final PsiElement element = pointer.getElement();
         final TextRange textRange = element.getTextRange();
         final String newValue = StringUtils.isEmpty(origin) ? String.format("\"%s\"", value) : StringUtils.replace(element.getText(), origin, value);
-        WriteAction.run(() -> {
+        WriteCommandAction.runWriteCommandAction(project, () -> {
             document.replaceString(textRange.getStartOffset(), textRange.getEndOffset(), newValue);
             PsiDocumentManager.getInstance(project).commitDocument(document);
         });

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/EditConnectionFix.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/EditConnectionFix.java
@@ -14,23 +14,22 @@ import com.intellij.util.IncorrectOperationException;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
 import com.microsoft.azure.toolkit.intellij.connector.ResourceConnectionActionsContributor;
 import com.microsoft.azure.toolkit.lib.common.action.AzureActionManager;
-import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import lombok.AllArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 
 @AllArgsConstructor
 public class EditConnectionFix implements IntentionAction {
-    private final Connection<? extends AzResource, ?> connection;
+    private final Connection<?, ?> connection;
 
     @Override
     public @IntentionName @NotNull String getText() {
-        return "Edit Connection";
+        return "Edit connection";
     }
 
     @Override
     public @NotNull @IntentionFamilyName String getFamilyName() {
-        return "Resource Connection Fixes";
+        return "Resource connection fixes";
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/JavaResourceConnectionLineMarkerProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/JavaResourceConnectionLineMarkerProvider.java
@@ -11,7 +11,6 @@ import com.intellij.psi.JavaTokenType;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiJavaToken;
 import com.microsoft.azure.toolkit.intellij.connector.Connection;
-import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nonnull;
@@ -25,7 +24,7 @@ public class JavaResourceConnectionLineMarkerProvider extends AbstractResourceCo
     }
 
     @Override
-    protected Connection<? extends AzResource, ?> getConnectionForPsiElement(@Nonnull PsiElement element) {
+    protected Connection<?, ?> getConnectionForPsiElement(@Nonnull PsiElement element) {
         final String value = StringUtils.strip(element.getText(), "\"");
         final Module module = ModuleUtil.findModuleForPsiElement(element);
         return Utils.getConnectionWithEnvironmentVariable(module, value);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/ResourceConnectionLineMarkerInfo.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/ResourceConnectionLineMarkerInfo.java
@@ -23,7 +23,6 @@ import com.microsoft.azure.toolkit.intellij.connector.projectexplorer.AbstractAz
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
 import com.microsoft.azure.toolkit.lib.common.action.AzureActionManager;
-import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
@@ -40,9 +39,9 @@ import static com.microsoft.azure.toolkit.ide.common.component.AzureResourceIcon
 
 public class ResourceConnectionLineMarkerInfo extends MergeableLineMarkerInfo<PsiElement> {
     @Getter
-    private final Connection<? extends AzResource, ?> connection;
+    private final Connection<?, ?> connection;
 
-    public ResourceConnectionLineMarkerInfo(@Nonnull Connection<? extends AzResource, ?> connection, final AzureServiceResource<?> resource, @Nonnull PsiElement element) {
+    public ResourceConnectionLineMarkerInfo(@Nonnull Connection<?, ?> connection, final AzureServiceResource<?> resource, @Nonnull PsiElement element) {
         super(element, element.getTextRange(), getIcon(resource), ignore -> getToolTip(resource), null, null,
             GutterIconRenderer.Alignment.LEFT, () -> connection.getResource().getName());
         this.connection = connection;
@@ -85,7 +84,7 @@ public class ResourceConnectionLineMarkerInfo extends MergeableLineMarkerInfo<Ps
     }
 
     private static class ResourceConnectionGutterIconRender extends LineMarkerInfo.LineMarkerGutterIconRenderer<PsiElement> {
-        private final Connection<? extends AzResource, ?> connection;
+        private final Connection<?, ?> connection;
         @Getter
         private AnAction clickAction;
         private AnAction editConnectionAction;
@@ -93,7 +92,7 @@ public class ResourceConnectionLineMarkerInfo extends MergeableLineMarkerInfo<Ps
         @Getter
         private ActionGroup popupMenuActions;
 
-        public ResourceConnectionGutterIconRender(@Nonnull final ResourceConnectionLineMarkerInfo info, @Nonnull final Connection<? extends AzResource, ?> connection) {
+        public ResourceConnectionGutterIconRender(@Nonnull final ResourceConnectionLineMarkerInfo info, @Nonnull final Connection<?, ?> connection) {
             super(info);
             this.connection = connection;
             this.initActions();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/ResourceConnectionLineMarkerInfo.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/ResourceConnectionLineMarkerInfo.java
@@ -50,7 +50,7 @@ public class ResourceConnectionLineMarkerInfo extends MergeableLineMarkerInfo<Ps
         final AzureIcon resourceIcon = Azure.az(AzureAccount.class).isLoggedIn() ?
                 DEFAULT_AZURE_RESOURCE_ICON_PROVIDER.getIcon(resource.getData()) : null;
         final AzureIcon definitionIcon = AzureIcon.builder().iconPath(resource.getDefinition().getIcon()).build();
-        return Stream.of(resourceIcon, definitionIcon, AzureIcons.Connector.CONNECT)
+        return Stream.of(resourceIcon, definitionIcon, AzureIcons.Common.AZURE)
                 .filter(Objects::nonNull)
                 .filter(i -> !Objects.equals(AzureIcons.Common.REFRESH_ICON, i))
                 .map(IntelliJAzureIcons::getIcon)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/ResourceConnectionLineMarkerInfo.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/ResourceConnectionLineMarkerInfo.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.editor.markup.GutterIconRenderer;
 import com.intellij.psi.PsiElement;
+import com.microsoft.azure.toolkit.ide.common.icon.AzureIcon;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.intellij.common.IntelliJAzureIcons;
 import com.microsoft.azure.toolkit.intellij.connector.AzureServiceResource;
@@ -25,6 +26,7 @@ import com.microsoft.azure.toolkit.lib.common.action.AzureActionManager;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
@@ -47,10 +49,11 @@ public class ResourceConnectionLineMarkerInfo extends MergeableLineMarkerInfo<Ps
     }
 
     private static Icon getIcon(final AzureServiceResource<?> resource) {
-        final Icon dft = IntelliJAzureIcons.getIcon(Optional.ofNullable(resource.getDefinition().getIcon()).orElseGet(AzureIcons.Common.AZURE::getIconPath));
-        return Azure.az(AzureAccount.class).isLoggedIn() ?
-            Optional.ofNullable(IntelliJAzureIcons.getIcon(DEFAULT_AZURE_RESOURCE_ICON_PROVIDER.getIcon(resource.getData()))).orElse(dft) :
-            dft;
+        final String definitionIconPath = StringUtils.firstNonBlank(resource.getDefinition().getIcon(), AzureIcons.Connector.CONNECT.getIconPath());
+        final AzureIcon icon = Azure.az(AzureAccount.class).isLoggedIn() ?
+                DEFAULT_AZURE_RESOURCE_ICON_PROVIDER.getIcon(resource.getData()) :
+                AzureIcon.builder().iconPath(definitionIconPath).build();
+        return IntelliJAzureIcons.getIcon(icon);
     }
 
     private static String getToolTip(final AzureServiceResource<?> resource) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/Utils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/Utils.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.toolkit.intellij.connector.code;
 
+import com.intellij.codeInsight.completion.InsertionContext;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
@@ -14,8 +16,11 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.microsoft.azure.toolkit.intellij.connector.*;
 import com.microsoft.azure.toolkit.intellij.connector.dotazure.AzureModule;
+import com.microsoft.azure.toolkit.intellij.connector.dotazure.ConnectionManager;
 import com.microsoft.azure.toolkit.intellij.connector.dotazure.Profile;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
@@ -24,6 +29,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -35,15 +42,29 @@ public class Utils {
         return matcher.matches() ? matcher.group(1) : origin;
     }
 
+    public static <T> List<T> getConnectedResources(@Nonnull final Module module, @Nonnull final ResourceDefinition<T> definition) {
+        //noinspection unchecked
+        return Optional.of(module).map(AzureModule::from)
+                .map(AzureModule::getDefaultProfile).map(Profile::getConnectionManager).stream()
+                .flatMap(m -> m.getConnections().stream())
+                .filter(c -> Objects.equals(c.getDefinition().getResourceDefinition(), definition))
+                .map(Connection::getResource)
+                .filter(Resource::isValidResource)
+                .map(Resource::getData)
+                .map(resource -> (T) resource)
+                .toList();
+    }
+
     @Nullable
-    public static Connection<? extends AzResource, ?> getConnectionWithEnvironmentVariable(@Nullable final Module module,
+    public static Connection<?, ?> getConnectionWithEnvironmentVariable(@Nullable final Module module,
                                                                                  @Nonnull String variable) {
         final Profile defaultProfile = Optional.ofNullable(module).map(AzureModule::from).map(AzureModule::getDefaultProfile).orElse(null);
-        if (Objects.isNull(defaultProfile)) {
+        if (Objects.isNull(defaultProfile) || !defaultProfile.isEnvFileValid()) {
             return null;
         }
-        return (Connection<? extends AzResource, ?>) defaultProfile.getConnections().stream()
-                .filter(c -> isConnectionVariable(variable, defaultProfile, c))
+        return defaultProfile.getConnections().stream()
+                .filter(c -> defaultProfile.getGeneratedEnvironmentVariables(c).stream()
+                        .anyMatch(pair -> StringUtils.equalsIgnoreCase(pair.getKey(), variable)))
                 .findAny().orElse(null);
     }
 
@@ -54,6 +75,7 @@ public class Utils {
         if (Objects.isNull(defaultProfile)) {
             return null;
         }
+        //noinspection unchecked
         return (Connection<? extends AzResource, ?>) defaultProfile.getConnections().stream()
                 .filter(c -> Objects.equals(c.getResource().getData(), resource))
                 .findAny().orElse(null);
@@ -62,6 +84,49 @@ public class Utils {
     private static boolean isConnectionVariable(String variable, Profile defaultProfile, Connection<?, ?> c) {
         return defaultProfile.getGeneratedEnvironmentVariables(c).stream()
                 .anyMatch(pair -> StringUtils.equalsIgnoreCase(pair.getKey(), variable));
+    }
+
+    @SuppressWarnings("rawtypes")
+    @AzureOperation(name = "internal/connector.create_connection_in_properties")
+    public static void createAndInsert(@Nonnull Module module, @Nonnull Resource resource,
+                                       @Nonnull InsertionContext context, @Nonnull ConnectionManager connectionManager,
+                                       @Nonnull BiConsumer<Connection, InsertionContext> insertHandler,
+                                       @Nullable Consumer<InsertionContext> cancelHandler) {
+        final Project project = context.getProject();
+        if (resource.canConnectSilently()) {
+            final Connection<?, ?> c = createSilently(module, resource, connectionManager);
+            WriteCommandAction.runWriteCommandAction(project, () -> insertHandler.accept(c, context));
+        } else {
+            AzureTaskManager.getInstance().runLater(() -> {
+                final var dialog = new ConnectorDialog(project);
+                dialog.setConsumer(new ModuleResource(module.getName()));
+                dialog.setResource(resource);
+                if (dialog.showAndGet()) {
+                    final Connection<?, ?> c = dialog.getValue();
+                    WriteCommandAction.runWriteCommandAction(project, () -> insertHandler.accept(c, context));
+                } else {
+                    WriteCommandAction.runWriteCommandAction(project, () -> Optional.ofNullable(cancelHandler).ifPresent(c -> c.accept(context)));
+                }
+            });
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @AzureOperation(name = "internal/connector.creating_connection_silently_in_properties")
+    private static Connection<?, ?> createSilently(Module module, @Nonnull Resource resource,  ConnectionManager connectionManager) {
+        final Resource consumer = ModuleResource.Definition.IJ_MODULE.define(module.getName());
+        final ConnectionDefinition<?, ?> connectionDefinition = ConnectionManager.getDefinitionOrDefault(resource.getDefinition(), consumer.getDefinition());
+        final Connection<?, ?> connection = connectionDefinition.define(resource, consumer);
+        if (resource.getDefinition().isEnvPrefixSupported()) {
+            connection.setEnvPrefix(connectionManager.getNewPrefix(resource, consumer));
+        }
+        final AzureTaskManager taskManager = AzureTaskManager.getInstance();
+        taskManager.runLater(() -> taskManager.write(() -> {
+            final Profile profile = connectionManager.getProfile().getModule().initializeWithDefaultProfileIfNot();
+            profile.createOrUpdateConnection(connection);
+            profile.save();
+        }));
+        return connection;
     }
 
     @Nullable

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/function/FunctionConnectionAnnotator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/function/FunctionConnectionAnnotator.java
@@ -10,6 +10,8 @@ import com.intellij.lang.annotation.AnnotationBuilder;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
 import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
@@ -67,8 +69,10 @@ public class FunctionConnectionAnnotator implements Annotator {
             if (Objects.isNull(editor) || Objects.isNull(connection)) {
                 return;
             }
-            editor.getDocument().replaceString(element.getTextRange().getStartOffset(), element.getTextRange().getEndOffset(), String.format("\"%s\"", connection.getEnvPrefix()));
-            PsiDocumentManager.getInstance(element.getProject()).commitDocument(editor.getDocument());
+            WriteCommandAction.runWriteCommandAction(element.getProject(), () -> {
+                editor.getDocument().replaceString(element.getTextRange().getStartOffset(), element.getTextRange().getEndOffset(), String.format("\"%s\"", connection.getEnvPrefix()));
+                PsiDocumentManager.getInstance(element.getProject()).commitDocument(editor.getDocument());
+            });
         };
         final PsiLiteralExpression parent = (PsiLiteralExpression) element.getParent();
         final String value = parent.getValue() instanceof String ? (String) parent.getValue() : StringUtils.EMPTY;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/function/FunctionConnectionAnnotator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/function/FunctionConnectionAnnotator.java
@@ -64,7 +64,7 @@ public class FunctionConnectionAnnotator implements Annotator {
     private void addCreateNewConnectionFix(@Nonnull final PsiElement element, FunctionSupported<?> definition, @Nonnull final AnnotationBuilder builder) {
         final Consumer<Connection<?, ?>> consumer = connection -> {
             final Editor editor = PsiEditorUtil.findEditor(element);
-            if (Objects.isNull(editor)) {
+            if (Objects.isNull(editor) || Objects.isNull(connection)) {
                 return;
             }
             editor.getDocument().replaceString(element.getTextRange().getStartOffset(), element.getTextRange().getEndOffset(), String.format("\"%s\"", connection.getEnvPrefix()));

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/function/FunctionConnectionAnnotator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/function/FunctionConnectionAnnotator.java
@@ -70,8 +70,10 @@ public class FunctionConnectionAnnotator implements Annotator {
             editor.getDocument().replaceString(element.getTextRange().getStartOffset(), element.getTextRange().getEndOffset(), String.format("\"%s\"", connection.getEnvPrefix()));
             PsiDocumentManager.getInstance(element.getProject()).commitDocument(editor.getDocument());
         };
+        final PsiLiteralExpression parent = (PsiLiteralExpression) element.getParent();
+        final String value = parent.getValue() instanceof String ? (String) parent.getValue() : StringUtils.EMPTY;
         //noinspection ResultOfMethodCallIgnored
-        builder.withFix(AnnotationFixes.createNewConnection(definition, consumer));
+        builder.withFix(AnnotationFixes.createNewConnection(definition, consumer, value));
     }
 
     private void addChangeEnvironmentVariableFix(PsiElement element, FunctionSupported<?> definition, AnnotationBuilder builder) {
@@ -80,12 +82,13 @@ public class FunctionConnectionAnnotator implements Annotator {
         if (Objects.isNull(profile)) {
             return;
         }
+        final PsiLiteralExpression parent = (PsiLiteralExpression) element.getParent();
+        final String value = parent.getValue() instanceof String ? (String) parent.getValue() : StringUtils.EMPTY;
         final List<Connection<?, ?>> storageConnections = profile.getConnections().stream()
                 .filter(c -> Objects.equals(c.getResource().getDefinition(), definition))
                 .toList();
-        final String originalValue = element.getText().replace("\"", "");
         final SmartPsiElementPointer<PsiElement> pointer = SmartPointerManager.createPointer(element);
         //noinspection ResultOfMethodCallIgnored
-        storageConnections.forEach(connection -> builder.withFix(new ChangeEnvironmentVariableFix(originalValue, connection.getEnvPrefix(), pointer)));
+        storageConnections.forEach(connection -> builder.withFix(new ChangeEnvironmentVariableFix(value, connection.getEnvPrefix(), pointer)));
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/function/FunctionConnectionCompletionContributor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/function/FunctionConnectionCompletionContributor.java
@@ -54,6 +54,7 @@ public class FunctionConnectionCompletionContributor extends CompletionContribut
         put("com.microsoft.azure.functions.annotation.CosmosDBTrigger", "DocumentDB");
     }};
     public static final PsiJavaElementPattern.Capture<PsiElement> STORAGE_ACCOUNT_ANNOTATION = psiElement()
+            .withParent(PsiLiteralExpression.class)
             .insideAnnotationParam("com.microsoft.azure.functions.annotation.StorageAccount");
     public static final ElementPattern CONNECTION_NAME_VALUE = PsiJavaPatterns.psiNameValuePair().withName("connection").withParent(
             PlatformPatterns.psiElement(PsiAnnotationParameterList.class).withParent(

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/spring/PropertiesResourceConnectionLineMarkerProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/spring/PropertiesResourceConnectionLineMarkerProvider.java
@@ -15,7 +15,6 @@ import com.microsoft.azure.toolkit.intellij.connector.Connection;
 import com.microsoft.azure.toolkit.intellij.connector.ResourceDefinition;
 import com.microsoft.azure.toolkit.intellij.connector.code.AbstractResourceConnectionLineMarkerProvider;
 import com.microsoft.azure.toolkit.intellij.connector.spring.SpringSupported;
-import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -36,10 +35,10 @@ public class PropertiesResourceConnectionLineMarkerProvider extends AbstractReso
     }
 
     @Override
-    protected Connection<? extends AzResource, ?> getConnectionForPsiElement(@Nonnull PsiElement element) {
+    protected Connection<?, ?> getConnectionForPsiElement(@Nonnull PsiElement element) {
         final String text = extractVariableFromSpringProperties(element.getText());
         final Module module = ModuleUtil.findModuleForPsiElement(element);
-        final Connection<? extends AzResource, ?> connection = getConnectionWithEnvironmentVariable(module, text);;
+        final Connection<?, ?> connection = getConnectionWithEnvironmentVariable(module, text);
         if (Objects.isNull(connection)) {
             return null;
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/spring/YamlKeyCompletionProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/spring/YamlKeyCompletionProvider.java
@@ -91,8 +91,10 @@ public class YamlKeyCompletionProvider extends CompletionProvider<CompletionPara
         context.commitDocument();
         YamlUtils.insertYamlKeyValue(property, null, yamlFile, context);
         final YAMLKeyValue result = YAMLUtil.getQualifiedKeyInFile(yamlFile, getKeyListForProperty(property));
-        context.getEditor().getCaretModel().moveToOffset(result.getTextRange().getEndOffset() + 1);
-        AutoPopupController.getInstance(context.getProject()).scheduleAutoPopup(context.getEditor());
+        if (Objects.nonNull(result)) {
+            context.getEditor().getCaretModel().moveToOffset(result.getTextRange().getEndOffset() + 1);
+            AutoPopupController.getInstance(context.getProject()).scheduleAutoPopup(context.getEditor());
+        }
     }
 
     private String[] getKeyListForProperty(@Nonnull final String property) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/spring/YamlResourceConnectionLineMarkerProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/connector/code/spring/YamlResourceConnectionLineMarkerProvider.java
@@ -12,7 +12,6 @@ import com.microsoft.azure.toolkit.intellij.connector.Connection;
 import com.microsoft.azure.toolkit.intellij.connector.ResourceDefinition;
 import com.microsoft.azure.toolkit.intellij.connector.code.AbstractResourceConnectionLineMarkerProvider;
 import com.microsoft.azure.toolkit.intellij.connector.spring.SpringSupported;
-import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -35,17 +34,17 @@ public class YamlResourceConnectionLineMarkerProvider extends AbstractResourceCo
     }
 
     @Override
-    protected Connection<? extends AzResource, ?> getConnectionForPsiElement(@Nonnull PsiElement element) {
+    protected Connection<?, ?> getConnectionForPsiElement(@Nonnull PsiElement element) {
         final String text = extractVariableFromSpringProperties(element.getText());
         final Module module = ModuleUtil.findModuleForPsiElement(element);
-        final Connection<? extends AzResource, ?> connection = getConnectionWithEnvironmentVariable(module, text);
+        final Connection<?, ?> connection = getConnectionWithEnvironmentVariable(module, text);
         if (Objects.isNull(connection)) {
             return null;
         }
-        final ResourceDefinition<? extends AzResource> definition = connection.getResource().getDefinition();
+        final ResourceDefinition<?> definition = connection.getResource().getDefinition();
         final String property = YAMLUtil.getConfigFullName((YAMLPlainTextImpl) element);
         final List<Pair<String, String>> variables = definition instanceof SpringSupported ?
-            ((SpringSupported<? extends AzResource>) definition).getSpringProperties(property) : Collections.emptyList();
+            ((SpringSupported<?>) definition).getSpringProperties(property) : Collections.emptyList();
         return CollectionUtils.isNotEmpty(variables) && StringUtils.equalsIgnoreCase(variables.get(0).getKey(), property) ? connection : null;
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/ConnectorDialog.java
@@ -331,6 +331,10 @@ public class ConnectorDialog extends AzureDialog<Connection<?, ?>> implements Az
         this.fixConsumerType(definition.getConsumerDefinition());
     }
 
+    public void setEnvPrefix(@Nonnull final String envPrefix) {
+        envPrefixTextField.setText(envPrefix);
+    }
+
     public void setFixedEnvPrefix(@Nonnull final String envPrefix) {
         envPrefixTextField.setText(envPrefix);
         envPrefixTextField.setEnabled(false);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/Profile.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-resource-connector-lib/src/main/java/com/microsoft/azure/toolkit/intellij/connector/dotazure/Profile.java
@@ -193,6 +193,10 @@ public class Profile {
         });
     }
 
+    public boolean isEnvFileValid() {
+        return Optional.ofNullable(dotEnvFile).map(VirtualFile::isValid).orElse(false);
+    }
+
     @Nonnull
     @SneakyThrows(IOException.class)
     @AzureOperation(value = "boundary/connector.get_generated_env_from_dotenv.resource", params = "connection.getResource().getName()")


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
fix possible npe in yaml key completition provider, AB#2116998
Fix incorrect style in function connection annotator, AB#2119776
Fix possible NPE when insert connection env prefix, AB#2119770
Fix issues during connection validation, AB#2119769
Fix line marker icon path might be null, AB#2119768
Add validation to env file during get connection with env variable, and refine the return type
Delete code completion content after cancel create new connection
Fix wrong icon for refreshing resource, AB#2120078
Fix default env prefix for new create connection in code completion, AB#2120085


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
