### PR TITLE
Refresh app settings node only if funtion is running or stopped

### DIFF
--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/appsettings/AppSettingsNode.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/appsettings/AppSettingsNode.java
@@ -37,14 +37,15 @@ public class AppSettingsNode extends AzResourceNode<AppServiceAppBase<?, ?, ?>> 
 
     @Override
     public void onEvent(AzureEvent event) {
-        super.onEvent(event);
         final String type = event.getType();
         final Object source = event.getSource();
         // workaround to update app settings when app service properties is updated
         // todo: add new event for azure resource created/updated
-        if (source instanceof AzResource && StringUtils.equals(type, "resource.status_changed.resource") &&
+        if (source instanceof AzResource app && StringUtils.equals(type, "resource.status_changed.resource") &&
                 StringUtils.equals(((AzResource) source).getId(), getValue().getId())) {
-            this.refreshChildrenLater();
+            if (app.getFormalStatus().isRunning() || app.getFormalStatus().isStopped()) {
+                this.refreshChildrenLater();
+            }
         }
     }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Refresh app settings node only if funtion is running or stopped, in case endless loop refreshing


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
