### PR TITLE
Load app settings from security storage after load run configuration from disk

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice-java/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/runner/webappconfig/WebAppConfiguration.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice-java/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/webapp/runner/webappconfig/WebAppConfiguration.java
@@ -89,6 +89,8 @@ public class WebAppConfiguration extends AzureRunConfigurationBase<IntelliJWebAp
         Optional.ofNullable(element.getChild(JAVA_VERSION))
                 .map(javaVersionElement -> javaVersionElement.getAttributeValue(JAVA_VERSION))
                 .ifPresent(webAppSettingModel::setWebAppJavaVersion);
+        Optional.ofNullable(this.getAppSettingsKey())
+                .ifPresent(key -> webAppSettingModel.getConfig().setAppSettings(FunctionUtils.loadAppSettingsFromSecurityStorage(getAppSettingsKey())));
     }
 
     @Override


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Load app settings from security storage after load run configuration from disk, fixes #8206


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
