### PR TITLE
Register a handler for the swap deployment slot action

### DIFF
--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/function/FunctionAppActionsContributor.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/function/FunctionAppActionsContributor.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.toolkit.ide.appservice.function;
 
+import com.azure.resourcemanager.appservice.models.FunctionDeploymentSlot;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.toolkit.ide.appservice.AppServiceActionsContributor;
 import com.microsoft.azure.toolkit.ide.appservice.function.node.TriggerFunctionInBrowserAction;
@@ -34,6 +35,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
 
 import static com.microsoft.azure.toolkit.ide.common.action.ResourceCommonActionsContributor.OPEN_AZURE_SETTINGS;
 
@@ -237,6 +240,19 @@ public class FunctionAppActionsContributor implements IActionsContributor {
             .visibleWhen(s -> s instanceof FunctionAppBase<?, ?, ?> && !(s instanceof FunctionApp functionApp && (StringUtils.isNotBlank(functionApp.getEnvironmentId()))))
             .enableWhen(s -> s.getFormalStatus().isRunning())
             .register(am);
+    }
+
+    @Override
+    public void registerHandlers(AzureActionManager am) {
+        final BiPredicate<FunctionAppDeploymentSlot, Object> swapDeploymentSlotCondition = (r, e) -> r != null &&
+                StringUtils.equals(r.getStatus(), AzResource.Status.RUNNING);
+        final BiConsumer<FunctionAppDeploymentSlot, Object> swapDeploymentSlotHandler = (c, e) -> {
+            final FunctionDeploymentSlot deploymentSLot = c.getRemote();
+            if (deploymentSLot != null) {
+                deploymentSLot.swap("production");
+            }
+        };
+        am.registerHandler(SWAP_DEPLOYMENT_SLOT, swapDeploymentSlotCondition, swapDeploymentSlotHandler);
     }
 
     @Override

--- a/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/webapp/WebAppActionsContributor.java
+++ b/Utils/azure-toolkit-ide-libs/azure-toolkit-ide-appservice-lib/src/main/java/com/microsoft/azure/toolkit/ide/appservice/webapp/WebAppActionsContributor.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.toolkit.ide.appservice.webapp;
 
+import com.azure.resourcemanager.appservice.models.DeploymentSlot;
 import com.microsoft.azure.toolkit.ide.appservice.AppServiceActionsContributor;
 import com.microsoft.azure.toolkit.ide.common.IActionsContributor;
 import com.microsoft.azure.toolkit.ide.common.action.ResourceCommonActionsContributor;
@@ -127,6 +128,16 @@ public class WebAppActionsContributor implements IActionsContributor {
             StringUtils.equals(r.getStatus(), AzResource.Status.RUNNING);
         final BiConsumer<AzResource, Object> restartHandler = (c, e) -> ((AppServiceAppBase<?, ?, ?>) c).restart();
         am.registerHandler(ResourceCommonActionsContributor.RESTART, restartCondition, restartHandler);
+
+        final BiPredicate<WebAppDeploymentSlot, Object> swapDeploymentSlotCondition = (r, e) -> r != null &&
+                StringUtils.equals(r.getStatus(), AzResource.Status.RUNNING);
+        final BiConsumer<WebAppDeploymentSlot, Object> swapDeploymentSlotHandler = (c, e) -> {
+            final DeploymentSlot deploymentSLot = c.getRemote();
+            if (deploymentSLot != null) {
+                deploymentSLot.swap("production");
+            }
+        };
+        am.registerHandler(SWAP_DEPLOYMENT_SLOT, swapDeploymentSlotCondition, swapDeploymentSlotHandler);
     }
 
     @Override


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The Swap deployment slot action is disabled because there is no handler for it, so I registered a handler.


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
No

Any other comments?
-------------------
No

Has this been tested?
---------------------------
- [x] Tested
