### PR TITLE
Upgrade intellij gradle plugin to stable version

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle.kts
@@ -1,5 +1,6 @@
 import io.freefair.gradle.plugins.aspectj.AjcAction
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.net.URL
@@ -281,9 +282,12 @@ tasks {
         jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005")
     }
 
-//    val runLocalIde by registering(CustomRunIdeTask::class) {
-//        localPath = file("C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2024.1")
-//    }
+    // refers https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-testing-extension.html#intellijPlatformTesting
+    val testIde by intellijPlatformTesting.runIde.registering {
+        type = IntelliJPlatformType.IntellijIdeaCommunity
+        version = "2024.2"
+    }
+
     // Configure UI tests plugin
     // Read more: https://github.com/JetBrains/intellij-ui-test-robot
     //    testIdeUi {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle/libs.versions.toml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 # plugins
 kotlin = "1.9.24"
 changelog = "2.2.0"
-intellijPlatform = "2.0.0-beta7"
+intellijPlatform = "2.1.0"
 detekt = "1.23.6"
 ktlint = "12.1.1"
 #gradleIntelliJPlugin = "1.17.3"


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Upgrade intellij gradle plugin to 2.1.0
- Use intellijPlatformTesting extension to run/debug toolkits with community version


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
