### PR TITLE
Fix RedisCacheMock implementation

### DIFF
--- a/Utils/azure-toolkit-ide-hdinsight-libs/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/rediscache/RedisCacheMock.java
+++ b/Utils/azure-toolkit-ide-hdinsight-libs/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/rediscache/RedisCacheMock.java
@@ -19,7 +19,7 @@ import com.azure.resourcemanager.resources.fluentcore.arm.models.PrivateEndpoint
 import com.azure.resourcemanager.resources.fluentcore.arm.models.PrivateLinkResource;
 import reactor.core.publisher.Mono;
 
-public class RedisCacheMock implements RedisCache{
+public class RedisCacheMock implements RedisCache {
 
     private static final String MOCK_STRING = "test";
 
@@ -163,6 +163,11 @@ public class RedisCacheMock implements RedisCache{
     @Override
     public RedisAccessKeys regenerateKey(RedisKeyType keyType) {
         return new RedisAccessKeysMock();
+    }
+
+    @Override
+    public PublicNetworkAccess publicNetworkAccess() {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes an issue in `RedisCacheMock `which implements `RedisCache` interface. The `RedisCache` interface introduced a breaking change by adding new interface methods and not making them `default`. This requires all implementations to add this new method as well.


Does this close any currently open issues?
------------------------------------------
N/A


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<code>[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.13.0:testCompile (default-testCompile) on project azuretools-core: Compilation failure
[ERROR] **/azure-tools-for-java/Utils/azure-toolkit-ide-hdinsight-libs/azuretools-core/test/com/microsoft/azuretools/core/mvp/model/rediscache/RedisCacheMock.java:[22,8] com.microsoft.azuretools.core.mvp.model.rediscache.RedisCacheMock is not abstract and does not override abstract method publicNetworkAccess() in com.azure.resourcemanager.redis.models.RedisCache
</code>




Has this been tested?
---------------------------
- [x] Tested
