### PR TITLE
Fix azd install cancel button

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/TerminalUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/TerminalUtils.java
@@ -49,6 +49,16 @@ public class TerminalUtils {
         }, AzureTask.Modality.ANY);
     }
 
+    public static void executeInTerminal(TerminalWidget terminalWidget, String command) {
+        AzureTaskManager.getInstance().runLater(() -> {
+            AzureTaskManager.getInstance().runInBackground(OperationBundle.description("boundary/common.execute_in_terminal.command", command), () -> {
+                terminalWidget.getTtyConnectorAccessor().executeWithTtyConnector((connector) -> {
+                    terminalWidget.sendCommandToExecute(command);
+                });
+            });
+        }, AzureTask.Modality.ANY);
+    }
+
     @Nonnull
     public static TerminalWidget createTerminalWidget(@Nonnull Project project, @Nullable Path workingDir, String terminalTabTitle) {
         final TerminalToolWindowManager manager = TerminalToolWindowManager.getInstance(project);
@@ -57,7 +67,7 @@ public class TerminalUtils {
     }
 
     @Nonnull
-    private static TerminalWidget getOrCreateTerminalWidget(@Nonnull Project project, @Nullable Path workingDir, String terminalTabTitle) {
+    public static TerminalWidget getOrCreateTerminalWidget(@Nonnull Project project, @Nullable Path workingDir, String terminalTabTitle) {
         final TerminalToolWindowManager manager = TerminalToolWindowManager.getInstance(project);
         final String workingDirectory = Optional.ofNullable(workingDir).map(Path::toString).orElse(null);
         return manager.getTerminalWidgets().stream()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdNode.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdNode.java
@@ -55,13 +55,10 @@ public final class AzdNode extends Node<String> {
                 final String command;
                 if (System.getProperties().getProperty("os.name").toLowerCase().contains("windows")) {
                     command = "winget install microsoft.azd";
-                    TerminalUtils.executeInTerminal(project, "winget install microsoft.azd", "azd");
                 } else if (System.getProperties().getProperty("os.name").toLowerCase().contains("linux")) {
                     command = "curl -fsSL https://aka.ms/install-azd.sh | bash";
-                    TerminalUtils.executeInTerminal(project, "curl -fsSL https://aka.ms/install-azd.sh | bash", "azd");
                 } else {
                     command = "brew tap azure/azd && brew install azd";
-                    TerminalUtils.executeInTerminal(project, "brew tap azure/azd && brew install azd", "azd");
                 }
                 final ConfirmAndRunDialog installDialog = new ConfirmAndRunDialog(project, "Install azd", "Do you want to install Azure Developer CLI (azd)?", command);
                 installDialog.setOkButtonText("Install");

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/ConfirmAndRunDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/ConfirmAndRunDialog.java
@@ -2,6 +2,7 @@ package com.microsoft.azure.toolkit.intellij.explorer.azd;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.terminal.ui.TerminalWidget;
 import com.microsoft.azure.toolkit.intellij.common.TerminalUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -53,7 +54,8 @@ public class ConfirmAndRunDialog extends DialogWrapper {
     protected void doOKAction() {
         AzdUtils.logTelemetryEvent("azd-" + eventName + "-ok");
         super.doOKAction();
-        TerminalUtils.executeInTerminal(project, command, "azd");
+        final TerminalWidget azdTerminal = TerminalUtils.getOrCreateTerminalWidget(project, null, "azd");
+        TerminalUtils.executeInTerminal(azdTerminal, command);
     }
 
     @Override


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request introduces enhancements to terminal command execution within the Azure Toolkit for IntelliJ plugin, focusing on improving functionality and code clarity. The key updates include adding a new method to execute commands in a terminal widget, modifying access levels for terminal utility methods, and refactoring existing code to use the new functionality.

### Enhancements to terminal command execution:

* **New method for terminal command execution**:
  - Added `executeInTerminal(TerminalWidget terminalWidget, String command)` in `TerminalUtils` to allow sending commands directly to a terminal widget. This method runs commands asynchronously and ensures proper handling of the terminal's TTY connector.

* **Refactored terminal command execution in `ConfirmAndRunDialog`**:
  - Updated `doOKAction` in `ConfirmAndRunDialog` to use the new `executeInTerminal` method. It now retrieves or creates a terminal widget using `getOrCreateTerminalWidget` before executing commands, improving code clarity and reusability.

### Code accessibility and refactoring:

* **Modified access level of `getOrCreateTerminalWidget`**:
  - Changed `getOrCreateTerminalWidget` in `TerminalUtils` from `private` to `public`, enabling its use in other classes such as `ConfirmAndRunDialog`.

* **Removed redundant terminal execution calls**:
  - Eliminated direct calls to `executeInTerminal` with project-based parameters in `AzdNode`, consolidating terminal command execution logic into the new method.

* **Updated imports for terminal widget support**:
  - Added `TerminalWidget` import in `ConfirmAndRunDialog` to support the new terminal execution logic.
…


Does this close any currently open issues?
------------------------------------------
None


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
None

Has this been tested?
---------------------------
- [x] Tested
