### PR TITLE
Update MacOS to use absolute path

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/TerminalUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/TerminalUtils.java
@@ -79,9 +79,12 @@ public class TerminalUtils {
     }
 
     @Nonnull
-    public static TerminalWidget getTerminalWidget(@Nonnull Project project, @Nullable Path workingDir, String terminalTabTitle) {
+    public static synchronized TerminalWidget getTerminalWidget(@Nonnull Project project, @Nullable Path workingDir, String terminalTabTitle) {
         final TerminalToolWindowManager manager = TerminalToolWindowManager.getInstance(project);
         final String workingDirectory = Optional.ofNullable(workingDir).map(Path::toString).orElse(null);
+        if (manager.getToolWindow() != null) {
+            manager.getToolWindow().show();
+        }
         return manager.getTerminalWidgets().stream()
                 .filter(widget -> StringUtils.isBlank(terminalTabTitle) ||
                         StringUtils.equals(widget.getTerminalTitle().buildTitle(), terminalTabTitle))

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdNode.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdNode.java
@@ -36,7 +36,7 @@ public final class AzdNode extends Node<String> {
 
     private static final String WIN_AZD_INSTALL_COMMAND = "winget install microsoft.azd";
     private static final String LINUX_AZD_INSTALL_COMMAND = "set -o pipefail && curl -fsSL https://aka.ms/install-azd.sh | bash";
-    private static final String MAC_AZD_INSTALL_COMMAND = "brew tap azure/azd && brew install azd";
+    private static final String MAC_AZD_INSTALL_COMMAND = "source ~/.zshrc && brew tap azure/azd && brew install azd";
 
     private final Project project;
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdNode.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdNode.java
@@ -198,8 +198,10 @@ public final class AzdNode extends Node<String> {
             final String os = System.getProperty("os.name").toLowerCase();
             if (SystemUtils.IS_OS_WINDOWS) {
                 processBuilder.command("cmd", "/c", command); // Windows
+            } else if (SystemUtils.IS_OS_MAC) {
+                processBuilder.command("zsh", "-c", command); // Mac
             } else {
-                processBuilder.command("bash", "-c", command); // Linux/Unix
+                processBuilder.command("bash", "-c", command); // Linux
             }
 
             Process process = processBuilder.start();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdNode.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdNode.java
@@ -15,11 +15,11 @@ import com.intellij.openapi.project.Project;
 import com.microsoft.azure.toolkit.ide.common.component.Node;
 import com.microsoft.azure.toolkit.ide.common.icon.AzureIcons;
 import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
-import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -36,7 +36,8 @@ public final class AzdNode extends Node<String> {
 
     private static final String WIN_AZD_INSTALL_COMMAND = "winget install microsoft.azd";
     private static final String LINUX_AZD_INSTALL_COMMAND = "set -o pipefail && curl -fsSL https://aka.ms/install-azd.sh | bash";
-    private static final String MAC_AZD_INSTALL_COMMAND = "source ~/.zshrc && brew tap azure/azd && brew install azd";
+    private static final String BREW_PATH = getBrewPath();
+    private static final String MAC_AZD_INSTALL_COMMAND = "source ~/.zshrc && " + BREW_PATH + " tap azure/azd && " + BREW_PATH + " install azd";
 
     private final Project project;
 
@@ -204,15 +205,15 @@ public final class AzdNode extends Node<String> {
                 processBuilder.command("bash", "-c", command); // Linux
             }
 
-            Process process = processBuilder.start();
+            final Process process = processBuilder.start();
 
             // Read the command output
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                String output = reader.lines().collect(Collectors.joining("<br>"));
-                int exitCode = process.waitFor();
+            try (final BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                final String output = reader.lines().collect(Collectors.joining("<br>"));
+                final int exitCode = process.waitFor();
                 if (exitCode != 0) {
-                    try (BufferedReader errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-                        String error = errorReader.lines().collect(Collectors.joining("<br>"));
+                    try (final BufferedReader errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+                        final String error = errorReader.lines().collect(Collectors.joining("<br>"));
                         if (onError != null) {
                             onError.accept(error);
                         }
@@ -221,8 +222,25 @@ public final class AzdNode extends Node<String> {
                 }
                 return output;
             }
-        } catch (Exception e) {
+        } catch (final Exception e) {
             return null;
         }
+    }
+
+    private static String getBrewPath() {
+        // Try common brew locations
+        final String[] possiblePaths = {
+                "/opt/homebrew/bin/brew",  // Apple Silicon
+                "/usr/local/bin/brew"      // Intel Mac
+        };
+
+        for (final String path : possiblePaths) {
+            if (new File(path).exists()) {
+                return path;
+            }
+        }
+
+        // Fallback to PATH lookup
+        return "brew";
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdUtils.java
@@ -9,13 +9,11 @@ import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemeter;
 import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetry;
-import org.apache.commons.lang3.SystemUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 import static com.microsoft.azure.toolkit.intellij.common.TerminalUtils.getTerminalWidget;
 
@@ -40,9 +38,6 @@ public final class AzdUtils {
     }
 
     public static void executeInTerminal(Project project, String command) {
-        if (SystemUtils.IS_OS_WINDOWS) {
-            command = command + " \r\n";
-        }
         executeInExistingTerminal(project, command, null, "azd");
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-service-explorer/src/main/java/com/microsoft/azure/toolkit/intellij/explorer/azd/AzdUtils.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemeter;
 import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetry;
+import org.apache.commons.lang3.SystemUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -39,6 +40,9 @@ public final class AzdUtils {
     }
 
     public static void executeInTerminal(Project project, String command) {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            command = command + " \r\n";
+        }
         executeInExistingTerminal(project, command, null, "azd");
     }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This pull request introduces improvements for platform-specific command execution and robustness in the Azure Toolkit for IntelliJ plugin, especially for macOS and terminal integration. The main changes focus on correctly locating and using Homebrew on macOS, refining how commands are executed in background tasks, and ensuring terminal widgets are managed safely.

**Platform-specific command execution improvements:**

* Added logic to detect and use the correct Homebrew path on macOS (`getBrewPath`), updating the `MAC_AZD_INSTALL_COMMAND` to source `.zshrc` and use the detected path for more reliable installation. [[1]](diffhunk://#diff-4f468ed4f4be01bcde3f76b59348b77f05cc90210552c04f8b3b72f0b59db42dL39-R40) [[2]](diffhunk://#diff-4f468ed4f4be01bcde3f76b59348b77f05cc90210552c04f8b3b72f0b59db42dL222-R245)
* Updated background task execution to run commands using `zsh` on macOS, improving compatibility with user environments.

**Terminal integration and robustness:**

* Made `getTerminalWidget` method synchronized and ensured the terminal tool window is shown before returning the widget, improving thread safety and user experience.
* Appended a newline to commands executed in the terminal on Windows to ensure proper execution.

**Minor improvements:**

* Added missing imports and improved variable finality for better code clarity and reliability. [[1]](diffhunk://#diff-4f468ed4f4be01bcde3f76b59348b77f05cc90210552c04f8b3b72f0b59db42dL18-R22) [[2]](diffhunk://#diff-4f468ed4f4be01bcde3f76b59348b77f05cc90210552c04f8b3b72f0b59db42dR202-R216) [[3]](diffhunk://#diff-60097def084dfd960d65b6261bea59c7d45384ebe284f2322ba36c199b6a77e8R12)


Does this close any currently open issues?
------------------------------------------
None

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
None

Any other comments?
-------------------
None

Has this been tested?
---------------------------
- [x] Tested
