### PR TITLE
Remove maven.model dependency from 2025.2

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.jetbrains.idea.maven")
-        bundledPlugin("org.jetbrains.idea.maven.model")
         bundledPlugin("com.intellij.gradle")
     }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
`org.jetbrains.idea.maven.model` dependency is not available in 2025.2. Removing it from `develop.next` branch.


Does this close any currently open issues?
------------------------------------------
N/A

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
None

Has this been tested?
---------------------------
- [x] Tested
