### PR TITLE
Fix maven report background thread exception and update logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,8 +119,9 @@ All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in t
   - [3.0.6](#306)
 
 ## 3.96.0
+- Configure Azure MCP server for GitHub Copilot
 - Integrate azd to Azure Explorer 
-- Fix some known issues.
+- Fix some known issues
 
 ## 3.95.0
 - Update function cdn uri

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/AzureMcpPackageManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/AzureMcpPackageManager.java
@@ -77,7 +77,8 @@ public class AzureMcpPackageManager {
                 }
             }
         } catch (final IOException e) {
-            System.err.println("Error reading Azure MCP Server version: " + e.getMessage());
+            log.error("Error getting Azure MCP executable: " + e.getMessage());
+            AzureMcpUtils.logErrorTelemetryEvent("azmcp-get-executable", e);
         }
         return null;
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/AzureMcpUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/AzureMcpUtils.java
@@ -1,0 +1,41 @@
+package com.microsoft.azure.toolkit.intellij.azuremcp;
+
+import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
+import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemeter;
+import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetry;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.util.Map;
+
+public final class AzureMcpUtils {
+
+    private static final String GHCP_MCP_INITIALIZER = "GHCP_MCP_INITIALIZER";
+
+    private AzureMcpUtils() {
+    }
+
+    public static void logTelemetryEvent(String eventName) {
+        Map<String, String> properties = Map.of(
+                AzureTelemeter.OP_NAME, eventName,
+                AzureTelemeter.OP_PARENT_ID, GHCP_MCP_INITIALIZER,
+                AzureTelemeter.OPERATION_NAME, eventName, // what's the difference between OP_NAME and OPERATION_NAME?
+                AzureTelemeter.SERVICE_NAME, GHCP_MCP_INITIALIZER
+        );
+        AzureTaskManager.getInstance().runLater(() -> {
+            AzureTelemeter.log(AzureTelemetry.Type.INFO, properties);
+        });
+    }
+
+    public static void logErrorTelemetryEvent(String eventName, Exception ex) {
+        Map<String, String> properties = Map.of(
+                AzureTelemeter.OP_NAME, eventName,
+                AzureTelemeter.OP_PARENT_ID, GHCP_MCP_INITIALIZER,
+                AzureTelemeter.OPERATION_NAME, eventName, // what's the difference between OP_NAME and OPERATION_NAME?
+                AzureTelemeter.SERVICE_NAME, GHCP_MCP_INITIALIZER,
+                AzureTelemeter.ERROR_STACKTRACE, ExceptionUtils.getStackTrace(ex)
+        );
+        AzureTaskManager.getInstance().runLater(() -> {
+            AzureTelemeter.log(AzureTelemetry.Type.ERROR, properties);
+        });
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/GithubCopilotMcpInitializer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/GithubCopilotMcpInitializer.java
@@ -13,13 +13,9 @@ import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.startup.ProjectActivity;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.registry.Registry;
-import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
-import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemeter;
-import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetry;
 import kotlin.Unit;
 import kotlin.coroutines.Continuation;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,6 +26,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.microsoft.azure.toolkit.intellij.azuremcp.AzureMcpUtils.logErrorTelemetryEvent;
+import static com.microsoft.azure.toolkit.intellij.azuremcp.AzureMcpUtils.logTelemetryEvent;
+
 @Slf4j
 public class GithubCopilotMcpInitializer implements ProjectActivity, DumbAware, ProjectManagerListener {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
@@ -39,7 +38,6 @@ public class GithubCopilotMcpInitializer implements ProjectActivity, DumbAware, 
             .enable(SerializationFeature.INDENT_OUTPUT);
 
     private static final ComparableVersion LOWEST_SUPPORTED_COPILOT_VERSION = new ComparableVersion("1.5.50");
-    private static final String GHCP_MCP_INITIALIZER = "GitHubCopilotMcpInitializer";
     private static final String COPILOT_PLUGIN_ID = "com.github.copilot";
     private final AzureMcpPackageManager azureMcpPackageManager;
 
@@ -71,7 +69,7 @@ public class GithubCopilotMcpInitializer implements ProjectActivity, DumbAware, 
     private boolean isCopilotMcpSupported() {
         // Get all installed plugins
         final IdeaPluginDescriptor[] installedPlugins = PluginManagerCore.getPlugins();
-        boolean copilotMcpSupported = Arrays.stream(installedPlugins)
+        final boolean copilotMcpSupported = Arrays.stream(installedPlugins)
                 .anyMatch(plugin -> {
                     final boolean copilotPluginInstalled = COPILOT_PLUGIN_ID.equals(plugin.getPluginId().getIdString());
                     return copilotPluginInstalled && isMcpSupported(plugin.getVersion());
@@ -155,30 +153,5 @@ public class GithubCopilotMcpInitializer implements ProjectActivity, DumbAware, 
             configPath = new File(userHome, ".config/github-copilot/intellij");
         }
         return configPath;
-    }
-
-    public static void logTelemetryEvent(String eventName) {
-        Map<String, String> properties = Map.of(
-                AzureTelemeter.OP_NAME, eventName,
-                AzureTelemeter.OP_PARENT_ID, GHCP_MCP_INITIALIZER,
-                AzureTelemeter.OPERATION_NAME, eventName, // what's the difference between OP_NAME and OPERATION_NAME?
-                AzureTelemeter.SERVICE_NAME, GHCP_MCP_INITIALIZER
-        );
-        AzureTaskManager.getInstance().runLater(() -> {
-            AzureTelemeter.log(AzureTelemetry.Type.INFO, properties);
-        });
-    }
-
-    public static void logErrorTelemetryEvent(String eventName, Exception ex) {
-        Map<String, String> properties = Map.of(
-                AzureTelemeter.OP_NAME, eventName,
-                AzureTelemeter.OP_PARENT_ID, GHCP_MCP_INITIALIZER,
-                AzureTelemeter.OPERATION_NAME, eventName, // what's the difference between OP_NAME and OPERATION_NAME?
-                AzureTelemeter.SERVICE_NAME, GHCP_MCP_INITIALIZER,
-                AzureTelemeter.ERROR_STACKTRACE, ExceptionUtils.getStackTrace(ex)
-        );
-        AzureTaskManager.getInstance().runLater(() -> {
-            AzureTelemeter.log(AzureTelemetry.Type.ERROR, properties);
-        });
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/GithubCopilotMcpInitializer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/GithubCopilotMcpInitializer.java
@@ -113,7 +113,10 @@ public class GithubCopilotMcpInitializer implements ProjectActivity, DumbAware, 
         final McpServer azureMcpServer = new McpServer();
         azureMcpServer.setCommand(azMcpExe.getAbsolutePath());
         azureMcpServer.setArgs(Arrays.asList("server", "start"));
-        servers.put("Azure MCP Server", azureMcpServer);
+        if (servers.containsKey("Azure MCP Server")) {
+            servers.remove("Azure MCP Server");
+        }
+        servers.put("Azure MCP Server IntelliJ", azureMcpServer);
         Files.writeString(mcpConfigPath, OBJECT_MAPPER.writeValueAsString(mcpConfig));
         logTelemetryEvent("azmcp-copilot-initialization-success");
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
@@ -83,7 +83,8 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
     @Nullable
     @Override
     public Object execute(@Nonnull Project project, @Nonnull Continuation<? super Unit> continuation) {
-        scheduledExecutor.schedule(() -> generateReport(project), INITIAL_DELAY_IN_MINUTES, TimeUnit.MINUTES);
+        scheduledExecutor.schedule(() -> ApplicationManager.getApplication().runReadAction(() -> generateReport(project)),
+                INITIAL_DELAY_IN_MINUTES, TimeUnit.MINUTES);
         return null;
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/component/TreeUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/component/TreeUtils.java
@@ -126,14 +126,17 @@ public class TreeUtils {
         final MouseAdapter popupHandler = new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                final Object n = tree.getLastSelectedPathComponent();
-                if (n instanceof Tree.TreeNode) {
-                    final Tree.TreeNode<?> node = (Tree.TreeNode<?>) n;
-                    clickNode(e, node);
-                } else if (n instanceof Tree.LoadMoreNode && SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2) {
-                    ((Tree.LoadMoreNode) n).load();
+                final TreePath pathForLocation = tree.getPathForLocation(e.getX(), e.getY());
+                if (pathForLocation != null) {
+                    final Object n = pathForLocation.getLastPathComponent();
+                    if (n instanceof Tree.TreeNode) {
+                        final Tree.TreeNode<?> node = (Tree.TreeNode<?>) n;
+                        clickNode(e, node);
+                    } else if (n instanceof Tree.LoadMoreNode && SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2) {
+                        ((Tree.LoadMoreNode) n).load();
+                    }
+                    super.mouseClicked(e);
                 }
-                super.mouseClicked(e);
             }
 
             @AzureOperation(name = "user/$resource.click_node.resource", params = {"node.inner.getValue()"}, source = "node.inner.getValue()")


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request refactors telemetry logging for the Azure MCP IntelliJ plugin by extracting utility methods into a new helper class and updating error handling to improve consistency and maintainability. Additionally, it addresses thread safety for scheduled tasks in the Maven project report generator.

### Telemetry and Error Logging Refactor

* Introduced a new utility class `AzureMcpUtils` to centralize telemetry event logging, replacing duplicated methods and improving code organization. (`PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/AzureMcpUtils.java`)
* Updated references in `GithubCopilotMcpInitializer` to use the new utility class for telemetry logging, removing redundant code and static constants. (`GithubCopilotMcpInitializer.java`) [[1]](diffhunk://#diff-ebcf802d733de60670ba53e8836bd9ad0c37ca08f2c9586a9e9b43d3b13490c8L16-L22) [[2]](diffhunk://#diff-ebcf802d733de60670ba53e8836bd9ad0c37ca08f2c9586a9e9b43d3b13490c8R29-R31) [[3]](diffhunk://#diff-ebcf802d733de60670ba53e8836bd9ad0c37ca08f2c9586a9e9b43d3b13490c8L42) [[4]](diffhunk://#diff-ebcf802d733de60670ba53e8836bd9ad0c37ca08f2c9586a9e9b43d3b13490c8L159-L183)
* Enhanced error handling in `AzureMcpPackageManager` by logging errors via the new utility and telemetry system instead of printing to standard error. (`AzureMcpPackageManager.java`)

### Thread Safety and Scheduling

* Ensured that scheduled report generation in `MavenProjectReportGenerator` runs inside a read action for thread safety when accessing project data. (`MavenProjectReportGenerator.java`)

### Minor Improvements

* Minor variable renaming for clarity in `isCopilotMcpSupported` method. (`GithubCopilotMcpInitializer.java`)

Does this close any currently open issues?
------------------------------------------
None

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
None

Any other comments?
-------------------
No.

Has this been tested?
---------------------------
- [x] Tested



