### PR TITLE
Update the Azure MCP server name from releases list

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/AzureMcpPackageManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/AzureMcpPackageManager.java
@@ -3,9 +3,6 @@ package com.microsoft.azure.toolkit.intellij.azuremcp;
 import com.intellij.openapi.application.PathManager;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.NotNull;
@@ -40,7 +37,7 @@ public class AzureMcpPackageManager {
 
                 final Optional<GithubAsset> githubAsset = latestRelease.getAssets()
                         .stream()
-                        .filter(asset -> asset.getName().startsWith("azure-mcp-" + platform))
+                        .filter(asset -> asset.getName().startsWith("Azure.Mcp.Server-" + platform))
                         .findFirst();
 
                 if (githubAsset.isPresent()) {
@@ -58,13 +55,13 @@ public class AzureMcpPackageManager {
                         final File azMcpExe = new File(executablePath);
                         if (!azMcpExe.exists()) {
                             Files.writeString(versionFile, tagName, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
-                            final File azMcpTgz = new File(azMcpDir, "azmcp_" + tagName + ".tgz");
-                            log.info("Downloading Azure MCP Server to: " + azMcpTgz.getAbsolutePath());
-                            final boolean downloaded = gitHubClient.downloadToFile(asset.getBrowserDownloadUrl(), azMcpTgz);
-                            if (downloaded && digestMatches(azMcpTgz, asset.getDigest())) {
+                            final File azMcpZip = new File(azMcpDir, "azmcp_" + tagName + ".zip");
+                            log.info("Downloading Azure MCP Server to: " + azMcpZip.getAbsolutePath());
+                            final boolean downloaded = gitHubClient.downloadToFile(asset.getBrowserDownloadUrl(), azMcpZip);
+                            if (downloaded && digestMatches(azMcpZip, asset.getDigest())) {
                                 log.info("Downloaded Azure MCP Server successfully in " + (System.currentTimeMillis() - startTime) + " ms");
                                 log.info("Extracting Azure MCP Server to: " + extractedDir.getAbsolutePath());
-                                extractTarGz(azMcpTgz, extractedDir);
+                                extractZip(azMcpZip, extractedDir);
                                 log.info("Azure MCP Server extracted successfully to: " + extractedDir.getAbsolutePath());
                             }
                         }
@@ -83,11 +80,11 @@ public class AzureMcpPackageManager {
         return null;
     }
 
-    private boolean digestMatches(File azMcpTgz, String expectedDigest) {
+    private boolean digestMatches(File azMcpZip, String expectedDigest) {
         try {
             // GitHub releases API computes the SHA-256 digest of the file contents.
             // https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/
-            final String downloadFileDigest = DigestUtils.sha256Hex(new FileInputStream(azMcpTgz));
+            final String downloadFileDigest = DigestUtils.sha256Hex(new FileInputStream(azMcpZip));
             return StringUtils.equalsIgnoreCase("sha256:" + downloadFileDigest, expectedDigest);
         } catch (final Exception e) {
             log.error("Failed to calculate file digest", e);
@@ -134,28 +131,28 @@ public class AzureMcpPackageManager {
     }
 
     private @NotNull String getExecutableRelativePath() {
-        String executablePath = "/package/dist/azmcp";
+        String executablePath = "/azmcp";
         if (SystemUtils.IS_OS_WINDOWS) {
             executablePath += ".exe";
         }
         return executablePath;
     }
 
-    private void extractTarGz(File tarGzFile, File destDir) throws IOException {
-        try (final TarArchiveInputStream tarIn = new TarArchiveInputStream(
-                new GzipCompressorInputStream(
-                        new FileInputStream(tarGzFile)))) {
-            TarArchiveEntry entry;
-            while ((entry = tarIn.getNextTarEntry()) != null) {
-                final File outputFile = new File(destDir, entry.getName());
-                if (entry.isDirectory()) {
-                    if (!outputFile.exists()) {
-                        outputFile.mkdirs();
-                    }
+    private void extractZip(File zipFile, File destDir) throws IOException {
+        try (final java.util.zip.ZipInputStream zis = new java.util.zip.ZipInputStream(new FileInputStream(zipFile))) {
+            java.util.zip.ZipEntry zipEntry;
+            while ((zipEntry = zis.getNextEntry()) != null) {
+                final File outputFile = new File(destDir, zipEntry.getName());
+                if (zipEntry.isDirectory()) {
+                    if (!outputFile.exists()) outputFile.mkdirs();
                 } else {
-                    outputFile.getParentFile().mkdirs();
+                    if (!outputFile.getParentFile().exists()) outputFile.getParentFile().mkdirs();
                     try (final FileOutputStream fos = new FileOutputStream(outputFile)) {
-                        tarIn.transferTo(fos);
+                        final byte[] buffer = new byte[4096];
+                        int len;
+                        while ((len = zis.read(buffer)) > 0) {
+                            fos.write(buffer, 0, len);
+                        }
                     }
                 }
             }
@@ -164,13 +161,13 @@ public class AzureMcpPackageManager {
 
     private static String getPlatformIdentifier() {
         // Operating System detection
-        String os = null;
+        final String os;
         if (SystemUtils.IS_OS_WINDOWS) {
-            os = "win32";
+            os = "win";
         } else if (SystemUtils.IS_OS_LINUX) {
             os = "linux";
         } else if (SystemUtils.IS_OS_MAC) {
-            os = "darwin";
+            os = "osx";
         } else {
             throw new RuntimeException("Unsupported OS " + SystemUtils.OS_NAME);
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/GithubClient.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/GithubClient.java
@@ -29,6 +29,7 @@ public class GithubClient implements Closeable {
     private static final String AZURE_MCP_RELEASE_URL = "https://api.github.com/repos/microsoft/mcp/releases";
     private static final TypeReference<List<GithubRelease>> GITHUB_RELEASE_LIST_TYPE = new TypeReference<>() {
     };
+    private static final String AZURE_MCP_SERVER = "Azure.Mcp.Server";
 
     private final CloseableHttpClient httpClient = HttpClients.createDefault();
 
@@ -36,7 +37,10 @@ public class GithubClient implements Closeable {
         final HttpUriRequest request = RequestBuilder.get().setUri(AZURE_MCP_RELEASE_URL).build();
         try (final CloseableHttpResponse response = httpClient.execute(request)) {
             final List<GithubRelease> releases = OBJECT_MAPPER.readValue(response.getEntity().getContent(), GITHUB_RELEASE_LIST_TYPE);
-            return releases.stream().findFirst().orElse(null);
+            return releases.stream()
+                    .filter(release -> release.getName() != null && release.getName().startsWith(AZURE_MCP_SERVER))
+                    .findFirst()
+                    .orElse(null);
         } catch (final IOException exception) {
             log.error("Error getting latest Azure MCP release details: " + exception.getMessage());
             AzureMcpUtils.logErrorTelemetryEvent("azmcp-get-latest-release-failed", exception);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/GithubCopilotMcpInitializer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/src/main/java/com/microsoft/azure/toolkit/intellij/azuremcp/GithubCopilotMcpInitializer.java
@@ -39,6 +39,8 @@ public class GithubCopilotMcpInitializer implements ProjectActivity, DumbAware, 
 
     private static final ComparableVersion LOWEST_SUPPORTED_COPILOT_VERSION = new ComparableVersion("1.5.50");
     private static final String COPILOT_PLUGIN_ID = "com.github.copilot";
+    private static final String AZURE_MCP_SERVER_NAME = "Azure MCP Server IntelliJ";
+    private static final String LEGACY_SERVER_NAME = "Azure MCP Server";
     private final AzureMcpPackageManager azureMcpPackageManager;
 
     public GithubCopilotMcpInitializer() {
@@ -49,6 +51,7 @@ public class GithubCopilotMcpInitializer implements ProjectActivity, DumbAware, 
     public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
 
         if (Registry.is("azure.mcp.ghcp.autoconfigure.disabled", false)) {
+            logTelemetryEvent("azmcp-copilot-initialization-disabled");
             return null;
         }
 
@@ -114,11 +117,15 @@ public class GithubCopilotMcpInitializer implements ProjectActivity, DumbAware, 
         final McpServer azureMcpServer = new McpServer();
         azureMcpServer.setCommand(azMcpExe.getAbsolutePath());
         azureMcpServer.setArgs(Arrays.asList("server", "start"));
-        if (servers.containsKey("Azure MCP Server")) {
-            servers.remove("Azure MCP Server");
+        servers.remove(LEGACY_SERVER_NAME); // legacy name - remove if it exists
+
+        if (servers.containsKey(AZURE_MCP_SERVER_NAME)) {
+            final McpServer existingConfig = servers.get(AZURE_MCP_SERVER_NAME);
+            if (!azureMcpServer.getCommand().equals(existingConfig.getCommand())) {
+                servers.put(AZURE_MCP_SERVER_NAME, azureMcpServer);
+                Files.writeString(mcpConfigPath, OBJECT_MAPPER.writeValueAsString(mcpConfig));
+            }
         }
-        servers.put("Azure MCP Server IntelliJ", azureMcpServer);
-        Files.writeString(mcpConfigPath, OBJECT_MAPPER.writeValueAsString(mcpConfig));
         logTelemetryEvent("azmcp-copilot-initialization-success");
     }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request updates the initialization and configuration logic for the Azure MCP Server integration with GitHub Copilot in IntelliJ. The main focus is on improving how the server configuration is managed, ensuring legacy entries are cleaned up, and enhancing telemetry for troubleshooting and tracking.

Server configuration improvements:

* The code now removes any legacy server configuration named `Azure MCP Server` before adding or updating the new configuration under `Azure MCP Server IntelliJ`, preventing duplicate or outdated entries.
* When updating the server configuration, it only overwrites the existing entry if the command path has changed, reducing unnecessary writes to the configuration file.

Release selection logic:

* The logic for selecting the latest Azure MCP release from GitHub now filters releases to only those whose name starts with `Azure.Mcp.Server`, ensuring the correct artifact is chosen.

Telemetry enhancements:

* Added a telemetry event when Copilot MCP initialization is disabled via registry, improving observability of feature toggling.

Constants and naming:

* Introduced constants for server names (`AZURE_MCP_SERVER_NAME` and `LEGACY_SERVER_NAME`) to avoid hardcoding and improve maintainability.

Does this close any currently open issues?
------------------------------------------
None


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [x] Tested
