### PR TITLE
Update logging 

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azuremcp/src/com/microsoft/azuretools/azuremcp/AzureMcpPackageManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azuremcp/src/com/microsoft/azuretools/azuremcp/AzureMcpPackageManager.java
@@ -72,6 +72,11 @@ public class AzureMcpPackageManager {
                                 log.info("Azure MCP Server extracted successfully to: " + extractedDir.getAbsolutePath());
                             }
                         }
+                        
+                        if (azMcpExe.exists() && (azMcpExe.canExecute() || azMcpExe.setExecutable(true))) {
+                            log.info("Azure MCP Server executable found at: " + azMcpExe.getAbsolutePath());
+                            return azMcpExe;
+                        }
                     }
                 }
             }

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azuremcp/src/com/microsoft/azuretools/azuremcp/AzureMcpPackageManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azuremcp/src/com/microsoft/azuretools/azuremcp/AzureMcpPackageManager.java
@@ -17,14 +17,14 @@ import javax.annotation.Nullable;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.service.datalocation.Location;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class AzureMcpPackageManager {
 	
-	private static final Logger log = LoggerFactory.getLogger(AzureMcpPackageManager.class);
+    private static final ILog log = ILog.of(AzureMcpPackageManager.class);
+
     private final GithubClient gitHubClient;
     private final String platform;
 
@@ -60,7 +60,7 @@ public class AzureMcpPackageManager {
                         final String executablePath = extractedDir.getAbsolutePath() + getExecutableRelativePath();
                         final File azMcpExe = new File(executablePath);
                         if (!azMcpExe.exists()) {
-                            Files.writeString(versionFile, tagName, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                            
                             final File azMcpZip = new File(azMcpDirFile.getAbsolutePath(), "azmcp_" + tagName + ".zip");
                             log.info("Downloading Azure MCP Server to: " + azMcpZip.getAbsolutePath());
                             final boolean downloaded = gitHubClient.downloadToFile(asset.getBrowserDownloadUrl(), azMcpZip);
@@ -68,24 +68,15 @@ public class AzureMcpPackageManager {
                                 log.info("Downloaded Azure MCP Server successfully in " + (System.currentTimeMillis() - startTime) + " ms");
                                 log.info("Extracting Azure MCP Server to: " + extractedDir.getAbsolutePath());
                                 extractZip(azMcpZip, extractedDir);
+                                Files.writeString(versionFile, tagName, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
                                 log.info("Azure MCP Server extracted successfully to: " + extractedDir.getAbsolutePath());
                             }
-                        }
-                        
-                        
-                        boolean exists = azMcpExe.exists();
-                        boolean canExecute = azMcpExe.canExecute();
-                                             
-
-                        if (azMcpExe.exists() && (azMcpExe.canExecute() || azMcpExe.setExecutable(true))) {
-                            log.info("Azure MCP Server executable found at: " + azMcpExe.getAbsolutePath());
-                            return azMcpExe;
                         }
                     }
                 }
             }
-        } catch (final IOException e) {
-            log.error("Error getting Azure MCP executable: " + e.getMessage());
+        } catch (final Exception e) {
+            log.info("Error getting Azure MCP executable: " + e.getMessage());
         }
         return null;
     }
@@ -107,7 +98,7 @@ public class AzureMcpPackageManager {
             final String downloadFileDigest = DigestUtils.sha256Hex(new FileInputStream(azMcpZip));
             return StringUtils.equalsIgnoreCase("sha256:" + downloadFileDigest, expectedDigest);
         } catch (final Exception e) {
-            log.error("Failed to calculate file digest", e);
+            log.info("Failed to calculate file digest", e);
             return false;
         }
     }
@@ -135,7 +126,7 @@ public class AzureMcpPackageManager {
                     });
 
         } catch (final Exception exception) {
-            System.err.println("Error cleaning up Azure MCP Server: " + exception.getMessage());
+            log.info("Error cleaning up Azure MCP Server: " + exception.getMessage());
         }
     }
 
@@ -145,8 +136,8 @@ public class AzureMcpPackageManager {
                 Files.list(path).forEach(AzureMcpPackageManager::delete);
             }
             Files.delete(path);
-        } catch (final IOException e) {
-            System.err.println("Error deleting file: " + path.toString());
+        } catch (final Exception e) {
+        	log.info("Error deleting file: " + path.toString());
         }
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azuremcp/src/com/microsoft/azuretools/azuremcp/GithubClient.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azuremcp/src/com/microsoft/azuretools/azuremcp/GithubClient.java
@@ -1,29 +1,29 @@
 package com.microsoft.azuretools.azuremcp;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.eclipse.core.runtime.ILog;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 public class GithubClient implements Closeable {
 	
-	private static final Logger log = LoggerFactory.getLogger(GithubClient.class);
-	
+    private static final ILog log = ILog.of(GithubClient.class);
+
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .configure(JsonParser.Feature.ALLOW_COMMENTS, true)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
@@ -41,7 +41,7 @@ public class GithubClient implements Closeable {
             final List<GithubRelease> releases = OBJECT_MAPPER.readValue(response.getEntity().getContent(), GITHUB_RELEASE_LIST_TYPE);
             return releases.stream().findFirst().orElse(null);
         } catch (final IOException exception) {
-            log.error("Error getting latest Azure MCP release details: " + exception.getMessage());
+            log.info("Error getting latest Azure MCP release details: " + exception.getMessage());
             return null;
         }
     }
@@ -53,7 +53,7 @@ public class GithubClient implements Closeable {
             downloadResponse.getEntity().getContent().transferTo(fos);
             return true;
         } catch (final IOException exception) {
-            log.error("Error downloading Azure MCP: " + exception.getMessage());
+            log.info("Error downloading Azure MCP: " + exception.getMessage());
             return false;
         }
     }

--- a/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azuremcp/src/com/microsoft/azuretools/azuremcp/GithubCopilotAzureMcpInitializer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-eclipse/com.microsoft.azuretools.azuremcp/src/com/microsoft/azuretools/azuremcp/GithubCopilotAzureMcpInitializer.java
@@ -10,33 +10,36 @@ import com.microsoft.copilot.eclipse.ui.extensions.IMcpRegistrationProvider;
 public class GithubCopilotAzureMcpInitializer implements IMcpRegistrationProvider {
 	
     private static final ILog log = ILog.of(GithubCopilotAzureMcpInitializer.class);
-    private static final String PLUGIN_ID = "com.microsoft.azuretools.azuremcp";
 
 	private AzureMcpPackageManager azureMcpPackageManager;
 	private static final String MCP_CONFIG_TEMPLATE = "{ \"servers\": { \"azuremcp\": { \"command\": \"%s\", \"args\": [server, start], \"description\": \"Azure MCP Server\" } } }";
 
 	public GithubCopilotAzureMcpInitializer() {
 		this.azureMcpPackageManager = new AzureMcpPackageManager();
-		log.error("Azure MCP Initializer created");
+		log.info("Azure MCP Initializer created");
 	}
 	
 	@Override
     public CompletableFuture<String> getMcpServerConfigurations() {
-		log.error("getMcpServerConfigurations invoked");
+		log.info("getMcpServerConfigurations invoked");
         return CompletableFuture.supplyAsync(() -> getAzureMcpConfig());
     }
 
 	private String getAzureMcpConfig() {
-		File azureMcpExe = azureMcpPackageManager.getAzureMcpExecutable();
-		
-		if(azureMcpExe != null) {
-			log.info("Azure MCP executable available");
-
-			String mcpConfig = String.format(MCP_CONFIG_TEMPLATE, azureMcpExe.getAbsolutePath().replace("\\", "\\\\"));
-			azureMcpPackageManager.cleanup();
-			return mcpConfig;
-		} else {
-			log.error("Azure MCP executable not available");
+		try {
+			File azureMcpExe = azureMcpPackageManager.getAzureMcpExecutable();
+			if(azureMcpExe != null) {
+				log.info("Azure MCP executable available");
+	
+				String mcpConfig = String.format(MCP_CONFIG_TEMPLATE, azureMcpExe.getAbsolutePath().replace("\\", "\\\\"));
+				azureMcpPackageManager.cleanup();
+				return mcpConfig;
+			} else {
+				log.info("Azure MCP executable not available");
+				return null;
+			}
+		} catch (Exception e) {
+			log.info("Error while getting Azure MCP configuration", e);
 			return null;
 		}
 	}


### PR DESCRIPTION
This pull request refactors logging across several classes in the Azure MCP plugin, switching from SLF4J `Logger` to Eclipse's `ILog` interface, and standardizing log usage to only log at the info level. It also improves error handling by catching broader exceptions and consistently logging errors with `log.info` instead of printing to stderr or using error-level logs. Additionally, the code in `GithubCopilotAzureMcpInitializer` now uses info-level logging and wraps configuration retrieval in a try-catch block for robustness.

**Logging Framework Migration:**

* Replaced SLF4J `Logger` with Eclipse `ILog` in `AzureMcpPackageManager`, `GithubClient`, and `GithubCopilotAzureMcpInitializer`, updating all logger initializations accordingly. [[1]](diffhunk://#diff-1d2f284c77a12dc14e538eea2b16ef1b6e282b0012f36f650d6d181c6cd8e860R20-R27) [[2]](diffhunk://#diff-611b5f7f9890f37792e95e1b23618b187c38161639de64542d87e75b41a81a95L3-R25) [[3]](diffhunk://#diff-5fd8a82a4bfdc8cc049c7505de904d970ecae2db83308064b48b4187cb767ab7L13-R42)

**Error Handling and Logging Consistency:**

* Changed all error and exception logs to use `log.info` instead of `log.error` or `System.err.println`, ensuring consistent info-level logging for failures and errors throughout the codebase. [[1]](diffhunk://#diff-1d2f284c77a12dc14e538eea2b16ef1b6e282b0012f36f650d6d181c6cd8e860L63-R79) [[2]](diffhunk://#diff-1d2f284c77a12dc14e538eea2b16ef1b6e282b0012f36f650d6d181c6cd8e860L110-R101) [[3]](diffhunk://#diff-1d2f284c77a12dc14e538eea2b16ef1b6e282b0012f36f650d6d181c6cd8e860L138-R129) [[4]](diffhunk://#diff-1d2f284c77a12dc14e538eea2b16ef1b6e282b0012f36f650d6d181c6cd8e860L148-R140) [[5]](diffhunk://#diff-611b5f7f9890f37792e95e1b23618b187c38161639de64542d87e75b41a81a95L44-R44) [[6]](diffhunk://#diff-611b5f7f9890f37792e95e1b23618b187c38161639de64542d87e75b41a81a95L56-R56) [[7]](diffhunk://#diff-5fd8a82a4bfdc8cc049c7505de904d970ecae2db83308064b48b4187cb767ab7L13-R42)

**Robustness Improvements:**

* Wrapped the Azure MCP configuration retrieval logic in a try-catch block in `GithubCopilotAzureMcpInitializer`, logging any exceptions and returning null if errors occur.

**Minor Logic Adjustments:**

* Moved the update of the version file in `getAzureMcpExecutable` to occur after successful extraction of the MCP server, ensuring the version is only written when extraction succeeds.

These changes collectively improve the maintainability, consistency, and reliability of logging and error handling in the Azure MCP plugin code.