### PR TITLE
Add machine ID to appmod telemetry events

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/utils/AppModUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/utils/AppModUtils.java
@@ -20,6 +20,7 @@ public final class AppModUtils {
 
     private static final Logger LOG = Logger.getInstance(AppModUtils.class);
     private static final String SERVICE_NAME = "appmod";
+    private static final String MACHINE_ID = "machineid";
     // Set to true to enable telemetry debug logging (for development only)
     private static final boolean DEBUG_TELEMETRY = false;
 
@@ -40,7 +41,8 @@ public final class AppModUtils {
                 AzureTelemeter.OP_NAME, eventName,
                 AzureTelemeter.OP_PARENT_ID, SERVICE_NAME,
                 AzureTelemeter.OPERATION_NAME, eventName,
-                AzureTelemeter.SERVICE_NAME, SERVICE_NAME
+                AzureTelemeter.SERVICE_NAME, SERVICE_NAME,
+                MACHINE_ID, MachineIdUtils.getMachineId()
         );
         AzureTaskManager.getInstance().runLater(() -> {
             AzureTelemeter.log(AzureTelemetry.Type.INFO, properties);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/utils/MachineIdUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/utils/MachineIdUtils.java
@@ -1,0 +1,61 @@
+package com.microsoft.azure.toolkit.intellij.appmod.utils;
+
+import com.microsoft.azure.toolkit.lib.common.utils.NetUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * Utility class to generate a machine ID based on MAC address.
+ *
+ * Uses toolkit's NetUtils.getMac() which executes system commands (getmac on Windows,
+ * ifconfig/ip on Unix) to get the MAC address. The MAC is then normalized to match
+ * Node.js os.networkInterfaces() format (lowercase + colon separator) before hashing.
+ *
+ * Windows getmac command returns MACs in the order matching Node.js Friendly Name sorting,
+ * so the first valid MAC from getmac matches what Node.js would return.
+ */
+public class MachineIdUtils {
+
+    private static class MachineIdHolder {
+        static final String MACHINE_ID = computeMachineId();
+
+        private static String computeMachineId() {
+            try {
+                // Get MAC address using toolkit's NetUtils (uses getmac command on Windows)
+                String macAddress = NetUtils.getMac();
+                if (StringUtils.isBlank(macAddress)) {
+                    return null;
+                }
+
+                // Normalize MAC format to match Node.js: lowercase + colon separator
+                // NetUtils returns: 00-0D-3A-09-37-E5 (uppercase + hyphen on Windows)
+                // Node.js returns:  00:0d:3a:09:37:e5 (lowercase + colon)
+                String normalizedMac = macAddress.replace("-", ":").toLowerCase();
+
+                // SHA-256 hash of the normalized MAC address
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                byte[] hash = digest.digest(normalizedMac.getBytes(StandardCharsets.UTF_8));
+                return bytesToHex(hash);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    }
+
+    public static String getMachineId() {
+        if (MachineIdHolder.MACHINE_ID == null) {
+            return java.util.UUID.randomUUID().toString().toLowerCase();
+        }
+        return MachineIdHolder.MACHINE_ID;
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/utils/MachineIdUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/utils/MachineIdUtils.java
@@ -1,15 +1,12 @@
 package com.microsoft.azure.toolkit.intellij.appmod.utils;
 
-import com.microsoft.azure.toolkit.lib.common.utils.NetUtils;
-import org.apache.commons.lang3.StringUtils;
-
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 /**
  * Utility class to generate a machine ID based on MAC address.
  *
- * Uses toolkit's NetUtils.getMac() which executes system commands (getmac on Windows,
+ * Uses NetUtils.getMac() which executes system commands (getmac on Windows,
  * ifconfig/ip on Unix) to get the MAC address. The MAC is then normalized to match
  * Node.js os.networkInterfaces() format (lowercase + colon separator) before hashing.
  *
@@ -23,9 +20,9 @@ public class MachineIdUtils {
 
         private static String computeMachineId() {
             try {
-                // Get MAC address using toolkit's NetUtils (uses getmac command on Windows)
+                // Get MAC address using NetUtils (uses getmac command on Windows, ifconfig/ip on Unix)
                 String macAddress = NetUtils.getMac();
-                if (StringUtils.isBlank(macAddress)) {
+                if (macAddress == null || macAddress.trim().isEmpty()) {
                     return null;
                 }
 
@@ -45,16 +42,16 @@ public class MachineIdUtils {
     }
 
     public static String getMachineId() {
-        if (MachineIdHolder.MACHINE_ID == null) {
+        if (MachineIdUtils.MachineIdHolder.MACHINE_ID == null) {
             return java.util.UUID.randomUUID().toString().toLowerCase();
         }
-        return MachineIdHolder.MACHINE_ID;
+        return MachineIdUtils.MachineIdHolder.MACHINE_ID;
     }
 
     private static String bytesToHex(byte[] bytes) {
         StringBuilder sb = new StringBuilder();
         for (byte b : bytes) {
-            sb.append(String.format("%02x", b));
+            sb.append(String.format("%02x", b & 0xFF));
         }
         return sb.toString();
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/utils/NetUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/utils/NetUtils.java
@@ -1,0 +1,156 @@
+package com.microsoft.azure.toolkit.intellij.appmod.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NetUtils {
+
+    private static final int COMMAND_TIMEOUT_MS = 5000;
+    public static final Pattern INTACT_MAC_PATTERN = Pattern.compile("^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$");
+    private static final Pattern MAC_PATTERN = Pattern.compile("([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}");
+    private static final String[] INVALID_MAC_ADDRESS = {"00:00:00:00:00:00", "ff:ff:ff:ff:ff:ff", "ac:de:48:00:11:22"};
+    private static final String[][] UNIX_COMMANDS = {
+            {"/sbin/ifconfig", "-a"},
+            {"/sbin/ip", "link"}
+    };
+    private static final String[] WINDOWS_COMMAND = {"getmac"};
+
+    public static String getMac() {
+        final String commandMac = getMacByCommand();
+        if (StringUtils.isNotBlank(commandMac)) {
+            return commandMac;
+        }
+        return getMacByNetworkInterface();
+    }
+
+    private static String getMacByCommand() {
+        List<String> macs = getMacsByCommand();
+        return !macs.isEmpty() ? macs.get(0) : StringUtils.EMPTY;
+    }
+
+    private static List<String> getMacsByCommand() {
+        List<String> macs = new ArrayList<>();
+        final String os = System.getProperty("os.name").toLowerCase();
+
+        if (StringUtils.startsWithIgnoreCase(os, "win")) {
+            return getMacsByCommand(WINDOWS_COMMAND);
+        }
+
+        // Try Unix commands in order until one succeeds
+        for (String[] command : UNIX_COMMANDS) {
+            macs = getMacsByCommand(command);
+            if (!macs.isEmpty()) {
+                return macs;
+            }
+        }
+        return macs;
+    }
+
+    private static List<String> getMacsByCommand(String[] command) {
+        List<String> macs = new ArrayList<>();
+        final StringBuilder ret = new StringBuilder();
+        Process process = null;
+        try {
+            final ProcessBuilder probuilder = new ProcessBuilder(command);
+            probuilder.redirectErrorStream(true);
+            process = probuilder.start();
+            try (final InputStream inputStream = process.getInputStream();
+                 final InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+                 final BufferedReader br = new BufferedReader(inputStreamReader)) {
+                String tmp;
+                while ((tmp = br.readLine()) != null) {
+                    ret.append(tmp);
+                }
+            }
+            boolean finished = process.waitFor(COMMAND_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            if (!finished || process.exitValue() != 0) {
+                return macs;
+            }
+        } catch (IOException ex) {
+            return macs;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return macs;
+        } finally {
+            if (process != null && process.isAlive()) {
+                process.destroy();
+            }
+        }
+        String commandMacsString = ret.toString();
+
+        Matcher matcher = MAC_PATTERN.matcher(commandMacsString);
+        while (matcher.find()) {
+            String mac = matcher.group(0);
+            if (isValidMac(mac)) {
+                macs.add(mac);
+            }
+        }
+        return macs;
+    }
+
+    private static String getMacByNetworkInterface() {
+        List<String> macs = getMacsByNetworkInterface();
+        if (macs.isEmpty()) {
+            return StringUtils.EMPTY;
+        }
+        return macs.get(0);
+    }
+
+    private static List<String> getMacsByNetworkInterface() {
+        List<String> macs = new ArrayList<>();
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            if (interfaces == null) {
+                return macs;
+            }
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface networkInterface = interfaces.nextElement();
+                if (networkInterface.isLoopback()) {
+                    continue;
+                }
+                if (networkInterface.getHardwareAddress() != null) {
+                    byte[] mac = networkInterface.getHardwareAddress();
+                    // Refers https://www.mkyong.com/java/how-to-get-mac-address-in-java/
+                    StringBuilder sb = new StringBuilder();
+                    for (int i = 0; i < mac.length; i++) {
+                        sb.append(String.format("%02X%s", mac[i] & 0xFF, (i < mac.length - 1) ? "-" : ""));
+                    }
+                    String macStr = sb.toString();
+                    if (isValidMac(macStr)) {
+                        macs.add(macStr);
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            return macs;
+        }
+        return macs;
+    }
+
+    private static boolean isValidMac(String mac) {
+        if (StringUtils.isEmpty(mac)) {
+            return false;
+        }
+        if (!isValidRawMac(mac)) {
+            return false;
+        }
+        final String fixedMac = mac.replaceAll("-", ":");
+        return !StringUtils.equalsAnyIgnoreCase(fixedMac, INVALID_MAC_ADDRESS);
+    }
+
+    private static boolean isValidRawMac(String raw) {
+        return StringUtils.isNotEmpty(raw) && INTACT_MAC_PATTERN.matcher(raw).find();
+    }
+}


### PR DESCRIPTION
## Description
This PR adds a unique machine ID to telemetry events in the appmod plugin to enable better analytics and tracking of usage patterns across sessions.

## Changes
- **New `MachineIdUtils` class**: Generates a machine ID based on the device's MAC address
  - Uses `NetUtils.getMac()` to retrieve the MAC address
  - Normalizes MAC format to lowercase with colon separators (matching Node.js `os.networkInterfaces()` format)

- **Updated `AppModUtils`**: Integrates machine ID into telemetry event properties