### PR TITLE
fix(ui): override setAction(javax.swing.Action) in AzureActionButton …

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureActionButton.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureActionButton.java
@@ -20,11 +20,20 @@ import org.apache.commons.lang3.StringUtils;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * A JButton subclass that bridges Azure Toolkit {@link Action} with Swing buttons.
+ * <p>
+ * Overrides {@link AbstractButton#setAction(javax.swing.Action)} to prevent the inherited
+ * Swing method from clearing the button text/icon when the IntelliJ form runtime or
+ * Look-and-Feel calls it unexpectedly. This ensures compatibility with IntelliJ's New UI
+ * (2026.1+) where DarculaButtonUI may interact with the Swing Action property.
+ */
 public class AzureActionButton<T> extends JButton {
     public static final DataKey<ActionEvent> ACTION_EVENT_KEY = DataKey.create("AzureActionButton.actionEvent");
     private final ActionListener listener = this::onActionPerformed;
@@ -42,6 +51,25 @@ public class AzureActionButton<T> extends JButton {
         super();
         this.action = action;
         this.registerActionListener();
+    }
+
+    /**
+     * Override the inherited {@link AbstractButton#setAction(javax.swing.Action)} to prevent
+     * the Swing Action mechanism from clearing button text and icon. In IntelliJ's New UI,
+     * the form runtime or LAF may call this method, which by default calls
+     * {@code configurePropertiesFromAction()} and resets all button properties (text, icon,
+     * tooltip, enabled) from the javax.swing.Action — wiping out values set by the form
+     * instrumentation or programmatic code.
+     * <p>
+     * This no-op override preserves the button's text and icon as set by the GUI form
+     * or by calling {@link #setText(String)} / {@link #setIcon(Icon)} directly.
+     */
+    @Override
+    public void setAction(javax.swing.Action a) {
+        // Intentionally do NOT call super.setAction(a).
+        // The Swing default would call configurePropertiesFromAction() which clears
+        // text/icon/tooltip if the javax.swing.Action has no corresponding properties.
+        // Our buttons get their text from the .form file and icons from Java code.
     }
 
     public void setAction(@Nonnull final Action.Id<T> actionId) {


### PR DESCRIPTION
…for New UI compatibility

In IntelliJ 2026.1 EAP's New UI, the form runtime or DarculaButtonUI may call AbstractButton.setAction(javax.swing.Action) which triggers configurePropertiesFromAction() and clears the button text/icon set by the GUI form instrumentation.

Override this method as a no-op to preserve button text and icon values, fixing blank toolbar buttons in Properties views (e.g. WebApp, Function App, Redis, Spring Cloud, KeyVault, Database, etc.).

Fixes: https://dev.azure.com/mseng/VSJava/_workitems/edit/2367324

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
