### PR TITLE
bump version to 3.97.5 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in this file.
 
 - [Change Log](#change-log)
+  - [3.97.5](#3975)
   - [3.97.4](#3974)
   - [3.97.3](#3973)
   - [3.97.2](#3972)
@@ -123,6 +124,14 @@ All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in t
   - [3.0.8](#308)
   - [3.0.7](#307)
   - [3.0.6](#306)
+
+## 3.97.5
+### Added
+- Enable Azure Skills for GitHub Copilot.
+
+### Fixed
+- Fixed zip entry path check.
+- Fixed screen reader not reading the new status after selecting subscription with keyboard.
 
 ## 3.97.4
 - Update prompts and tool references of GitHub Copilot modernization.

--- a/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml
+++ b/PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>com.microsoft.azuretools</groupId>
     <artifactId>utils</artifactId>
-    <version>3.97.4</version>
+    <version>3.97.5</version>
   </parent>
   <groupId>com.microsoft.azuretools</groupId>
   <artifactId>com.microsoft.azuretools.sdk.lib</artifactId>
@@ -39,7 +39,7 @@
   </organization>
 
   <properties>
-    <azuretool.version>3.97.4</azuretool.version>
+    <azuretool.version>3.97.5</azuretool.version>
     <azuretool.sdk.version>3.32.0.qualifier</azuretool.sdk.version>
     <azure.toolkit-lib.version>0.52.2</azure.toolkit-lib.version>
   </properties>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=3.97.4
+pluginVersion=3.97.5
 intellijDisplayVersion=2024.2
 intellij_version=IU-242-EAP-SNAPSHOT
 scala_plugin=org.intellij.scala:2024.2.5

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
              xmlns:xi="http://www.w3.org/2001/XInclude">
   <id>com.microsoft.tooling.msservices.intellij.azure</id>
   <name>Azure Toolkit</name>
-  <version>3.97.4</version>
+  <version>3.97.5</version>
   <vendor email="java@microsoft.com" url="http://www.microsoft.com">Microsoft</vendor>
 
   <description>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib-java/src/main/resources/whatsnew.md
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib-java/src/main/resources/whatsnew.md
@@ -1,6 +1,14 @@
 <!-- Version: 3.88.0 -->
 # What's new in Azure Toolkit for IntelliJ
 
+## 3.97.5
+### Added
+- Enable Azure Skills for GitHub Copilot.
+
+### Fixed
+- Fixed zip entry path check.
+- Fixed screen reader not reading the new status after selecting subscription with keyboard.
+
 ## 3.97.4
 - Update prompts and tool references of GitHub Copilot modernization.
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=3.97.4
+pluginVersion=3.97.5
 intellijDisplayVersion=2025.3
 intellij_version=253-EAP-SNAPSHOT
 platformVersion=253-EAP-SNAPSHOT

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
              xmlns:xi="http://www.w3.org/2001/XInclude">
   <id>com.microsoft.tooling.msservices.intellij.azure</id>
   <name>Azure Toolkit for IntelliJ</name>
-  <version>3.97.4</version>
+  <version>3.97.5</version>
   <vendor email="java@microsoft.com" url="http://www.microsoft.com">Microsoft</vendor>
 
   <description><![CDATA[
@@ -28,9 +28,15 @@
   <change-notes>
     <![CDATA[
     <html>
-      <h2 id="3-97-4">3.97.4</h2>
+      <h2 id="3-97-5">3.97.5</h2>
+      <h3 id="added">Added</h3>
       <ul>
-      <li>Update prompts and tool references of GitHub Copilot modernization.</li>
+      <li>Enable Azure Skills for GitHub Copilot.</li>
+      </ul>
+      <h3 id="fixed">Fixed</h3>
+      <ul>
+      <li>Fixed zip entry path check.</li>
+      <li>Fixed screen reader not reading the new status after selecting subscription with keyboard.</li>
       </ul>
       <p>You may get the full change log <a href="https://github.com/Microsoft/azure-tools-for-java/blob/develop/CHANGELOG.md">here</a></p>
     </html>

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azuretools</groupId>
     <artifactId>utils</artifactId>
-    <version>3.97.4</version>
+    <version>3.97.5</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}-${project.version}</name>
     <properties>


### PR DESCRIPTION
## Endgame Prep for v3.97.5

Bump version from 3.97.4 to 3.97.5 and update changelog/whatsnew.

### Changes since 3.97.4:
- Enable Azure Skills for GitHub Copilot
- Fixed zip entry path check

### Updated files (8):
1. CHANGELOG.md
2. Utils/pom.xml
3. PluginsAndFeatures/AddLibrary/AzureLibraries/pom.xml
4. azure-toolkit-for-intellij/gradle.properties
5. azure-intellij-plugin-base/gradle.properties
6. azure-intellij-plugin-base/plugin.xml
7. azure-toolkit-for-intellij/plugin.xml
8. whatsnew.md