### PR TITLE
Fix UI Freeze: Use non-blocking ReadAction in MavenProjectReportGenerator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@
     ```
 * Use Gradle to build the plugin
     ```
-    $ ./gradlew -b PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle buildPlugin
+    $ ./gradlew -b PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle.kts buildPlugin
     ```
     You can find the outputs under ```PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions```
     

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
@@ -88,7 +88,9 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
         ReadAction.nonBlocking(() -> {
             generateReport(project);
             return Unit.INSTANCE;
-        }).submit(scheduledExecutor);
+        }).inSmartMode(project)
+          .expireWhen(project::isDisposed)
+          .submit(scheduledExecutor);
 
         return null;
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.intellij.lang.StdLanguages;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
@@ -80,11 +81,15 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
         telemetryClient = new TelemetryClient(configuration);
     }
 
+    //@TODO recheck if generated report is idempotent (still the same)
     @Nullable
     @Override
     public Object execute(@Nonnull Project project, @Nonnull Continuation<? super Unit> continuation) {
-        scheduledExecutor.schedule(() -> ApplicationManager.getApplication().runReadAction(() -> generateReport(project)),
-                INITIAL_DELAY_IN_MINUTES, TimeUnit.MINUTES);
+        ReadAction.nonBlocking(() -> {
+            generateReport(project);
+            return Unit.INSTANCE;
+        }).submit(scheduledExecutor);
+
         return null;
     }
 


### PR DESCRIPTION
## Summary
Replaces the blocking `runReadAction` call in `MavenProjectReportGenerator.execute()` with `ReadAction.nonBlocking()` to prevent UI freeze reports.
Fixes the main UI Freeze by the Azure plugin (which is the top 1 third party freeze on JetBrains IDE's)
<img width="1280" height="766" alt="image" src="https://github.com/user-attachments/assets/3d4b8d91-0e27-44e4-9a4c-e910c1b04bbe" />

## Changes
- Replaced `ApplicationManager.getApplication().runReadAction()` with `ReadAction.nonBlocking().submit()`
- Addresses UI Freeze Report #78032859

## TODO
- [ ] Verify generated report is still idempotent

