### PR TITLE
Fix: maven project report generator hardening

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@
     ```
 * Use Gradle to build the plugin
     ```
-    $ ./gradlew -b PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle buildPlugin
+    $ ./gradlew -b PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle.kts buildPlugin
     ```
     You can find the outputs under ```PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions```
     

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
@@ -9,6 +9,7 @@ import com.intellij.lang.StdLanguages;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManagerListener;
@@ -119,6 +120,8 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
                     log.debug("Report for " + key + ": " + OBJECT_MAPPER.writeValueAsString(value));
                     sendReportToAppInsights(value);
                 }
+            } catch (final ProcessCanceledException e) {
+                throw e;
             } catch (final Exception e) {
                 log.error("Unable to send the Azure SDK report ", e);
             }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
@@ -9,6 +9,7 @@ import com.intellij.lang.StdLanguages;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
@@ -90,6 +91,7 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
             generateReport(project);
             return Unit.INSTANCE;
         }).inSmartMode(project)
+          .coalesceBy(project, MavenProjectReportGenerator.class)
           .expireWhen(project::isDisposed)
           .submit(scheduledExecutor);
 
@@ -201,9 +203,6 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
     }
 
     private void analyzeCode(MavenProjectsManager mavenProjectsManager, MavenProject mavenProject, MavenProjectReport report) {
-        final Map<String, Integer> methodCallFrequency = new HashMap<>();
-        final Map<String, Integer> betaMethodCallFrequency = new HashMap<>();
-
         final Module module = ApplicationManager.getApplication()
                 .runReadAction((Computable<Module>) () -> mavenProjectsManager.findModule(mavenProject));
         if (module == null) {
@@ -212,35 +211,46 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
         final Project project = mavenProjectsManager.getProject();
         // Search for all methods in the library with the target annotation
         final AzureSearchScope azureSearchScope = new AzureSearchScope(project);
-        final Collection<PsiClass> classes = AllClassesSearch.search(azureSearchScope, project).findAll();
-        for (final PsiClass psiClass : classes) {
+        AllClassesSearch.search(azureSearchScope, project).forEach(psiClass -> {
+            ProgressManager.checkCanceled();
             for (final PsiMethod method : psiClass.getMethods()) {
-                final MethodCallDetails serviceMethodCall = findAnnotatedMethodCalls(mavenProject, report, method, project, SERVICE_METHOD_ANNOTATION);
+                ProgressManager.checkCanceled();
+                final MethodCallDetails serviceMethodCall = findAnnotatedMethodCalls(mavenProject, method, project, SERVICE_METHOD_ANNOTATION);
                 if (serviceMethodCall != null) {
                     report.addServiceMethodCall(serviceMethodCall);
                 }
-                final MethodCallDetails betaMethodCall = findAnnotatedMethodCalls(mavenProject, report, method, project, BETA_METHOD_ANNOTATION);
+                final MethodCallDetails betaMethodCall = findAnnotatedMethodCalls(mavenProject, method, project, BETA_METHOD_ANNOTATION);
                 if (betaMethodCall != null) {
                     report.addBetaMethodCall(betaMethodCall);
                 }
             }
-        }
+            return true;
+        });
     }
 
     @Nullable
-    private MethodCallDetails findAnnotatedMethodCalls(MavenProject mavenProject, MavenProjectReport report,
+    private MethodCallDetails findAnnotatedMethodCalls(MavenProject mavenProject,
                                                        PsiMethod method, Project project, String annotation) {
         final PsiAnnotation psiAnnotation = method.getAnnotation(annotation);
         if (psiAnnotation != null) {
+            ProgressManager.checkCanceled();
             // Annotated method found; search for references
             final Collection<PsiReference> references = ReferencesSearch.search(method, new MavenRootProjectScope(project, mavenProject)).findAll();
             if (!references.isEmpty()) {
-                final String methodName = method.getContainingClass().getQualifiedName() + "." + method.getName();
-                final String returnType = method.getReturnType().getCanonicalText();
+                final PsiClass containingClass = method.getContainingClass();
+                final PsiType returnType = method.getReturnType();
+                if (containingClass == null || returnType == null) {
+                    return null;
+                }
+                final String className = containingClass.getQualifiedName();
+                if (className == null) {
+                    return null;
+                }
+                final String methodName = className + "." + method.getName();
                 final String params = Arrays.stream(method.getParameterList().getParameters())
                         .map(parameter -> parameter.getType().getCanonicalText())
                         .collect(Collectors.joining(","));
-                final String methodSignature = returnType + " " + methodName + "(" + params + ")";
+                final String methodSignature = returnType.getCanonicalText() + " " + methodName + "(" + params + ")";
                 return new MethodCallDetails().setCallFrequency(references.size()).setMethodName(methodSignature);
             }
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
@@ -88,7 +88,9 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
         ReadAction.nonBlocking(() -> {
             generateReport(project);
             return Unit.INSTANCE;
-        }).submit(scheduledExecutor);
+        }).inSmartMode(project)
+          .expireWhen(project::isDisposed)
+          .submit(scheduledExecutor);
 
         return null;
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.intellij.lang.StdLanguages;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
@@ -80,11 +81,15 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
         telemetryClient = new TelemetryClient(configuration);
     }
 
+    //@TODO recheck if generated report is idempotent (still the same)
     @Nullable
     @Override
     public Object execute(@Nonnull Project project, @Nonnull Continuation<? super Unit> continuation) {
-        scheduledExecutor.schedule(() -> ApplicationManager.getApplication().runReadAction(() -> generateReport(project)),
-                INITIAL_DELAY_IN_MINUTES, TimeUnit.MINUTES);
+        ReadAction.nonBlocking(() -> {
+            generateReport(project);
+            return Unit.INSTANCE;
+        }).submit(scheduledExecutor);
+
         return null;
     }
 


### PR DESCRIPTION
## What this PR does
This follow-up hardens `MavenProjectReportGenerator` to better handle IntelliJ cancellation and reduce heavy PSI search behavior under load. #11981 

## Changes
- Add non-blocking read action coalescing:
  - `.coalesceBy(project, MavenProjectReportGenerator.class)`
- Make class scanning more cancellation-friendly:
  - switch from materializing results with `findAll()` to lazy iteration via `forEach(...)`
- Add explicit cancellation checkpoints:
  - `ProgressManager.checkCanceled()` in class/method scanning flow
- Improve null safety when building method signatures:
  - guard `containingClass`, `qualifiedName`, and `returnType` before use
- Remove unused locals in code analysis path

## Why
- Avoid redundant queued report scans
- React faster to IDE cancellation/write-priority events
- Reduce memory pressure from bulk PSI result collection
- Prevent edge-case null-related failures during signature extraction

## Validation
- `./gradlew :azure-intellij-plugin-java-sdk:compileJava --no-daemon` ✅
- `./gradlew runIde --stacktrace` with a clean sandbox ✅
- No `ProcessCanceledException` / report-send error observed in inspected startup log

## Scope notes
- This is intentionally separated from PR #11981 to keep that review focused on the original comment fix.
