### PR TITLE
Fix report generation and use nonblocking read action

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/java/sdk/MavenProjectReportGenerator.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.startup.ProjectActivity;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.psi.search.searches.AllClassesSearch;
@@ -81,17 +80,16 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
         telemetryClient = new TelemetryClient(configuration);
     }
 
-    //@TODO recheck if generated report is idempotent (still the same)
     @Nullable
     @Override
     public Object execute(@Nonnull Project project, @Nonnull Continuation<? super Unit> continuation) {
-        ReadAction.nonBlocking(() -> {
-            generateReport(project);
-            return Unit.INSTANCE;
-        }).inSmartMode(project)
-          .expireWhen(project::isDisposed)
-          .submit(scheduledExecutor);
-
+        scheduledExecutor.schedule(() ->
+                ReadAction.nonBlocking(() -> {
+                            generateReport(project);
+                            return Unit.INSTANCE;
+                        }).inSmartMode(project)
+                        .expireWhen(project::isDisposed)
+                        .executeSynchronously(), INITIAL_DELAY_IN_MINUTES, TimeUnit.MINUTES);
         return null;
     }
 
@@ -120,7 +118,7 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
                     sendReportToAppInsights(value);
                 }
             } catch (final Exception e) {
-                log.error("Unable to send the Azure SDK report ", e);
+                log.info("Unable to send the Azure SDK report ", e);
             }
         } else {
             log.debug("Azure telemetry is disabled");
@@ -201,8 +199,9 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
         final Map<String, Integer> methodCallFrequency = new HashMap<>();
         final Map<String, Integer> betaMethodCallFrequency = new HashMap<>();
 
-        final Module module = ApplicationManager.getApplication()
-                .runReadAction((Computable<Module>) () -> mavenProjectsManager.findModule(mavenProject));
+        final Module module = ReadAction.nonBlocking(() -> mavenProjectsManager.findModule(mavenProject))
+                .expireWhen(mavenProjectsManager.getProject()::isDisposed)
+                .executeSynchronously();
         if (module == null) {
             return;
         }
@@ -252,7 +251,7 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
             telemetryClient.flush();
             log.info("Successfully sent the report to Application Insights");
         } catch (final Exception ex) {
-            log.error("Unable to send report to Application Insights. " + ex.getMessage());
+            log.info("Unable to send report to Application Insights. " + ex.getMessage());
         }
     }
 
@@ -273,24 +272,29 @@ public final class MavenProjectReportGenerator implements ProjectActivity, DumbA
 
     private void checkDependencyManagement(MavenProjectsManager mavenProjectsManager, MavenProject mavenProject, MavenProjectReport report) {
         final VirtualFile pomFile = mavenProject.getFile();
-        final PsiFile psiFile = ApplicationManager.getApplication()
-                .runReadAction((Computable<PsiFile>) () -> PsiManager.getInstance(mavenProjectsManager.getProject()).findFile(pomFile));
+        final PsiFile psiFile = ReadAction.nonBlocking(() -> PsiManager.getInstance(mavenProjectsManager.getProject()).findFile(pomFile))
+                .expireWhen(mavenProjectsManager.getProject()::isDisposed)
+                .executeSynchronously();
         if (psiFile == null) {
             return;
         }
         final FileViewProvider viewProvider = psiFile.getViewProvider();
         final XmlFile xmlFile = (XmlFile) viewProvider.getPsi(StdLanguages.XML);
-        final XmlTag rootTag = ApplicationManager.getApplication()
-                .runReadAction((Computable<XmlTag>) xmlFile::getRootTag);
+        final XmlTag rootTag = ReadAction.nonBlocking(() -> xmlFile.getRootTag())
+                .expireWhen(mavenProjectsManager.getProject()::isDisposed)
+                .executeSynchronously();
         if (rootTag != null && "project".equals(rootTag.getName())) {
-            final XmlTag dependencyManagement = ApplicationManager.getApplication()
-                    .runReadAction((Computable<XmlTag>) () -> rootTag.findFirstSubTag("dependencyManagement"));
+            final XmlTag dependencyManagement = ReadAction.nonBlocking(() -> rootTag.findFirstSubTag("dependencyManagement"))
+                    .expireWhen(mavenProjectsManager.getProject()::isDisposed)
+                    .executeSynchronously();
             if (dependencyManagement != null) {
-                final XmlTag dependenciesTag = ApplicationManager.getApplication()
-                        .runReadAction((Computable<XmlTag>) () -> dependencyManagement.findFirstSubTag("dependencies"));
+                final XmlTag dependenciesTag = ReadAction.nonBlocking(() -> dependencyManagement.findFirstSubTag("dependencies"))
+                        .expireWhen(mavenProjectsManager.getProject()::isDisposed)
+                        .executeSynchronously();
                 if (dependenciesTag != null) {
-                    final XmlTag[] dependencyTags = ApplicationManager.getApplication()
-                            .runReadAction((Computable<XmlTag[]>) () -> dependenciesTag.findSubTags("dependency"));
+                    final XmlTag[] dependencyTags = ReadAction.nonBlocking(() -> dependenciesTag.findSubTags("dependency"))
+                            .expireWhen(mavenProjectsManager.getProject()::isDisposed)
+                            .executeSynchronously();
 
                     for (final XmlTag dependencyTag : dependencyTags) {
                         final String groupId = getTextValue(dependencyTag, "groupId");


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request refactors the `MavenProjectReportGenerator` class to modernize read actions, improve thread safety, and standardize logging. The main focus is on replacing legacy synchronous read actions with IntelliJ's `ReadAction.nonBlocking` API, ensuring that code analysis and report generation are performed safely in a non-blocking manner. Additionally, logging for error handling is updated to use `info` level instead of `error`, which reduces noise for expected or non-critical issues.

### Refactoring for Thread Safety and Modern APIs

* Replaced all usages of `ApplicationManager.getApplication().runReadAction` with `ReadAction.nonBlocking`, ensuring that read actions are performed off the UI thread and are properly expired if the project is disposed. This affects methods such as `analyzeCode`, `checkDependencyManagement`, and related XML parsing logic. [[1]](diffhunk://#diff-5b190f665649c58bbd9463b31c725ba66c78dcb5ec6699e1126131e1ad640934L204-R204) [[2]](diffhunk://#diff-5b190f665649c58bbd9463b31c725ba66c78dcb5ec6699e1126131e1ad640934L276-R297)

* Updated the scheduling of the report generation in the `execute` method to use `ReadAction.nonBlocking().executeSynchronously()` inside a scheduled executor, aligning with IntelliJ's best practices for background tasks.

### Logging Improvements

* Changed error-level logging to info-level for cases where report sending fails, both in `generateReport` and `sendReportToAppInsights`, to avoid unnecessary error logs for expected or non-critical failures. [[1]](diffhunk://#diff-5b190f665649c58bbd9463b31c725ba66c78dcb5ec6699e1126131e1ad640934L123-R121) [[2]](diffhunk://#diff-5b190f665649c58bbd9463b31c725ba66c78dcb5ec6699e1126131e1ad640934L255-R254)

### Code Cleanup

* Removed unused imports such as `Computable` to clean up the codebase.
