### PR TITLE
Replace runReadAction with ReadAction.nonBlocking in IntellijAzureTaskManager and AzureArtifact

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureArtifact.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib-java/src/main/java/com/microsoft/azure/toolkit/intellij/common/AzureArtifact.java
@@ -6,13 +6,12 @@
 package com.microsoft.azure.toolkit.intellij.common;
 
 import com.intellij.icons.AllIcons;
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.externalSystem.model.project.ExternalProjectPojo;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -129,7 +128,7 @@ public class AzureArtifact {
         if (this.getReferencedObject() == null) {
             return null;
         }
-        return ApplicationManager.getApplication().runReadAction((Computable<Module>) () -> switch (type) {
+        return ReadAction.nonBlocking(() -> switch (type) {
             case Gradle -> {
                 final Path path = Paths.get(((ExternalProjectPojo) referencedObject).getPath());
                 yield Optional.ofNullable(VfsUtil.findFile(path, true))
@@ -141,7 +140,8 @@ public class AzureArtifact {
                 .map(p -> VfsUtil.findFile(p, true))
                 .map(f -> ProjectFileIndex.getInstance(project).getModuleForFile(f)).orElse(null);
             case File -> getNearestParentModuleForFile((VirtualFile) this.getReferencedObject());
-        });
+        }).expireWhen(project::isDisposed)
+          .executeSynchronously();
     }
 
     @Nullable

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/task/IntellijAzureTaskManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/task/IntellijAzureTaskManager.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.toolkit.intellij.common.task;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.progress.PerformInBackgroundOption;
 import com.intellij.openapi.progress.ProgressIndicator;
@@ -30,7 +31,12 @@ public class IntellijAzureTaskManager extends AzureTaskManager {
 
     @Override
     protected void doRead(Runnable runnable, final AzureTask<?> task) {
-        ApplicationManager.getApplication().runReadAction(runnable);
+        final Project project = (Project) task.getProject();
+        final var builder = ReadAction.nonBlocking(runnable);
+        if (project != null) {
+            builder.expireWhen(project::isDisposed);
+        }
+        builder.executeSynchronously();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Replaced `ApplicationManager.getApplication().runReadAction()` with `ReadAction.nonBlocking().executeSynchronously()` in `IntellijAzureTaskManager.doRead()` and `AzureArtifact.getModule()`
- Added `expireWhen(project::isDisposed)` to properly handle project disposal
- Follows the same pattern established in PR #11995 for `MavenProjectReportGenerator`
- Removes unused `Computable` import from `AzureArtifact`

## Motivation
Using blocking `runReadAction` can cause UI freezes. The `ReadAction.nonBlocking` API is the recommended IntelliJ approach for performing read actions without blocking the EDT.

## Test plan
- [x] `compileJava` passes successfully
- [ ] Verify no regression in Azure task execution flows
- [ ] Verify artifact module resolution still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)