### PR TITLE
bump version to 3.97.6 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in this file.
 
 - [Change Log](#change-log)
+  - [3.97.6](#3976)
   - [3.97.5](#3975)
   - [3.97.4](#3974)
   - [3.97.3](#3973)
@@ -124,6 +125,10 @@ All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in t
   - [3.0.8](#308)
   - [3.0.7](#307)
   - [3.0.6](#306)
+
+## 3.97.6
+### Fixed
+- Fixed several UI freeze issues caused by non-cancellable read actions in Azure task manager, Azure artifact resolution, Maven report generation, and background JDK version checks.
 
 ## 3.97.5
 ### Added

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
              xmlns:xi="http://www.w3.org/2001/XInclude">
   <id>com.microsoft.tooling.msservices.intellij.azure</id>
   <name>Azure Toolkit</name>
-  <version>3.97.5</version>
+  <version>3.97.6</version>
   <vendor email="java@microsoft.com" url="http://www.microsoft.com">Microsoft</vendor>
 
   <description>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib-java/src/main/resources/whatsnew.md
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib-java/src/main/resources/whatsnew.md
@@ -1,6 +1,10 @@
 <!-- Version: 3.88.0 -->
 # What's new in Azure Toolkit for IntelliJ
 
+## 3.97.6
+### Fixed
+- Fixed several UI freeze issues caused by non-cancellable read actions in Azure task manager, Azure artifact resolution, Maven report generation, and background JDK version checks.
+
 ## 3.97.5
 ### Added
 - Enable Azure Skills for GitHub Copilot.

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=3.97.5
+pluginVersion=3.97.6
 intellijDisplayVersion=2025.3
 intellij_version=253-EAP-SNAPSHOT
 platformVersion=253-EAP-SNAPSHOT

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
              xmlns:xi="http://www.w3.org/2001/XInclude">
   <id>com.microsoft.tooling.msservices.intellij.azure</id>
   <name>Azure Toolkit for IntelliJ</name>
-  <version>3.97.5</version>
+  <version>3.97.6</version>
   <vendor email="java@microsoft.com" url="http://www.microsoft.com">Microsoft</vendor>
 
   <description><![CDATA[
@@ -28,15 +28,10 @@
   <change-notes>
     <![CDATA[
     <html>
-      <h2 id="3-97-5">3.97.5</h2>
-      <h3 id="added">Added</h3>
-      <ul>
-      <li>Enable Azure Skills for GitHub Copilot.</li>
-      </ul>
+      <h2 id="3-97-6">3.97.6</h2>
       <h3 id="fixed">Fixed</h3>
       <ul>
-      <li>Fixed zip entry path check.</li>
-      <li>Fixed screen reader not reading the new status after selecting subscription with keyboard.</li>
+      <li>Fixed several UI freeze issues caused by non-cancellable read actions in Azure task manager, Azure artifact resolution, Maven report generation, and background JDK version checks.</li>
       </ul>
       <p>You may get the full change log <a href="https://github.com/Microsoft/azure-tools-for-java/blob/develop/CHANGELOG.md">here</a></p>
     </html>


### PR DESCRIPTION
Bump plugin version to 3.97.6 and update changelog / what's new / plugin.xml for the next patch release.

## Changes in 3.97.6

### Fixed
- Fixed several UI freeze issues caused by non-cancellable read actions in Azure task manager, Azure artifact resolution, Maven report generation, and background JDK version checks.

## Files updated
- `CHANGELOG.md`
- `PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib-java/src/main/resources/whatsnew.md`
- `PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml` (version + change-notes)
- `PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml` (version)
- `PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties` (`pluginVersion=3.97.6`)

## Commits included since v3.97.5
- #11998 Replace runReadAction with ReadAction.nonBlocking in IntellijAzureTaskManager and AzureArtifact
- #11995 Fix report generation and use nonblocking read action
- #11981 Handle Maven report read action in smart mode and expire on project dispose
- UI Freeze Report #78032859: heavy non-cancellable read action on background check