### PR TITLE
Support IntelliJ IDEA 2026.2

### DIFF
--- a/.azure-pipelines/build-pull-request.yml
+++ b/.azure-pipelines/build-pull-request.yml
@@ -109,6 +109,12 @@ extends:
                 inputs:
                   type: InlineScript
                   script: ./gradlew buildUtils -x buildToolkitsLib || exit -1
+              - task: JavaToolInstaller@0
+                displayName: Use Java 25 for IntelliJ
+                inputs:
+                  versionSpec: "25"
+                  jdkArchitectureOption: x64
+                  jdkSourceOption: PreInstalled
               - task: ms-devlabs.utilitytasks.task-Shellpp.Shellpp@0
                 displayName: Build IntelliJ
                 inputs:

--- a/.azure-pipelines/sign-for-stable-release.yml
+++ b/.azure-pipelines/sign-for-stable-release.yml
@@ -90,23 +90,22 @@ extends:
                 clean: true
                 fetchTags: false
               - task: PowerShell@2
-                displayName: Install JDK 21
+                displayName: Install JDK 25
                 inputs:
                   targetType: inline
                   script: |
-                    # Download Adoptium/Temurin JDK 21.0.8
-                    Write-Host "Downloading Java 21.0.8..."
-                    $source = "https://download.oracle.com/java/21/archive/jdk-21.0.2_windows-x64_bin.zip"
-                    $destination = "$(build.sourcesdirectory)\jdk21_x64_windows.zip"
+                    Write-Host "Downloading Java 25.0.2..."
+                    $source = "https://download.oracle.com/java/25/archive/jdk-25.0.2_windows-x64_bin.zip"
+                    $destination = "$(build.sourcesdirectory)\jdk25_x64_windows.zip"
                     Invoke-WebRequest -Uri $source -OutFile $destination
               - task: JavaToolInstaller@0
-                displayName: 'Use Java 21'
+                displayName: 'Use Java 25'
                 inputs:
-                  versionSpec: 21
+                  versionSpec: 25
                   jdkArchitectureOption: x64
                   jdkSourceOption: LocalDirectory
-                  jdkFile: '$(build.sourcesdirectory)\jdk21_x64_windows.zip'
-                  jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk21'
+                  jdkFile: '$(build.sourcesdirectory)\jdk25_x64_windows.zip'
+                  jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk25'
               - task: UseNode@1
                 inputs:
                   version: "22.x"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in this file.
 
 - [Change Log](#change-log)
+  - [Unreleased](#unreleased)
   - [3.97.6](#3976)
   - [3.97.5](#3975)
   - [3.97.4](#3974)
@@ -125,6 +126,10 @@ All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in t
   - [3.0.8](#308)
   - [3.0.7](#307)
   - [3.0.6](#306)
+
+## [Unreleased]
+### Added
+- Added support for IntelliJ IDEA 2026.2.
 
 ## 3.97.6
 ### Fixed

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/AppServiceStreamingLogManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appservice/src/main/java/com/microsoft/azure/toolkit/intellij/legacy/appservice/AppServiceStreamingLogManager.java
@@ -118,7 +118,7 @@ public enum AppServiceStreamingLogManager {
 
     private StreamingLogsConsoleView getOrCreateConsoleView(Project project, String resourceId) {
         return consoleViewMap.compute(resourceId,
-            (id, view) -> (view == null || view.isDisposed()) ? new StreamingLogsConsoleView(project) : view);
+            (id, view) -> (view == null || view.isConsoleDisposed()) ? new StreamingLogsConsoleView(project) : view);
     }
 
     interface ILogStreaming {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azuremcp/build.gradle.kts
@@ -3,8 +3,9 @@ dependencies {
     implementation(project(":azure-intellij-plugin-lib-java"))
     implementation("com.microsoft.azure:azure-toolkit-common-lib")
     implementation("com.microsoft.azure:azure-toolkit-ide-common-lib")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
-    testImplementation("org.mockito:mockito-core:3.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.mockito:mockito-core:5.23.0")
 
     intellijPlatform {
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
@@ -27,6 +27,7 @@
   <idea-version since-build="222.2270.31" until-build="222.*"/>
   <resource-bundle>com.microsoft.intellij.ui.messages.messages</resource-bundle>
   <depends>com.intellij.modules.java</depends>
+  <depends>com.intellij.modules.jcef</depends>
   <depends>org.jetbrains.idea.maven</depends>
   <depends>com.intellij.gradle</depends>
   <xi:include href="/META-INF/azure-intellij-plugin-lib-java.xml" xpointer="xpointer(/idea-plugin/*)"/>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-containerservice/src/main/java/com/microsoft/azure/toolkit/intellij/containerservice/actions/OpenKubernetesPluginAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-containerservice/src/main/java/com/microsoft/azure/toolkit/intellij/containerservice/actions/OpenKubernetesPluginAction.java
@@ -10,7 +10,6 @@ import com.intellij.execution.services.ServiceEventListener;
 import com.intellij.execution.services.ServiceViewContributor;
 import com.intellij.execution.services.ServiceViewManager;
 import com.intellij.ide.projectView.PresentationData;
-import com.intellij.kubernetes.api.Context;
 import com.intellij.kubernetes.api.KubernetesApiProvider;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.openapi.project.Project;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-hdinsight-base/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-hdinsight-base/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.jetbrains.idea.maven")
-        plugin("org.intellij.scala:2024.2.5")
+        plugin("org.intellij.scala:2026.2.5")
     }
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-hdinsight-lib/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-hdinsight-lib/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
         // intellijIdeaUltimate(properties("platformVersion").get())
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugin("com.intellij.java")
-        plugin("org.intellij.scala:2024.2.5")
+        plugin("org.intellij.scala:2026.2.5")
     }
 
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-hdinsight/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-hdinsight/build.gradle.kts
@@ -18,6 +18,6 @@ dependencies {
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.jetbrains.idea.maven")
-        plugin("org.intellij.scala:2024.2.5")
+        plugin("org.intellij.scala:2026.2.5")
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-java-sdk/build.gradle.kts
@@ -3,8 +3,9 @@ dependencies {
     implementation(project(":azure-intellij-plugin-lib-java"))
     implementation("com.microsoft.azure:azure-toolkit-common-lib")
     implementation("com.microsoft.azure:azure-toolkit-ide-common-lib")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
-    testImplementation("org.mockito:mockito-core:3.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.mockito:mockito-core:5.23.0")
 
     intellijPlatform {
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/build.gradle.kts
@@ -28,4 +28,3 @@ dependencies {
         bundledPlugin("org.jetbrains.plugins.terminal")
     }
 }
-

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/streaminglog/StreamingLogsConsoleView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/streaminglog/StreamingLogsConsoleView.java
@@ -14,12 +14,11 @@ import static com.microsoft.azure.toolkit.intellij.common.AzureBundle.message;
 
 public class StreamingLogsConsoleView extends ConsoleViewImpl {
     private static final String SEPARATOR = System.getProperty("line.separator");
-    private boolean isDisposed;
+    private boolean disposed;
     private Disposable subscription;
 
     public StreamingLogsConsoleView(@NotNull Project project) {
         super(project, true);
-        this.isDisposed = false;
         this.setUpdateFoldingsEnabled(false);
     }
 
@@ -43,13 +42,8 @@ public class StreamingLogsConsoleView extends ConsoleViewImpl {
         return subscription != null && !subscription.isDisposed();
     }
 
-    /**
-     * Returns whether this console view has been disposed.
-     * Note: In IntelliJ 261+, ConsoleViewImpl.isDisposed() is private final,
-     * so this is NOT an override but a new public method for callers.
-     */
-    public boolean isDisposed() {
-        return this.isDisposed;
+    public boolean isConsoleDisposed() {
+        return this.disposed;
     }
 
     private void printlnToConsole(String message, ConsoleViewContentType consoleViewContentType) {
@@ -59,7 +53,7 @@ public class StreamingLogsConsoleView extends ConsoleViewImpl {
     @Override
     public void dispose() {
         super.dispose();
-        this.isDisposed = true;
+        this.disposed = true;
         closeStreamingLog();
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-samples/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-samples/build.gradle.kts
@@ -9,5 +9,6 @@ dependencies {
     intellijPlatform {
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugin("Git4Idea")
+        bundledModule("intellij.platform.vcs.impl")
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-synapse/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-synapse/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.jetbrains.idea.maven")
-        plugins("org.intellij.scala:2024.2.5")
+        plugins("org.intellij.scala:2026.2.5")
     }
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle.kts
@@ -1,6 +1,7 @@
 import io.freefair.gradle.plugins.aspectj.AjcAction
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URI
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -23,6 +24,10 @@ plugins {
 
 group = properties("pluginGroup").get()
 
+changelog {
+    path.set(rootProject.file("../../CHANGELOG.md").canonicalPath)
+}
+
 allprojects {
     apply {
         plugin("java")
@@ -33,12 +38,15 @@ allprojects {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(properties("javaToolchainVersion").get().toInt())
         }
     }
 
     kotlin {
-        jvmToolchain(21)
+        jvmToolchain(properties("javaToolchainVersion").get().toInt())
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(properties("javaVersion").get()))
+        }
     }
 
     repositories {
@@ -63,8 +71,9 @@ allprojects {
             intellijIdeaUltimate(properties("platformVersion").get()) {
                 useInstaller = false
             }
-            // JBR 25 required to run IntelliJ 2026.1 (PathClassLoader is JBR-only)
+            // JBR 25 required to run IntelliJ 2026.2 (PathClassLoader is JBR-only)
             jetbrainsRuntime()
+            bundledPlugin("com.intellij.modules.jcef")
             // MavenId/MavenCoordinate classes moved from maven plugin to repository-search plugin in 261
             bundledPlugin("org.jetbrains.idea.reposearch")
             // Test framework classes moved to separate modules in 261
@@ -75,12 +84,16 @@ allprojects {
         implementation(platform("com.microsoft.azure:azure-toolkit-libs:0.52.2"))
         implementation(platform("com.microsoft.azure:azure-toolkit-ide-libs:0.52.2"))
         implementation(platform("com.microsoft.hdinsight:azure-toolkit-ide-hdinsight-libs:0.1.1"))
+        implementation("commons-collections:commons-collections:3.2.2")
 
-        compileOnly("org.projectlombok:lombok:1.18.32")
+        compileOnly("org.projectlombok:lombok:1.18.46")
         compileOnly("org.jetbrains:annotations:24.0.0")
-        annotationProcessor("org.projectlombok:lombok:1.18.32")
+        annotationProcessor("org.projectlombok:lombok:1.18.46")
         implementation("com.microsoft.azure:azure-toolkit-common-lib:0.52.2")
+        implementation("org.aspectj:aspectjrt:1.9.25")
+        implementation("org.aspectj:aspectjweaver:1.9.25")
         aspect("com.microsoft.azure:azure-toolkit-common-lib:0.52.2")
+        aspect("org.aspectj:aspectjweaver:1.9.25")
         // junit was removed from IntelliJ platform bundled libs in 261
         testImplementation("junit:junit:4.13.2")
     }
@@ -90,7 +103,6 @@ allprojects {
         implementation { exclude(module = "log4j") }
         implementation { exclude(module = "stax-api") }
         implementation { exclude(module = "groovy-xml") }
-        implementation { exclude(module = "groovy-templates") }
         implementation { exclude(module = "jna") }
         implementation { exclude(module = "xpp3") }
         implementation { exclude(module = "pull-parser") }
@@ -106,8 +118,8 @@ allprojects {
     tasks {
 
         compileJava {
-            sourceCompatibility = "21"
-            targetCompatibility = "21"
+            sourceCompatibility = properties("javaVersion").get()
+            targetCompatibility = properties("javaVersion").get()
         }
 
         compileKotlin {
@@ -194,52 +206,53 @@ dependencies {
         bundledPlugin("com.intellij.properties")
         bundledPlugin("org.jetbrains.plugins.terminal")
         bundledPlugin("org.intellij.plugins.markdown")
+        bundledPlugin("com.intellij.modules.jcef")
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file for plugin from JetBrains Marketplace.
         plugins(properties("platformPlugins").map { it.split(',') })
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-lib")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-lib-java")))
+        pluginComposedModule(implementation(project(":azure-intellij-resource-connector-lib")))
+        pluginComposedModule(implementation(project(":azure-intellij-resource-connector-lib-java")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-service-explorer")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-guidance")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-guidance-java")))
+        pluginComposedModule(implementation(project(":azure-sdk-reference-book")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-springcloud")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-storage")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-storage-java")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-appservice")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-appservice-java")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-arm")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-applicationinsights")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-cosmos")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-cognitiveservices")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-monitor")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-containerregistry")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-containerservice")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-containerapps")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-database")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-database-java")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-vm")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-redis")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-redis-java")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-samples")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-bicep")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-eventhubs")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-servicebus")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-keyvault")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-keyvault-java")))
+        pluginComposedModule(implementation(project(":azure-intellij-resource-connector-aad")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-hdinsight-lib")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-sqlserverbigdata")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-hdinsight")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-synapse")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-sparkoncosmos")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-hdinsight-base")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-integration-services")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-cloud-shell")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-java-sdk")))
+        pluginComposedModule(implementation(project(":azure-intellij-plugin-azuremcp")))
     }
-    implementation(project(":azure-intellij-plugin-lib"))
-    implementation(project(":azure-intellij-plugin-lib-java"))
-    implementation(project(":azure-intellij-resource-connector-lib"))
-    implementation(project(":azure-intellij-resource-connector-lib-java"))
-    implementation(project(":azure-intellij-plugin-service-explorer"))
-    implementation(project(":azure-intellij-plugin-guidance"))
-    implementation(project(":azure-intellij-plugin-guidance-java"))
-    implementation(project(":azure-sdk-reference-book"))
-    implementation(project(":azure-intellij-plugin-springcloud"))
-    implementation(project(":azure-intellij-plugin-storage"))
-    implementation(project(":azure-intellij-plugin-storage-java"))
-    implementation(project(":azure-intellij-plugin-appservice"))
-    implementation(project(":azure-intellij-plugin-appservice-java"))
-    implementation(project(":azure-intellij-plugin-arm"))
-    implementation(project(":azure-intellij-plugin-applicationinsights"))
-    implementation(project(":azure-intellij-plugin-cosmos"))
-    implementation(project(":azure-intellij-plugin-cognitiveservices"))
-    implementation(project(":azure-intellij-plugin-monitor"))
-    implementation(project(":azure-intellij-plugin-containerregistry"))
-    implementation(project(":azure-intellij-plugin-containerservice"))
-    implementation(project(":azure-intellij-plugin-containerapps"))
-    implementation(project(":azure-intellij-plugin-database"))
-    implementation(project(":azure-intellij-plugin-database-java"))
-    implementation(project(":azure-intellij-plugin-vm"))
-    implementation(project(":azure-intellij-plugin-redis"))
-    implementation(project(":azure-intellij-plugin-redis-java"))
-    implementation(project(":azure-intellij-plugin-samples"))
-    implementation(project(":azure-intellij-plugin-bicep"))
-    implementation(project(":azure-intellij-plugin-eventhubs"))
-    implementation(project(":azure-intellij-plugin-servicebus"))
-    implementation(project(":azure-intellij-plugin-keyvault"))
-    implementation(project(":azure-intellij-plugin-keyvault-java"))
-    implementation(project(":azure-intellij-resource-connector-aad"))
-    implementation(project(":azure-intellij-plugin-hdinsight-lib"))
-    implementation(project(":azure-intellij-plugin-sqlserverbigdata"))
-    implementation(project(":azure-intellij-plugin-hdinsight"))
-    implementation(project(":azure-intellij-plugin-synapse"))
-    implementation(project(":azure-intellij-plugin-sparkoncosmos"))
-    implementation(project(":azure-intellij-plugin-hdinsight-base"))
-    implementation(project(":azure-intellij-plugin-integration-services"))
-    implementation(project(":azure-intellij-plugin-cloud-shell"))
-    implementation(project(":azure-intellij-plugin-java-sdk"))
-    implementation(project(":azure-intellij-plugin-azuremcp"))
     implementation("commons-io:commons-io")
     implementation("org.apache.commons:commons-lang3")
     implementation("com.microsoft.azure:azure-toolkit-common-lib")
@@ -322,7 +335,7 @@ tasks {
 
     // refers https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-testing-extension.html#intellijPlatformTesting
     val testIde by intellijPlatformTesting.runIde.registering {
-        type = IntelliJPlatformType.IntellijIdeaCommunity
+        type = IntelliJPlatformType.IntellijIdeaUltimate
         version = properties("platformVersion").get()
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -1,16 +1,17 @@
 pluginVersion=3.97.6
-intellijDisplayVersion=2026.1
-intellij_version=261-EAP-SNAPSHOT
-platformVersion=261-EAP-SNAPSHOT
+intellijDisplayVersion=2026.2
+intellij_version=262.8665.176-EAP
+platformVersion=262.8665.176-EAP
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild=261
-pluginUntilBuild=261.*
+pluginSinceBuild=262
+pluginUntilBuild=262.*
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
-platformPlugins=org.intellij.scala:2026.1.8
+platformPlugins=org.intellij.scala:2026.2.5
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IU
 needPatchVersion=true
-javaVersion=21
+javaVersion=25
+javaToolchainVersion=25
 applicationinsights.key=57cc111a-36a8-44b3-b044-25d293b8b77c
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.microsoft.azuretools
@@ -22,7 +23,7 @@ platformDownloadSources=true
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion=9.0
+gradleVersion=9.1.0
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=warn
@@ -34,5 +35,3 @@ org.gradle.configureondemand=true
 org.gradle.daemon=true
 org.gradle.jvmargs='-Duser.language=en'
 org.jetbrains.intellij.platform.buildFeature.useBinaryReleases=false
-
-

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle/libs.versions.toml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle/libs.versions.toml
@@ -2,17 +2,17 @@
 # libraries
 
 # plugins
-kotlin = "2.2.20"
+kotlin = "2.4.0"
 changelog = "2.4.0"
 #intellijPlatform = "2.10.1"
-intellijPlatform = "2.12.0"
+intellijPlatform = "2.18.1"
 detekt = "1.23.6"
 ktlint = "12.1.1"
 #gradleIntelliJPlugin = "1.17.3"
 #qodana = "2024.1.5"
 aspectj = "9.2.0"
 springDependencyManagement = "1.1.6"
-serialization = "1.9.24"
+serialization = "2.4.0"
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle/wrapper/gradle-wrapper.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,7 @@
   </change-notes>
 
   <depends>com.intellij.modules.platform</depends>
+  <depends>com.intellij.modules.jcef</depends>
 
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
   <idea-version since-build="232.7754.73" until-build="232.*"/>


### PR DESCRIPTION
## Summary
- target IntelliJ IDEA 2026.2 build 262.8665.176-EAP
- upgrade the build to JDK 25, Gradle 9.1, Kotlin 2.4, and IntelliJ Platform Gradle Plugin 2.18.1
- adapt platform modules, JCEF, plugin packaging, CI, and 262 API changes

## Validation
- full IntelliJ plugin test suite
- buildPlugin
- runIde with the Azure Toolkit loaded

## Notes
Plugin Verifier now processes the plugin successfully. The remaining API-compatibility backlog and three legacy resource-bundle findings are intentionally deferred to the API compatibility phase.