### PR TITLE
Fix OAuth reauthentication action

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/action/IntellijAccountActionsContributor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-lib/src/main/java/com/microsoft/azure/toolkit/intellij/common/action/IntellijAccountActionsContributor.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.account.IAccount;
 import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
 import com.microsoft.azure.toolkit.lib.auth.IAccountActions;
+import com.microsoft.azure.toolkit.lib.auth.ReauthenticationRequest;
 import com.microsoft.azure.toolkit.lib.common.action.Action;
 import com.microsoft.azure.toolkit.lib.common.action.AzureActionManager;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
@@ -81,6 +82,14 @@ public class IntellijAccountActionsContributor implements IActionsContributor, I
             .withLabel("Select Subscriptions...")
             .withIcon(AzureIcons.Action.SELECT_SUBSCRIPTION.getIconPath())
             .withHandler((Object v, AnActionEvent e) -> SelectSubscriptionsAction.selectSubscriptions(e.getProject()))
+            .withAuthRequired(false)
+            .register(am);
+
+        new Action<>(IAccountActions.REAUTHENTICATE)
+            .withLabel("Reauthenticate")
+            .withIcon(AzureIcons.Common.SIGN_IN.getIconPath())
+            .withHandler((ReauthenticationRequest request, AnActionEvent e) ->
+                AzureTaskManager.getInstance().runInBackground("Reauthenticate Azure account", request::authenticate))
             .withAuthRequired(false)
             .register(am);
     }


### PR DESCRIPTION
Registers the IntelliJ action exposed when an authenticated OAuth session requires user interaction again. The action runs reauthentication in the background; the shared toolkit then refreshes Azure resources without clearing selected subscriptions.

Depends on microsoft/azure-maven-plugins#2561. The same-named shared-library branch is available for CI source resolution.

Validation: azure-intellij-plugin-lib compilation passed against the patched toolkit 0.52.2 artifact on JDK 25.