### PR TITLE
docs(changelog): add appmod fixes to 3.97.7 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in t
 - Preserve proxy, run configuration, Project Explorer, Cosmos DB SSL, and refresh behavior during the migration
 - Preserve file chooser guidance, button accessibility metadata, and plugin lifecycle cleanup
 - Fix registry key conflict for Cosmos DB dbtools module
+- Fixed Copilot Modernization branding: install prompts now say "GitHub Copilot Modernization" instead of "App Modernization".
+- Fixed CVE fix actions not using the designated custom agent and restored the missing "Fix the vulnerable with GitHub Copilot" action in Problems view context menu.
+- Fixed "Install GitHub Copilot Modernization" suffix being repeatedly appended on menu hover.
 
 ## 3.97.6
 ### Added

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
@@ -24,6 +24,9 @@
           <li>Preserve proxy, run configuration, Project Explorer, Cosmos DB SSL, and refresh behavior during the migration</li>
           <li>Preserve file chooser guidance, button accessibility metadata, and plugin lifecycle cleanup</li>
           <li>Fix registry key conflict for Cosmos DB dbtools module</li>
+          <li>Fixed Copilot Modernization branding: install prompts now say "GitHub Copilot Modernization" instead of "App Modernization".</li>
+          <li>Fixed CVE fix actions not using the designated custom agent and restored the missing "Fix the vulnerable with GitHub Copilot" action in Problems view context menu.</li>
+          <li>Fixed "Install GitHub Copilot Modernization" suffix being repeatedly appended on menu hover.</li>
         </ul>
         <p>You may get the full change log <a href="https://github.com/Microsoft/azure-tools-for-java/blob/develop/CHANGELOG.md">here</a></p>
     </html>


### PR DESCRIPTION
## Summary
- Add changelog entries for [#12179](https://github.com/microsoft/azure-tools-for-java/pull/12179) appmod fixes to the 3.97.7 release notes.

## Changes added to 3.97.7
- Fixed Copilot Modernization branding: install prompts now say "GitHub Copilot Modernization" instead of "App Modernization".
- Fixed CVE fix actions not using the designated custom agent and restored the missing "Fix the vulnerable with GitHub Copilot" action in Problems view context menu.
- Fixed "Install GitHub Copilot Modernization" suffix being repeatedly appended on menu hover.

## Test plan
- [ ] Verify CHANGELOG.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)