### PR TITLE
bump version to 3.97.7 for `develop.next` branch and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in this file.
 
-## [Unreleased]
-
 ## 3.97.7
 ### Fixed
 - Migrate IntelliJ Platform integrations to APIs supported by IntelliJ IDEA 2026.2
 - Preserve proxy, run configuration, Project Explorer, Cosmos DB SSL, and refresh behavior during the migration
 - Preserve file chooser guidance, button accessibility metadata, and plugin lifecycle cleanup
 - Fix registry key conflict for Cosmos DB dbtools module
+- Fixed appmod plugin: Copilot modernization branding, CVE fix actions with custom agent support, and context menu hover issue.
 
 ## 3.97.6
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to "Azure Toolkit for IntelliJ IDEA" will be documented in this file.
 
+## [Unreleased]
+
 ## 3.97.7
 ### Fixed
 - Migrate IntelliJ Platform integrations to APIs supported by IntelliJ IDEA 2026.2

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-base/src/main/resources/META-INF/plugin.xml
@@ -24,6 +24,7 @@
           <li>Preserve proxy, run configuration, Project Explorer, Cosmos DB SSL, and refresh behavior during the migration</li>
           <li>Preserve file chooser guidance, button accessibility metadata, and plugin lifecycle cleanup</li>
           <li>Fix registry key conflict for Cosmos DB dbtools module</li>
+          <li>Fixed appmod plugin: Copilot modernization branding, CVE fix actions with custom agent support, and context menu hover issue.</li>
         </ul>
         <p>You may get the full change log <a href="https://github.com/Microsoft/azure-tools-for-java/blob/develop/CHANGELOG.md">here</a></p>
     </html>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
develop.next branch: bump version to 3.97.7 and update changelog


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
