### PR TITLE
Fix MicroBuild JAR signing regression

### DIFF
--- a/.azure-pipelines/sign-for-stable-release.yml
+++ b/.azure-pipelines/sign-for-stable-release.yml
@@ -120,9 +120,12 @@ extends:
                     ConnectedPMEServiceName: "40012d40-9ded-4f75-8476-d60758200346"
                   ${{ else }}:
                     signType: "test"
+                  # Keep the last known-good package until the MicroBuild certificate regression is fixed.
+                  version: "1.1.1330"
                   feedSource: "https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
                 env:
                   MicroBuildOutputFolderOverride: "$(Agent.TempDirectory)"
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               - task: PowerShell@2
                 displayName: Build Plugin
                 inputs:
@@ -170,10 +173,15 @@ extends:
                       $counter++
                       Write-Host "[$counter/$($files.Count)] Signing: $($file.Name) with sign type: $(SIGNTYPE)"
                       dotnet "$env:MBSIGN_APPFOLDER/DDSignFiles.dll" -- /file:"$($file.FullName)" /certs:100010171 /signType:$(SIGNTYPE)
+                      if ($LASTEXITCODE -ne 0) {
+                        throw "Failed to sign '$($file.FullName)' (exit code $LASTEXITCODE)"
+                      }
                       Write-Host "  ✓ Signed successfully"
                     }
                     Write-Host "All JAR files signed successfully"
                   workingDirectory: 'artifacts/intellij/folder/azure-toolkit-for-intellij/lib'
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               - task: CmdLine@2
                 displayName: Repackage
                 inputs:


### PR DESCRIPTION
## Summary
- pin `MicroBuild.Plugins.Signing` to the last known-good `1.1.1330` release
- pass `System.AccessToken` to plugin installation and JAR signing
- stop immediately when `DDSignFiles` returns a non-zero exit code

## Root cause
Scheduled real-sign builds started failing after the signing package automatically moved from `1.1.1330` to `1.1.1374`. The newer package looks for authentication certificate `ea4022a2-6f71-4214-88b6-18d2bbd6b4cc`, while PME installs `AUTH-CORP` with subject `dec434ad-6bd4-4a20-b400-4bf6db7fc3fb`.

The signing loop also ignored the failed process exit code, causing the task to retry every JAR until its four-hour timeout.

Failed build: https://mseng.visualstudio.com/VSJava/_build/results?buildId=31892392

## Validation
- `git diff --check`
- targeted checks for the pinned package, access-token propagation, fail-fast handling, and changed-file scope