### PR TITLE
Fix remaining CFS policy violations

### DIFF
--- a/.azure-pipelines/cfs-init.gradle
+++ b/.azure-pipelines/cfs-init.gradle
@@ -62,6 +62,11 @@ def forbiddenHosts = [
     'maven-central.storage-download.googleapis.com',
 ] as Set
 
+def atlassianHosts = [
+    'maven.atlassian.com',
+    'maven.artifacts.atlassian.com',
+] as Set
+
 def normalizeRepositoryPath = { repositoryUrl ->
     def path = (repositoryUrl?.path ?: '').toLowerCase(Locale.ROOT).replaceAll('/+$', '')
     path ?: '/'
@@ -91,6 +96,13 @@ def includeUtilsReactorModules = { contentFilter ->
 
 def scopedMavenLocalExclusiveRegistered = Collections.newSetFromMap(new IdentityHashMap<>())
 
+def isAtlassianPublicRepository = { MavenArtifactRepository repository ->
+    def repositoryUrl = repository.url
+    def host = repositoryUrl?.host?.toLowerCase(Locale.ROOT)
+    def path = normalizeRepositoryPath(repositoryUrl)
+    host == 'maven.atlassian.com' && path == '/repository/public'
+}
+
 def isScopedMavenLocalRepository = { MavenArtifactRepository repository ->
     normalizeRepositoryUri(repository.url) == scopedMavenLocalRepositoryUri
 }
@@ -108,10 +120,14 @@ def isForbiddenRepository = { MavenArtifactRepository repository ->
         return true
     }
 
+    if (atlassianHosts.contains(host)) {
+        return true
+    }
+
     // Preserve JetBrains-specialized paths such as /intellij-dependencies.
     if (host == 'cache-redirector.jetbrains.com') {
         def upstreamHost = path.tokenize('/').find()
-        return upstreamHost != null && forbiddenHosts.contains(upstreamHost)
+        return upstreamHost != null && (forbiddenHosts.contains(upstreamHost) || atlassianHosts.contains(upstreamHost))
     }
 
     return false
@@ -138,7 +154,19 @@ def restrictScopedMavenLocalRepository = { repositories, MavenArtifactRepository
     }
 }
 
+def restrictAtlassianPublicRepository = { MavenArtifactRepository repository ->
+    if (!isAtlassianPublicRepository(repository)) {
+        return
+    }
+
+    repository.content {
+        includeModule 'com.michaelbaranov', 'microba'
+    }
+}
+
 def routeToCfs = { MavenArtifactRepository repository ->
+    restrictAtlassianPublicRepository(repository)
+
     if (!isForbiddenRepository(repository)) {
         return
     }

--- a/.azure-pipelines/cfs-init.gradle
+++ b/.azure-pipelines/cfs-init.gradle
@@ -91,13 +91,6 @@ def includeUtilsReactorModules = { contentFilter ->
 
 def scopedMavenLocalExclusiveRegistered = Collections.newSetFromMap(new IdentityHashMap<>())
 
-def isAtlassianPublicRepository = { MavenArtifactRepository repository ->
-    def repositoryUrl = repository.url
-    def host = repositoryUrl?.host?.toLowerCase(Locale.ROOT)
-    def path = normalizeRepositoryPath(repositoryUrl)
-    host == 'maven.atlassian.com' && path == '/repository/public'
-}
-
 def isScopedMavenLocalRepository = { MavenArtifactRepository repository ->
     normalizeRepositoryUri(repository.url) == scopedMavenLocalRepositoryUri
 }
@@ -122,17 +115,6 @@ def isForbiddenRepository = { MavenArtifactRepository repository ->
     }
 
     return false
-}
-
-def restrictAtlassianRepository = { MavenArtifactRepository repository ->
-    if (!isAtlassianPublicRepository(repository)) {
-        return
-    }
-
-    // Microba is only available here; keep Atlassian only for that vendor group.
-    repository.content {
-        includeGroup 'com.michaelbaranov'
-    }
 }
 
 def restrictScopedMavenLocalRepository = { repositories, MavenArtifactRepository repository ->
@@ -173,7 +155,6 @@ watchRepositories = { repositories ->
     repositories.all { repository ->
         if (repository instanceof MavenArtifactRepository) {
             restrictScopedMavenLocalRepository(repositories, repository)
-            restrictAtlassianRepository(repository)
             routeToCfs(repository)
         }
     }

--- a/.azure-pipelines/sign-for-stable-release.yml
+++ b/.azure-pipelines/sign-for-stable-release.yml
@@ -201,6 +201,10 @@ extends:
                 displayName: "Manifest Generator "
                 inputs:
                   BuildDropPath: $(build.artifactstagingdirectory)/plugin
+                env:
+                  CFS_MAVEN_URL: $(CFS_MAVEN_URL)
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MAVEN_ARGS: '-s "$(Build.SourcesDirectory)\.azure-pipelines\cfs-settings.xml" "-Dmaven.repo.local=$(Agent.TempDirectory)\azure-tools-maven-repository"'
       - stage: Release_Plugin
         condition: ${{ variables.DoProceedToRelease }}
         displayName: Release Plugin to Marketplace

--- a/.azure-pipelines/sign-for-stable-release.yml
+++ b/.azure-pipelines/sign-for-stable-release.yml
@@ -126,17 +126,63 @@ extends:
                 env:
                   MicroBuildOutputFolderOverride: "$(Agent.TempDirectory)"
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              - task: UniversalPackages@0
+                displayName: Download internal Gradle distribution
+                inputs:
+                  command: download
+                  feedsToUse: internal
+                  vstsFeed: VSJava/vscjava
+                  vstsFeedPackage: gradle-distribution
+                  vstsPackageVersion: 9.0.0
+                  downloadDirectory: $(Agent.TempDirectory)\gradle-distribution
+              - task: PowerShell@2
+                displayName: Prepare internal Gradle distribution
+                inputs:
+                  targetType: inline
+                  script: |
+                    $ErrorActionPreference = "Stop"
+                    $gradleDownloadDirectory = "$(Agent.TempDirectory)\gradle-distribution"
+                    $gradleZip = Join-Path $gradleDownloadDirectory "gradle-9.0-bin.zip"
+                    $expectedSha256 = "8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b"
+                    $expandedGradleDirectory = Join-Path $gradleDownloadDirectory "expanded"
+                    $extractedGradleDirectory = Join-Path $expandedGradleDirectory "gradle-9.0.0"
+                    $normalizedGradleDirectory = Join-Path $expandedGradleDirectory "gradle-9.0"
+                    $gradleBat = Join-Path $normalizedGradleDirectory "bin\gradle.bat"
+
+                    if (-not (Test-Path -Path $gradleZip -PathType Leaf)) {
+                      throw "Gradle distribution zip was not downloaded to '$gradleZip'."
+                    }
+
+                    $actualSha256 = (Get-FileHash -Path $gradleZip -Algorithm SHA256).Hash.ToLowerInvariant()
+                    if ($actualSha256 -ne $expectedSha256) {
+                      throw "Gradle distribution checksum mismatch. Expected $expectedSha256 but found $actualSha256 for '$gradleZip'."
+                    }
+
+                    if (Test-Path -Path $expandedGradleDirectory) {
+                      Remove-Item -Path $expandedGradleDirectory -Recurse -Force
+                    }
+
+                    Expand-Archive -Path $gradleZip -DestinationPath $expandedGradleDirectory -Force
+
+                    if (-not (Test-Path -Path $extractedGradleDirectory -PathType Container)) {
+                      throw "Expected extracted Gradle directory '$extractedGradleDirectory' was not found after extracting '$gradleZip'."
+                    }
+
+                    Move-Item -Path $extractedGradleDirectory -Destination $normalizedGradleDirectory
+
+                    if (-not (Test-Path -Path $gradleBat -PathType Leaf)) {
+                      throw "Gradle launcher '$gradleBat' was not found after extracting '$gradleZip'."
+                    }
               - task: PowerShell@2
                 displayName: Build Plugin
                 inputs:
                   targetType: inline
                   script: |
                     mvn -v
-                    # ./gradlew buildUtils || exit -1
                     mvn "-Dmaven.repo.local=$env:CFS_MAVEN_LOCAL_REPOSITORY" -s "$(Build.SourcesDirectory)\.azure-pipelines\cfs-settings.xml" clean install -f "$(Build.SourcesDirectory)\Utils\pom.xml" -T 1C "-Dcheckstyle.skip=true" "-Dmaven.test.skip=true" "-Dmaven.javadoc.skip=true"
                     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-                    cd PluginsAndFeatures/azure-toolkit-for-intellij
-                    ./gradlew "-Dmaven.repo.local=$env:CFS_MAVEN_LOCAL_REPOSITORY" -I "$(Build.SourcesDirectory)\.azure-pipelines\cfs-init.gradle" clean buildPlugin -s "-Papplicationinsights.key=$(INTELLIJ_KEY)" "-PneedPatchVersion=false" "-Psources=false" "-Porg.gradle.configureondemand=false" "-Porg.gradle.daemon=false" "-Porg.gradle.unsafe.configuration-cache=false" "-Porg.gradle.caching=false"
+                    cd "$(Build.SourcesDirectory)\PluginsAndFeatures\azure-toolkit-for-intellij"
+                    & "$(Agent.TempDirectory)\gradle-distribution\expanded\gradle-9\bin\gradle.bat" "-Dmaven.repo.local=$env:CFS_MAVEN_LOCAL_REPOSITORY" -I "$(Build.SourcesDirectory)\.azure-pipelines\cfs-init.gradle" clean buildPlugin -s "-Papplicationinsights.key=$(INTELLIJ_KEY)" "-PneedPatchVersion=false" "-Psources=false" "-Porg.gradle.configureondemand=false" "-Porg.gradle.daemon=false" "-Porg.gradle.unsafe.configuration-cache=false" "-Porg.gradle.caching=false"
                 env:
                   USE_STABLE_VERSION: $(IsStableBuild)
                   CFS_MAVEN_LOCAL_REPOSITORY: $(Agent.TempDirectory)\azure-tools-maven-repository

--- a/.azure-pipelines/sign-for-stable-release.yml
+++ b/.azure-pipelines/sign-for-stable-release.yml
@@ -182,7 +182,7 @@ extends:
                     mvn "-Dmaven.repo.local=$env:CFS_MAVEN_LOCAL_REPOSITORY" -s "$(Build.SourcesDirectory)\.azure-pipelines\cfs-settings.xml" clean install -f "$(Build.SourcesDirectory)\Utils\pom.xml" -T 1C "-Dcheckstyle.skip=true" "-Dmaven.test.skip=true" "-Dmaven.javadoc.skip=true"
                     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
                     cd "$(Build.SourcesDirectory)\PluginsAndFeatures\azure-toolkit-for-intellij"
-                    & "$(Agent.TempDirectory)\gradle-distribution\expanded\gradle-9\bin\gradle.bat" "-Dmaven.repo.local=$env:CFS_MAVEN_LOCAL_REPOSITORY" -I "$(Build.SourcesDirectory)\.azure-pipelines\cfs-init.gradle" clean buildPlugin -s "-Papplicationinsights.key=$(INTELLIJ_KEY)" "-PneedPatchVersion=false" "-Psources=false" "-Porg.gradle.configureondemand=false" "-Porg.gradle.daemon=false" "-Porg.gradle.unsafe.configuration-cache=false" "-Porg.gradle.caching=false"
+                    & "$(Agent.TempDirectory)\gradle-distribution\expanded\gradle-9.0\bin\gradle.bat" "-Dmaven.repo.local=$env:CFS_MAVEN_LOCAL_REPOSITORY" -I "$(Build.SourcesDirectory)\.azure-pipelines\cfs-init.gradle" clean buildPlugin -s "-Papplicationinsights.key=$(INTELLIJ_KEY)" "-PneedPatchVersion=false" "-Psources=false" "-Porg.gradle.configureondemand=false" "-Porg.gradle.daemon=false" "-Porg.gradle.unsafe.configuration-cache=false" "-Porg.gradle.caching=false"
                 env:
                   USE_STABLE_VERSION: $(IsStableBuild)
                   CFS_MAVEN_LOCAL_REPOSITORY: $(Agent.TempDirectory)\azure-tools-maven-repository

--- a/.azure-pipelines/sign-for-stable-release.yml
+++ b/.azure-pipelines/sign-for-stable-release.yml
@@ -182,7 +182,7 @@ extends:
                     mvn "-Dmaven.repo.local=$env:CFS_MAVEN_LOCAL_REPOSITORY" -s "$(Build.SourcesDirectory)\.azure-pipelines\cfs-settings.xml" clean install -f "$(Build.SourcesDirectory)\Utils\pom.xml" -T 1C "-Dcheckstyle.skip=true" "-Dmaven.test.skip=true" "-Dmaven.javadoc.skip=true"
                     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
                     cd "$(Build.SourcesDirectory)\PluginsAndFeatures\azure-toolkit-for-intellij"
-                    & "$(Agent.TempDirectory)\gradle-distribution\expanded\gradle-9.0\bin\gradle.bat" "-Dmaven.repo.local=$env:CFS_MAVEN_LOCAL_REPOSITORY" -I "$(Build.SourcesDirectory)\.azure-pipelines\cfs-init.gradle" clean buildPlugin -s "-Papplicationinsights.key=$(INTELLIJ_KEY)" "-PneedPatchVersion=false" "-Psources=false" "-Porg.gradle.configureondemand=false" "-Porg.gradle.daemon=false" "-Porg.gradle.unsafe.configuration-cache=false" "-Porg.gradle.caching=false"
+                    & "$(Agent.TempDirectory)\gradle-distribution\expanded\gradle-9.0\bin\gradle.bat" "-Dmaven.repo.local=$env:CFS_MAVEN_LOCAL_REPOSITORY" -I "$(Build.SourcesDirectory)\.azure-pipelines\cfs-init.gradle" clean buildPlugin -s "-Papplicationinsights.key=$(INTELLIJ_KEY)" "-PneedPatchVersion=false" "-Psources=false" "-Porg.gradle.configureondemand=false" "-Porg.gradle.daemon=false" "-Porg.gradle.unsafe.configuration-cache=false" "-Porg.gradle.caching=false" "-Porg.jetbrains.intellij.platform.selfUpdateCheck=false"
                 env:
                   USE_STABLE_VERSION: $(IsStableBuild)
                   CFS_MAVEN_LOCAL_REPOSITORY: $(Agent.TempDirectory)\azure-tools-maven-repository

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle.kts
@@ -46,8 +46,6 @@ allprojects {
         mavenLocal()
         maven("https://cache-redirector.jetbrains.com/repo1.maven.org/maven2")
         maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
-        maven("https://maven.atlassian.com/repository/public")
-
         intellijPlatform {
             defaultRepositories()
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle.kts
@@ -46,6 +46,7 @@ allprojects {
         mavenLocal()
         maven("https://cache-redirector.jetbrains.com/repo1.maven.org/maven2")
         maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
+        maven("https://maven.atlassian.com/repository/public")
         intellijPlatform {
             defaultRepositories()
         }


### PR DESCRIPTION
## Summary

- route `ManifestGeneratorTask` Maven component detection through authenticated `vscjava` CFS settings
- download and checksum-verify the pinned Gradle 9.0 distribution from a `vscjava` Universal Package instead of `services.gradle.org`
- resolve Microba through CFS in CI while preserving the existing Atlassian repository for local developer builds

## Root cause

Build 31919047 reported:
- CFSClean: 11 `repo.maven.apache.org` connections from `ManifestGeneratorTask`
- CFSClean2: 1 Gradle wrapper distribution connection to `services.gradle.org`
- CFSClean3: 2 Atlassian redirect connections for Microba

## Validation

- full pipeline-equivalent local build passed: Maven Utils + internal Gradle `clean buildPlugin`
- Manifest Maven child simulation recorded POM/JAR provenance as `vscjava`
- pinned Gradle ZIP SHA-256: `8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b`
- Microba 0.4.4.3 CFS POM/JAR checksums match upstream
- direct request evidence in verification logs: Maven Central 0, Gradle public endpoints 0, Atlassian 0

## Remaining validation

- hosted pipeline run and `Stop Network Isolation` telemetry must confirm CFSClean/CFSClean2/CFSClean3 are all compliant