### PR TITLE
Enhancements and fixes to the Java upgrade detection and notification in appmod plugin

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
     implementation(project(":azure-intellij-plugin-lib-java"))
     // runtimeOnly project(path: ":azure-intellij-plugin-lib", configuration: "instrumentedJar")
     implementation("com.microsoft.azure:azure-toolkit-ide-common-lib")
+    testImplementation("org.mockito:mockito-core:5.20.0")
     intellijPlatform {
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugin("com.intellij.java")

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/JavaUpgradeCheckStartupActivity.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/JavaUpgradeCheckStartupActivity.java
@@ -6,13 +6,14 @@
 package com.microsoft.azure.toolkit.intellij.appmod.javaupgrade;
 
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.ProjectActivity;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.openapi.extensions.PluginId;
+import com.intellij.util.Alarm;
 import com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.dao.JavaUpgradeIssue;
 import com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service.JavaUpgradeIssuesCache;
 import com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service.JavaVersionNotificationService;
@@ -36,15 +37,21 @@ public class JavaUpgradeCheckStartupActivity implements ProjectActivity, DumbAwa
     
     // Additional delay after smart mode to ensure Maven/Gradle sync is complete
     private static final long POST_INDEXING_DELAY_SECONDS = 3;
+    private static final int MAVEN_IMPORT_DEBOUNCE_MILLIS = 1000;
     private static final String COPILOT_PLUGIN_ID = "com.github.copilot";
     
     @Override
     public Object execute(@Nonnull Project project, @Nonnull Continuation<? super Unit> continuation) {
+        final Alarm mavenImportAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, project);
         MavenProjectsManager.getInstance(project).addManagerListener(
             new MavenProjectsManager.Listener() {
                 @Override
                 public void projectImportCompleted() {
-                    performJavaUpgradeCheck(project, false);
+                    mavenImportAlarm.cancelAllRequests();
+                    mavenImportAlarm.addRequest(
+                        () -> performJavaUpgradeCheck(project, false),
+                        MAVEN_IMPORT_DEBOUNCE_MILLIS
+                    );
                 }
             },
             project

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/JavaUpgradeCheckStartupActivity.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/JavaUpgradeCheckStartupActivity.java
@@ -20,6 +20,7 @@ import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import kotlin.Unit;
 import kotlin.coroutines.Continuation;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.idea.maven.project.MavenProjectsManager;
 import reactor.core.publisher.Mono;
 
 import javax.annotation.Nonnull;
@@ -39,6 +40,16 @@ public class JavaUpgradeCheckStartupActivity implements ProjectActivity, DumbAwa
     
     @Override
     public Object execute(@Nonnull Project project, @Nonnull Continuation<? super Unit> continuation) {
+        MavenProjectsManager.getInstance(project).addManagerListener(
+            new MavenProjectsManager.Listener() {
+                @Override
+                public void projectImportCompleted() {
+                    performJavaUpgradeCheck(project, false);
+                }
+            },
+            project
+        );
+
         // Wait for indexing to complete before running the check
         DumbService.getInstance(project).runWhenSmart(() -> {
             // Add a small delay after smart mode to ensure Maven/Gradle sync is done
@@ -48,7 +59,7 @@ public class JavaUpgradeCheckStartupActivity implements ProjectActivity, DumbAwa
                         if (project.isDisposed()) {
                             return;
                         }
-                        performJavaUpgradeCheck(project);
+                        performJavaUpgradeCheck(project, true);
                     },
                     error -> {
                         /* Error during Java upgrade check startup */
@@ -63,7 +74,7 @@ public class JavaUpgradeCheckStartupActivity implements ProjectActivity, DumbAwa
     /**
      * Performs the jdk version, framework version and CVE issue check and shows notifications for any issues found.
      */
-    private void performJavaUpgradeCheck(@Nonnull Project project) {
+    private void performJavaUpgradeCheck(@Nonnull Project project, boolean showNotification) {
         try {
             log.info("Starting Java upgrade issues detection for project: {}", project.getName());
             // Run the analysis in a background thread
@@ -99,7 +110,7 @@ public class JavaUpgradeCheckStartupActivity implements ProjectActivity, DumbAwa
                     DaemonCodeAnalyzer.getInstance(project).restart();
                     
                     // Show notifications if there are issues
-                    if (!allIssues.isEmpty()) {
+                    if (showNotification && !allIssues.isEmpty()) {
                         final JavaVersionNotificationService notificationService = JavaVersionNotificationService.getInstance();
                         notificationService.showNotifications(project, allIssues);
                     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/CveFixDependencyInProblemsViewAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/CveFixDependencyInProblemsViewAction.java
@@ -109,7 +109,7 @@ public class CveFixDependencyInProblemsViewAction extends AnAction implements Du
 
     @Override
     public @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.BGT;
+        return ActionUpdateThread.EDT;
     }
 
     /**

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/JavaUpgradeQuickFix.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/JavaUpgradeQuickFix.java
@@ -18,7 +18,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
+import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.utils.Constants.APPMOD_CVE_AGENT_NAME;
 import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.utils.Constants.APPMOD_UPGRADE_AGENT_NAME;
+import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.utils.Constants.FIX_VULNERABLE_DEPENDENCY_WITH_COPILOT_PROMPT;
 import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.utils.Constants.UPGRADE_JAVA_FRAMEWORK_PROMPT;
 
 /**
@@ -56,7 +58,10 @@ public class JavaUpgradeQuickFix implements LocalQuickFix {
     public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
         try {
             String prompt = buildPromptForIssue(issue);
-            JavaVersionNotificationService.getInstance().openCopilotChatWithPrompt(project, prompt, APPMOD_UPGRADE_AGENT_NAME);
+            final String agentName = issue.getUpgradeReason() == JavaUpgradeIssue.UpgradeReason.CVE
+                ? APPMOD_CVE_AGENT_NAME
+                : APPMOD_UPGRADE_AGENT_NAME;
+            JavaVersionNotificationService.getInstance().openCopilotChatWithPrompt(project, prompt, agentName);
             AppModUtils.logTelemetryEvent("openCopilotChatForJavaUpgradeQuickFix", Map.of("appmodPluginInstalled", String.valueOf(AppModPluginInstaller.isAppModPluginInstalled())));
         } catch (Throwable ex) {
             log.error("Failed to apply Java upgrade quick fix", ex);
@@ -64,6 +69,12 @@ public class JavaUpgradeQuickFix implements LocalQuickFix {
     }
 
     private String buildPromptForIssue(@NotNull JavaUpgradeIssue issue) {
+        if (issue.getUpgradeReason() == JavaUpgradeIssue.UpgradeReason.CVE) {
+            final String coordinate = issue.getCurrentVersion() == null
+                ? issue.getPackageId()
+                : issue.getPackageId() + ":" + issue.getCurrentVersion();
+            return String.format(FIX_VULNERABLE_DEPENDENCY_WITH_COPILOT_PROMPT, coordinate);
+        }
         return String.format(
             UPGRADE_JAVA_FRAMEWORK_PROMPT,
             issue.getPackageDisplayName(), issue.getCurrentVersion(), issue.getSuggestedVersion()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/UpgradeInProblemsViewAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/UpgradeInProblemsViewAction.java
@@ -95,7 +95,7 @@ public class UpgradeInProblemsViewAction extends AnAction implements DumbAware {
 
     @Override
     public @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.BGT;
+        return ActionUpdateThread.EDT;
     }
 
     @Nullable

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/UpgradeInProblemsViewAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/UpgradeInProblemsViewAction.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.action;
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.microsoft.azure.toolkit.intellij.appmod.common.AppModPluginInstaller;
+import com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service.JavaVersionNotificationService;
+import com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.utils.ProblemsViewUtils;
+import com.microsoft.azure.toolkit.intellij.appmod.utils.AppModUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.utils.Constants.APPMOD_UPGRADE_AGENT_NAME;
+import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.utils.Constants.UPGRADE_JAVA_FRAMEWORK_PROMPT;
+
+/**
+ * Promotes Java and framework upgrade quick fixes to the Problems View context menu.
+ */
+@Slf4j
+public class UpgradeInProblemsViewAction extends AnAction implements DumbAware {
+
+    private static final Pattern UPGRADE_DESCRIPTION_PATTERN = Pattern.compile(
+        "Your project uses (.+?) (\\S+)\\. Consider upgrading (.+?) to (\\S+), " +
+            "the latest LTS version, for better performance and support"
+    );
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        final Project project = event.getData(CommonDataKeys.PROJECT);
+        if (project == null || project.isDisposed()) {
+            return;
+        }
+        final UpgradeDescription upgrade =
+            parseUpgradeDescription(ProblemsViewUtils.extractProblemDescription(event));
+        if (upgrade == null) {
+            return;
+        }
+
+        try {
+            JavaVersionNotificationService.getInstance().openCopilotChatWithPrompt(
+                project,
+                String.format(
+                    UPGRADE_JAVA_FRAMEWORK_PROMPT,
+                    upgrade.packageDisplayName(),
+                    upgrade.currentVersion(),
+                    upgrade.suggestedVersion()
+                ),
+                APPMOD_UPGRADE_AGENT_NAME
+            );
+            AppModUtils.logTelemetryEvent(
+                "openCopilotChatForUpgradeInProblemsViewAction",
+                Map.of(
+                    "appmodPluginInstalled",
+                    String.valueOf(AppModPluginInstaller.isAppModPluginInstalled())
+                )
+            );
+        } catch (Throwable throwable) {
+            log.error("Failed to open Copilot chat for Java or framework upgrade", throwable);
+        }
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent event) {
+        final Project project = event.getData(CommonDataKeys.PROJECT);
+        final VirtualFile file = event.getData(CommonDataKeys.VIRTUAL_FILE);
+        final UpgradeDescription upgrade =
+            parseUpgradeDescription(ProblemsViewUtils.extractProblemDescription(event));
+        final boolean visible = project != null && !project.isDisposed() &&
+            isBuildFile(file) && upgrade != null;
+        event.getPresentation().setEnabledAndVisible(visible);
+        if (!visible) {
+            return;
+        }
+
+        String actionName = getActionName(upgrade);
+        if (!AppModPluginInstaller.isAppModPluginInstalled()) {
+            actionName += AppModPluginInstaller.TO_INSTALL_APP_MODE_PLUGIN;
+        }
+        event.getPresentation().setText(actionName);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
+    @Nullable
+    static UpgradeDescription parseUpgradeDescription(@Nullable String description) {
+        if (description == null) {
+            return null;
+        }
+        final Matcher matcher = UPGRADE_DESCRIPTION_PATTERN.matcher(description);
+        if (!matcher.find() || !matcher.group(1).equals(matcher.group(3))) {
+            return null;
+        }
+        return new UpgradeDescription(matcher.group(1), matcher.group(2), matcher.group(4));
+    }
+
+    @NotNull
+    static String getActionName(@NotNull UpgradeDescription upgrade) {
+        return "Upgrade " + upgrade.packageDisplayName() + " with Copilot";
+    }
+
+    private static boolean isBuildFile(@Nullable VirtualFile file) {
+        return file != null && (
+            file.getName().equals("pom.xml") ||
+                file.getName().endsWith(".gradle") ||
+                file.getName().endsWith(".gradle.kts")
+        );
+    }
+
+    record UpgradeDescription(
+        @NotNull String packageDisplayName,
+        @NotNull String currentVersion,
+        @NotNull String suggestedVersion
+    ) {
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/inspection/JavaUpgradeIssuesInspection.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/inspection/JavaUpgradeIssuesInspection.java
@@ -22,8 +22,11 @@ import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service.Ja
 
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.idea.maven.project.MavenProject;
+import org.jetbrains.idea.maven.project.MavenProjectsManager;
 
 import java.util.List;
+import java.util.Properties;
 
 /**
  * Inspection that displays Java upgrade issues detected by JavaUpgradeDetectionService.
@@ -53,19 +56,19 @@ public class JavaUpgradeIssuesInspection extends LocalInspectionTool {
             return PsiElementVisitor.EMPTY_VISITOR;
         }
 
-        // Get cached issues (computed once at project startup)
-        final JavaUpgradeIssue jdkIssue = cache.getJdkIssue();
         final List<JavaUpgradeIssue> dependencyIssues = cache.getDependencyIssues();
+        final Properties mavenProperties = getMavenProperties(project, file);
 
         return new XmlElementVisitor() {
             @Override
             public void visitXmlTag(@NotNull XmlTag tag) {
                 super.visitXmlTag(tag);
 
-                // Check for JDK version tags
-                if (jdkIssue != null) {
-                    if (isJavaVersionProperty(tag) || isCompilerPluginVersionTag(tag)) {
-                        registerProblem(holder, tag, jdkIssue);
+                if (isJavaVersionProperty(tag) || isCompilerPluginVersionTag(tag)) {
+                    final JavaUpgradeIssue javaIssue =
+                        JavaUpgradeProblemLocator.createJavaVersionIssue(tag, mavenProperties);
+                    if (javaIssue != null) {
+                        registerProblem(holder, tag, javaIssue);
                     }
                 }
 
@@ -93,6 +96,16 @@ public class JavaUpgradeIssuesInspection extends LocalInspectionTool {
         };
     }
 
+    @NotNull
+    private Properties getMavenProperties(@NotNull Project project, @NotNull PsiFile file) {
+        if (file.getVirtualFile() == null) {
+            return new Properties();
+        }
+        final MavenProjectsManager manager = MavenProjectsManager.getInstanceIfCreated(project);
+        final MavenProject mavenProject =
+            manager == null ? null : manager.findProject(file.getVirtualFile());
+        return mavenProject == null ? new Properties() : mavenProject.getProperties();
+    }
     private void registerProblem(@NotNull ProblemsHolder holder, @NotNull XmlTag tag, @NotNull JavaUpgradeIssue issue) {
         log.info("Registering Java upgrade issue in inspection: {}", issue);
         holder.registerProblem(

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/inspection/JavaUpgradeProblemLocator.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/inspection/JavaUpgradeProblemLocator.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.inspection;
+
+import com.intellij.psi.xml.XmlTag;
+import com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.dao.JavaUpgradeIssue;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service.JavaUpgradeIssuesDetectionService.JDK_DISPLAY_NAME;
+import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service.JavaUpgradeIssuesDetectionService.JDK_LEARN_MORE_URL;
+import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service.JavaUpgradeIssuesDetectionService.MATURE_JAVA_LTS_VERSION;
+import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service.JavaUpgradeIssuesDetectionService.PACKAGE_ID_JDK;
+import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.utils.Constants.ISSUE_DISPLAY_NAME;
+
+final class JavaUpgradeProblemLocator {
+
+    private JavaUpgradeProblemLocator() {
+    }
+
+    static JavaUpgradeIssue createJavaVersionIssue(@NotNull XmlTag versionTag) {
+        return createJavaVersionIssue(versionTag, new Properties());
+    }
+
+    static JavaUpgradeIssue createJavaVersionIssue(
+        @NotNull XmlTag versionTag,
+        @NotNull Properties effectiveProperties
+    ) {
+        return createJavaVersionIssue(
+            resolveVersionText(versionTag, effectiveProperties, new HashSet<>()));
+    }
+
+    static JavaUpgradeIssue createJavaVersionIssue(@Nullable String versionText) {
+        final Integer version = parseJavaVersion(versionText);
+        if (version == null || version < 8 || version >= MATURE_JAVA_LTS_VERSION) {
+            return null;
+        }
+        return JavaUpgradeIssue.builder()
+            .packageId(PACKAGE_ID_JDK)
+            .packageDisplayName(JDK_DISPLAY_NAME)
+            .upgradeReason(JavaUpgradeIssue.UpgradeReason.JRE_TOO_OLD)
+            .severity(JavaUpgradeIssue.Severity.WARNING)
+            .currentVersion(String.valueOf(version))
+            .supportedVersion(">=" + MATURE_JAVA_LTS_VERSION)
+            .suggestedVersion(String.valueOf(MATURE_JAVA_LTS_VERSION))
+            .message(String.format(
+                ISSUE_DISPLAY_NAME,
+                JDK_DISPLAY_NAME,
+                version,
+                JDK_DISPLAY_NAME,
+                MATURE_JAVA_LTS_VERSION
+            ))
+            .learnMoreUrl(JDK_LEARN_MORE_URL)
+            .build();
+    }
+
+    @Nullable
+    private static String resolveVersionText(
+        @NotNull XmlTag versionTag,
+        @NotNull Properties effectiveProperties,
+        @NotNull Set<String> resolvingProperties
+    ) {
+        final String versionText = versionTag.getValue().getText().trim();
+        if (!versionText.startsWith("${") || !versionText.endsWith("}")) {
+            return versionText;
+        }
+
+        final String propertyName = versionText.substring(2, versionText.length() - 1);
+        if (!resolvingProperties.add(propertyName)) {
+            return null;
+        }
+
+        XmlTag current = versionTag;
+        while (current != null) {
+            final XmlTag properties = "properties".equals(current.getName())
+                ? current
+                : current.findFirstSubTag("properties");
+            if (properties != null) {
+                final XmlTag property = properties.findFirstSubTag(propertyName);
+                if (property != null) {
+                    return resolveVersionText(property, effectiveProperties, resolvingProperties);
+                }
+            }
+            current = current.getParentTag();
+        }
+        return resolvePropertyValue(
+            effectiveProperties.getProperty(propertyName),
+            effectiveProperties,
+            resolvingProperties
+        );
+    }
+
+    @Nullable
+    private static String resolvePropertyValue(
+        @Nullable String value,
+        @NotNull Properties effectiveProperties,
+        @NotNull Set<String> resolvingProperties
+    ) {
+        if (value == null) {
+            return null;
+        }
+        final String normalized = value.trim();
+        if (!normalized.startsWith("${") || !normalized.endsWith("}")) {
+            return normalized;
+        }
+        final String propertyName = normalized.substring(2, normalized.length() - 1);
+        if (!resolvingProperties.add(propertyName)) {
+            return null;
+        }
+        return resolvePropertyValue(
+            effectiveProperties.getProperty(propertyName),
+            effectiveProperties,
+            resolvingProperties
+        );
+    }
+
+    @Nullable
+    private static Integer parseJavaVersion(@Nullable String versionText) {
+        if (versionText == null) {
+            return null;
+        }
+        final String normalized = versionText.trim();
+        if (normalized.isEmpty() || normalized.startsWith("${")) {
+            return null;
+        }
+        final String majorVersion = normalized.startsWith("1.")
+            ? normalized.substring(2)
+            : normalized;
+        final int separator = majorVersion.indexOf('.');
+        final String major = separator < 0 ? majorVersion : majorVersion.substring(0, separator);
+        try {
+            return Integer.parseInt(major);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/service/JavaUpgradeIssuesCache.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/service/JavaUpgradeIssuesCache.java
@@ -122,7 +122,7 @@ public final class JavaUpgradeIssuesCache implements Disposable {
      * Refreshes the cache by re-scanning the project.
      * This should be called at project startup and when the project model changes.
      */
-    public void refresh() {
+    public synchronized void refresh() {
         try {
             if (project.isDisposed()) {
                 return;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/service/JavaUpgradeIssuesDetectionService.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/service/JavaUpgradeIssuesDetectionService.java
@@ -192,7 +192,7 @@ public class JavaUpgradeIssuesDetectionService {
         )
     );
     
-    private static final String JDK_LEARN_MORE_URL = 
+    public static final String JDK_LEARN_MORE_URL =
         "https://learn.microsoft.com/azure/developer/java/fundamentals/java-support-on-azure";
     
     private static JavaUpgradeIssuesDetectionService instance;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/service/JavaVersionNotificationService.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/service/JavaVersionNotificationService.java
@@ -28,6 +28,7 @@ import static com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service.Ja
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayDeque;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Set;
@@ -88,7 +89,7 @@ public class JavaVersionNotificationService {
     }
     
     /**
-     * Shows a notification for the first outdated version issue.
+     * Shows a notification for the highest-priority upgrade issue.
      * Only shows if notifications are enabled for the Java upgrade feature.
      *
      * @param project The project context
@@ -111,9 +112,22 @@ public class JavaVersionNotificationService {
             return;
         }
         
-        // Only show notification for the first issue
-        final JavaUpgradeIssue firstIssue = issues.get(0);
-        showNotification(project, firstIssue);
+        showNotification(project, selectNotificationIssue(issues));
+    }
+
+    @Nonnull
+    static JavaUpgradeIssue selectNotificationIssue(@Nonnull List<JavaUpgradeIssue> issues) {
+        return issues.stream()
+            .min(Comparator.comparingInt(JavaVersionNotificationService::getNotificationPriority))
+            .orElseThrow();
+    }
+
+    private static int getNotificationPriority(@Nonnull JavaUpgradeIssue issue) {
+        return switch (issue.getUpgradeReason()) {
+            case JRE_TOO_OLD -> 0;
+            case CVE -> 1;
+            default -> 2;
+        };
     }
     
     /**

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/utils/Constants.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/utils/Constants.java
@@ -12,7 +12,7 @@ public class Constants {
     public static final String SCAN_AND_RESOLVE_CVES_WITH_COPILOT_DISPLAY_NAME = "Scan and Resolve CVEs with Copilot";
     public static final String FIX_VULNERABLE_DEPENDENCY_WITH_COPILOT_PROMPT = "Fix the vulnerable dependency %s by using #appmod-validate-cves-for-java";
     public static final String FIX_VULNERABLE_DEPENDENCY_WITH_COPILOT_DISPLAY_NAME = "Fix the vulnerable dependency with Copilot";
-    public static final String ISSUE_DISPLAY_NAME = "Your project uses %s %s. Consider upgrading to %s to the latest LTS version for better performance and support";
+    public static final String ISSUE_DISPLAY_NAME = "Your project uses %s %s. Consider upgrading %s to %s, the latest LTS version, for better performance and support";
     public static final String APPMOD_CVE_AGENT_NAME = "modernize-java-security";
     public static final String APPMOD_UPGRADE_AGENT_NAME = "modernize-java-upgrade";
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/resources/META-INF/azure-intellij-plugin-appmod.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/resources/META-INF/azure-intellij-plugin-appmod.xml
@@ -45,6 +45,12 @@
                 description="Fix this vulnerable dependency using GitHub Copilot">
             <add-to-group group-id="ProblemsView.ToolWindow.TreePopup" anchor="first"/>
         </action>
+        <action id="AzureToolkit.JavaUpgradeInProblemsViewAction"
+                class="com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.action.UpgradeInProblemsViewAction"
+                text="Upgrade with Copilot"
+                description="Upgrade this Java runtime or framework using GitHub Copilot">
+            <add-to-group group-id="ProblemsView.ToolWindow.TreePopup" anchor="first"/>
+        </action>
         <action id="AzureToolkit.UpgradeInProblemsViewAction"
                 class="com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.action.CveFixInProblemsViewAction"
                 text="Scan and Resolve CVEs with Copilot"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/resources/META-INF/azure-intellij-plugin-appmod.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/main/resources/META-INF/azure-intellij-plugin-appmod.xml
@@ -51,12 +51,6 @@
                 description="Upgrade this Java runtime or framework using GitHub Copilot">
             <add-to-group group-id="ProblemsView.ToolWindow.TreePopup" anchor="first"/>
         </action>
-        <action id="AzureToolkit.UpgradeInProblemsViewAction"
-                class="com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.action.CveFixInProblemsViewAction"
-                text="Scan and Resolve CVEs with Copilot"
-                description="Fix this vulnerable dependency using GitHub Copilot">
-            <add-to-group group-id="ProblemsView.ToolWindow.TreePopup" anchor="first"/>
-        </action>
         <!-- Upgrade action in GitHub Copilot context menu -->
         <action id="AzureToolkit.JavaUpgradeContextMenu"
                 class="com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.action.JavaUpgradeContextMenuAction"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/test/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/CveActionsTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/test/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/CveActionsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.action;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class CveActionsTest {
+
+    @Test
+    public void exposesFrameworkUpgradeAsTopLevelProblemsViewAction() {
+        final String description =
+            "Your project uses Spring Boot 2.0.1.RELEASE. " +
+                "Consider upgrading Spring Boot to 3.5, the latest LTS version, " +
+                "for better performance and support";
+
+        final UpgradeInProblemsViewAction.UpgradeDescription upgrade =
+            UpgradeInProblemsViewAction.parseUpgradeDescription(description);
+
+        assertNotNull(upgrade);
+        assertEquals("Spring Boot", upgrade.packageDisplayName());
+        assertEquals("2.0.1.RELEASE", upgrade.currentVersion());
+        assertEquals("3.5", upgrade.suggestedVersion());
+        assertEquals(
+            "Upgrade Spring Boot with Copilot",
+            UpgradeInProblemsViewAction.getActionName(upgrade)
+        );
+    }
+
+    @Test
+    public void doesNotExposeTopLevelUpgradeActionForCveProblems() {
+        assertNull(UpgradeInProblemsViewAction.parseUpgradeDescription(
+            "Security vulnerability CVE-2020-36518 detected in " +
+                "maven:com.fasterxml.jackson.core:jackson-databind:2.9.4 Upgrade required"
+        ));
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/test/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/CveActionsTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/test/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/action/CveActionsTest.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.action;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -39,5 +40,11 @@ public class CveActionsTest {
             "Security vulnerability CVE-2020-36518 detected in " +
                 "maven:com.fasterxml.jackson.core:jackson-databind:2.9.4 Upgrade required"
         ));
+    }
+
+    @Test
+    public void updatesProblemsViewActionsOnEdt() {
+        assertEquals(ActionUpdateThread.EDT, new UpgradeInProblemsViewAction().getActionUpdateThread());
+        assertEquals(ActionUpdateThread.EDT, new CveFixDependencyInProblemsViewAction().getActionUpdateThread());
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/test/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/inspection/JavaUpgradeIssuesInspectionTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/test/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/inspection/JavaUpgradeIssuesInspectionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.inspection;
+
+import com.intellij.psi.xml.XmlTag;
+import com.intellij.psi.xml.XmlTagValue;
+import com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.dao.JavaUpgradeIssue;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JavaUpgradeIssuesInspectionTest {
+
+    @Test
+    public void createsJavaIssueFromPomJavaVersion() {
+        final JavaUpgradeIssue issue = JavaUpgradeProblemLocator.createJavaVersionIssue("8");
+
+        assertEquals("8", issue.getCurrentVersion());
+        assertEquals(JavaUpgradeIssue.UpgradeReason.JRE_TOO_OLD, issue.getUpgradeReason());
+    }
+
+    @Test
+    public void acceptsLegacyJavaVersionSyntax() {
+        final JavaUpgradeIssue issue = JavaUpgradeProblemLocator.createJavaVersionIssue("1.8");
+
+        assertEquals("8", issue.getCurrentVersion());
+    }
+
+    @Test
+    public void ignoresSupportedOrPropertyReferenceVersions() {
+        assertNull(JavaUpgradeProblemLocator.createJavaVersionIssue("21"));
+        assertNull(JavaUpgradeProblemLocator.createJavaVersionIssue("${java.version}"));
+    }
+
+    @Test
+    public void resolvesJavaVersionFromAnotherMavenProperty() {
+        final XmlTag properties = mock(XmlTag.class);
+        final XmlTag javaVersion = valueTag("${jdk.version}");
+        final XmlTag jdkVersion = valueTag("8");
+        when(properties.getName()).thenReturn("properties");
+        when(properties.findFirstSubTag("jdk.version")).thenReturn(jdkVersion);
+        when(javaVersion.getParentTag()).thenReturn(properties);
+
+        final JavaUpgradeIssue issue =
+            JavaUpgradeProblemLocator.createJavaVersionIssue(javaVersion);
+
+        assertEquals("8", issue.getCurrentVersion());
+    }
+
+    @Test
+    public void resolvesJavaVersionFromEffectiveParentProperties() {
+        final XmlTag javaVersion = valueTag("${parent.java.version}");
+        final Properties effectiveProperties = new Properties();
+        effectiveProperties.setProperty("parent.java.version", "8");
+
+        final JavaUpgradeIssue issue =
+            JavaUpgradeProblemLocator.createJavaVersionIssue(javaVersion, effectiveProperties);
+
+        assertEquals("8", issue.getCurrentVersion());
+    }
+
+    private static XmlTag valueTag(String value) {
+        final XmlTag tag = mock(XmlTag.class);
+        final XmlTagValue tagValue = mock(XmlTagValue.class);
+        when(tag.getValue()).thenReturn(tagValue);
+        when(tagValue.getText()).thenReturn(value);
+        return tag;
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/test/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/service/JavaUpgradeIssuesCacheTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/test/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/service/JavaUpgradeIssuesCacheTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service;
+
+import org.junit.Test;
+
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.assertTrue;
+
+public class JavaUpgradeIssuesCacheTest {
+
+    @Test
+    public void serializesFullProjectScans() throws NoSuchMethodException {
+        assertTrue(Modifier.isSynchronized(
+            JavaUpgradeIssuesCache.class.getMethod("refresh").getModifiers()
+        ));
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/test/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/service/JavaVersionNotificationServiceTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-appmod/src/test/java/com/microsoft/azure/toolkit/intellij/appmod/javaupgrade/service/JavaVersionNotificationServiceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.service;
+
+import com.microsoft.azure.toolkit.intellij.appmod.javaupgrade.dao.JavaUpgradeIssue;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertSame;
+
+public class JavaVersionNotificationServiceTest {
+
+    @Test
+    public void prioritizesUnsupportedJdkThenCveThenOtherUpgrades() {
+        final JavaUpgradeIssue dependencyIssue = issue(
+            "spring-boot",
+            JavaUpgradeIssue.UpgradeReason.END_OF_LIFE
+        );
+        final JavaUpgradeIssue cveIssue = issue(
+            "vulnerable-dependency",
+            JavaUpgradeIssue.UpgradeReason.CVE
+        );
+        final JavaUpgradeIssue jdkIssue = issue(
+            "jdk",
+            JavaUpgradeIssue.UpgradeReason.JRE_TOO_OLD
+        );
+
+        assertSame(
+            jdkIssue,
+            JavaVersionNotificationService.selectNotificationIssue(
+                List.of(dependencyIssue, cveIssue, jdkIssue)
+            )
+        );
+        assertSame(
+            cveIssue,
+            JavaVersionNotificationService.selectNotificationIssue(
+                List.of(dependencyIssue, cveIssue)
+            )
+        );
+        assertSame(
+            dependencyIssue,
+            JavaVersionNotificationService.selectNotificationIssue(List.of(dependencyIssue))
+        );
+    }
+
+    private static JavaUpgradeIssue issue(
+        String packageId,
+        JavaUpgradeIssue.UpgradeReason reason
+    ) {
+        return JavaUpgradeIssue.builder()
+            .packageId(packageId)
+            .packageDisplayName(packageId)
+            .upgradeReason(reason)
+            .severity(JavaUpgradeIssue.Severity.WARNING)
+            .message(packageId)
+            .build();
+    }
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request introduces several enhancements and fixes to the Java upgrade detection and notification features in the Azure Toolkit for IntelliJ plugin. The main improvements include better detection and reporting of Java version issues in Maven projects, improved notification logic, and new actions to streamline the upgrade process directly from the Problems View.

**Java upgrade detection and notification improvements:**

* Added a new `JavaUpgradeProblemLocator` utility to resolve and report Java version issues in Maven build files, including handling property references and nested property resolution.
* Updated the inspection logic in `JavaUpgradeIssuesInspection.java` to dynamically detect Java version problems in XML tags using Maven project properties, instead of relying solely on cached issues. [[1]](diffhunk://#diff-44e9b8d0c2487359113bd214f94ab26d35c3cfb5bb6d78511de78f412ada9c26L56-R71) [[2]](diffhunk://#diff-44e9b8d0c2487359113bd214f94ab26d35c3cfb5bb6d78511de78f412ada9c26R99-R108) [[3]](diffhunk://#diff-44e9b8d0c2487359113bd214f94ab26d35c3cfb5bb6d78511de78f412ada9c26R25-R29)

**Notification and quick fix enhancements:**

* Improved the `JavaUpgradeCheckStartupActivity` to trigger upgrade checks after Maven project imports and to control when notifications are shown, preventing unnecessary alerts. [[1]](diffhunk://#diff-28fa14775d8f65cdb19bf9ad144a7378a4129ddb664498a33b4178e304b7dbf0R23) [[2]](diffhunk://#diff-28fa14775d8f65cdb19bf9ad144a7378a4129ddb664498a33b4178e304b7dbf0R43-R52) [[3]](diffhunk://#diff-28fa14775d8f65cdb19bf9ad144a7378a4129ddb664498a33b4178e304b7dbf0L51-R62) [[4]](diffhunk://#diff-28fa14775d8f65cdb19bf9ad144a7378a4129ddb664498a33b4178e304b7dbf0L66-R77) [[5]](diffhunk://#diff-28fa14775d8f65cdb19bf9ad144a7378a4129ddb664498a33b4178e304b7dbf0L102-R113)
* Enhanced the quick fix logic in `JavaUpgradeQuickFix.java` to select the appropriate Copilot agent and prompt format based on the specific upgrade reason (e.g., CVE vs. framework upgrade). [[1]](diffhunk://#diff-01547d1d9451ea3d5511db1a8b9d4465664b453f730bd25aebe99d36b939a50eR21-R23) [[2]](diffhunk://#diff-01547d1d9451ea3d5511db1a8b9d4465664b453f730bd25aebe99d36b939a50eL59-R77)

**User interface and action improvements:**

* Introduced a new `UpgradeInProblemsViewAction` that adds a context menu action in the Problems View, allowing users to trigger Copilot-powered upgrades for Java and frameworks directly from detected issues.

**Dependency updates:**

* Added `mockito-core` as a test dependency in the build configuration for improved unit testing capabilities.

**Other fixes:**

* Made `JDK_LEARN_MORE_URL` public for broader access.

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3054999/?view=edit


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
<img width="1929" height="1246" alt="image" src="https://github.com/user-attachments/assets/fe2329ba-f024-4948-88e4-623b08108528" />


Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [x] Tested
